### PR TITLE
fix: measure rehearsal plaintext payloads in bytes

### DIFF
--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -206,10 +206,26 @@ func (a *PayloadRehearsalAdapter) Preview(ctx context.Context, c apptypes.Payloa
 		return apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("inspect pending rehearsal migrations: %w", err)
 	}
 	var eventRows, auditRows, eventBytes, auditBytes int64
-	if err = db.QueryRowContext(ctx, `SELECT count(*),coalesce(sum(length(body)),0) FROM events`).Scan(&eventRows, &eventBytes); err != nil {
+	// Codec metadata is authoritative for encoded rows. Legacy rows have no
+	// plaintext byte metadata and are identity-encoded, so their BLOB length is
+	// the plaintext byte count. Never use SQLite length(TEXT), which counts
+	// characters rather than UTF-8 bytes.
+	eventAggregateQuery := `SELECT count(*),coalesce(sum(CASE WHEN body_plaintext_bytes IS NOT NULL THEN body_plaintext_bytes ELSE length(CAST(body AS BLOB)) END),0) FROM events`
+	auditAggregateQuery := `SELECT count(*),coalesce(sum(CASE WHEN command_plaintext_bytes IS NOT NULL THEN command_plaintext_bytes ELSE length(CAST(command_text AS BLOB)) END+CASE WHEN input_plaintext_bytes IS NOT NULL THEN input_plaintext_bytes ELSE length(CAST(input_text AS BLOB)) END+CASE WHEN output_plaintext_bytes IS NOT NULL THEN output_plaintext_bytes ELSE length(CAST(output_text AS BLOB)) END),0) FROM command_audits`
+	var codecMetadata bool
+	if err = db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pragma_table_info('events') WHERE name='body_plaintext_bytes')`).Scan(&codecMetadata); err != nil {
+		return apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("inspect payload codec metadata: %w", err)
+	}
+	if !codecMetadata {
+		// The copied target may predate the codec foundation. Its migration plan
+		// is still measurable, but the metadata columns do not exist yet.
+		eventAggregateQuery = `SELECT count(*),coalesce(sum(length(CAST(body AS BLOB))),0) FROM events`
+		auditAggregateQuery = `SELECT count(*),coalesce(sum(length(CAST(command_text AS BLOB))+length(CAST(input_text AS BLOB))+length(CAST(output_text AS BLOB))),0) FROM command_audits`
+	}
+	if err = db.QueryRowContext(ctx, eventAggregateQuery).Scan(&eventRows, &eventBytes); err != nil {
 		return apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("inspect event aggregates: %w", err)
 	}
-	if err = db.QueryRowContext(ctx, `SELECT count(*),coalesce(sum(length(command_text)+length(input_text)+length(output_text)),0) FROM command_audits`).Scan(&auditRows, &auditBytes); err != nil {
+	if err = db.QueryRowContext(ctx, auditAggregateQuery).Scan(&auditRows, &auditBytes); err != nil {
 		return apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("inspect audit aggregates: %w", err)
 	}
 	if err = db.Close(); err != nil {

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -218,7 +218,9 @@ func (a *PayloadRehearsalAdapter) Preview(ctx context.Context, c apptypes.Payloa
 	}
 	if !codecMetadata {
 		// The copied target may predate the codec foundation. Its migration plan
-		// is still measurable, but the metadata columns do not exist yet.
+		// is still measurable, but the metadata columns do not exist yet. One
+		// probe covers both tables: migration 036 adds every *_plaintext_bytes
+		// column in a single step, so events and command_audits cannot disagree.
 		eventAggregateQuery = `SELECT count(*),coalesce(sum(length(CAST(body AS BLOB))),0) FROM events`
 		auditAggregateQuery = `SELECT count(*),coalesce(sum(length(CAST(command_text AS BLOB))+length(CAST(input_text AS BLOB))+length(CAST(output_text AS BLOB))),0) FROM command_audits`
 	}

--- a/infrastructure/sqlite/payload_rehearsal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_test.go
@@ -147,7 +147,9 @@ func TestPayloadRehearsalPreviewMeasuresBytesOnATargetPredatingTheCodecColumns(t
 }
 
 // migrationsBelowVersion returns the migration catalog truncated to versions
-// strictly below limit, so a store can be built at an older schema.
+// strictly below limit, so a store can be built at an older schema. This is the
+// catalog's own prefix, not a reconstruction of any particular past release --
+// enough to reach the pre-codec schema, which is what the fallback needs.
 func migrationsBelowVersion(t *testing.T, migrations fs.FS, limit int) fs.FS {
 	t.Helper()
 	paths, err := fs.Glob(migrations, "*.sql")

--- a/infrastructure/sqlite/payload_rehearsal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	_ "modernc.org/sqlite"
 
 	apptypes "github.com/duck8823/traceary/application/types"
@@ -19,6 +20,72 @@ import (
 	infra "github.com/duck8823/traceary/infrastructure/sqlite"
 	sqliteschema "github.com/duck8823/traceary/schema/sqlite"
 )
+
+func TestPayloadRehearsalPreviewReportsPlaintextBytesForLegacyAndEncodedRows(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name               string
+		encoded            bool
+		wantPlaintextBytes int64
+	}{
+		{name: "legacy multibyte text", wantPlaintextBytes: int64(len([]byte("あいうえお")) + len([]byte("入力")) + len([]byte("出力")))},
+		{name: "encoded row uses recorded plaintext bytes", encoded: true, wantPlaintextBytes: int64(len([]byte("あいうえお")) + len([]byte("入力")) + len([]byte("出力")))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			dir, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			live, target := filepath.Join(dir, "live.db"), filepath.Join(dir, "target.db")
+			migrations, err := sqliteschema.Migrations()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = infra.NewStoreManagementDatasource(infra.NewDatabase(live, migrations)).Initialize(ctx); err != nil {
+				t.Fatal(err)
+			}
+			db, err := sql.Open("sqlite", live)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = db.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at) VALUES('event-1','prompt','test','session-1',?,'2026-08-01T00:00:00Z')`, "あいうえお"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = db.Exec(`INSERT INTO command_audits(event_id,command_text,input_text,output_text) VALUES('event-1',?,?,?)`, "", "入力", "出力"); err != nil {
+				t.Fatal(err)
+			}
+			if err = db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			copyTestFile(t, live, target)
+			if tt.encoded {
+				db, err = sql.Open("sqlite", target)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err = db.Exec(`UPDATE events SET body=?,body_codec='zstd',body_format_version=1,body_plaintext_bytes=?,body_encoded_bytes=2,body_sha256=? WHERE id='event-1'`, []byte{0, 1}, len([]byte("あいうえお")), strings.Repeat("0", 64)); err != nil {
+					t.Fatal(err)
+				}
+				if _, err = db.Exec(`PRAGMA journal_mode=DELETE`); err != nil {
+					t.Fatal(err)
+				}
+				if err = db.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			adapter := newRehearsalAdapter(t, migrations, live)
+			metrics, err := adapter.Preview(ctx, rehearsalTestConfig(target, live, filepath.Join(dir, "backup.db")))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.wantPlaintextBytes, metrics.PlaintextBytes); diff != "" {
+				t.Fatalf("plaintext bytes mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestPayloadRehearsalDeterministicStopResumeScrubRollback(t *testing.T) {
 	ctx := context.Background()

--- a/infrastructure/sqlite/payload_rehearsal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_test.go
@@ -8,8 +8,10 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -85,6 +87,92 @@ func TestPayloadRehearsalPreviewReportsPlaintextBytesForLegacyAndEncodedRows(t *
 			}
 		})
 	}
+}
+
+// A rehearsal target only has to be a distinct file from the live store, so an
+// operator can point it at an older backup — that is what rehearsalMigrationsPending
+// exists to detect. Such a target predates the codec foundation and has none of
+// the *_plaintext_bytes columns, which selects the fallback aggregate. Exercise
+// it against a real pre-036 store rather than trusting the query by inspection.
+func TestPayloadRehearsalPreviewMeasuresBytesOnATargetPredatingTheCodecColumns(t *testing.T) {
+	ctx := context.Background()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, target := filepath.Join(dir, "live.db"), filepath.Join(dir, "target.db")
+	migrations, err := sqliteschema.Migrations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = infra.NewStoreManagementDatasource(infra.NewDatabase(live, migrations)).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	legacy := migrationsBelowVersion(t, migrations, 36)
+	if err = infra.NewStoreManagementDatasource(infra.NewDatabase(target, legacy)).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var codecColumn int
+	if err = db.QueryRow(`SELECT count(*) FROM pragma_table_info('events') WHERE name='body_plaintext_bytes'`).Scan(&codecColumn); err != nil {
+		t.Fatal(err)
+	}
+	if codecColumn != 0 {
+		t.Fatalf("target was expected to predate the codec columns, but events.body_plaintext_bytes exists")
+	}
+	if _, err = db.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at) VALUES('event-1','prompt','test','session-1',?,'2026-08-01T00:00:00Z')`, "あいうえお"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`INSERT INTO command_audits(event_id,command_text,input_text,output_text) VALUES('event-1',?,?,?)`, "", "入力", "出力"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`PRAGMA journal_mode=DELETE`); err != nil {
+		t.Fatal(err)
+	}
+	if err = db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	adapter := newRehearsalAdapter(t, migrations, live)
+	metrics, err := adapter.Preview(ctx, rehearsalTestConfig(target, live, filepath.Join(dir, "backup.db")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := int64(len([]byte("あいうえお")) + len([]byte("入力")) + len([]byte("出力")))
+	if diff := cmp.Diff(want, metrics.PlaintextBytes); diff != "" {
+		t.Fatalf("plaintext bytes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// migrationsBelowVersion returns the migration catalog truncated to versions
+// strictly below limit, so a store can be built at an older schema.
+func migrationsBelowVersion(t *testing.T, migrations fs.FS, limit int) fs.FS {
+	t.Helper()
+	paths, err := fs.Glob(migrations, "*.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	truncated := fstest.MapFS{}
+	for _, path := range paths {
+		version, err := strconv.Atoi(strings.SplitN(filepath.Base(path), "_", 2)[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if version >= limit {
+			continue
+		}
+		body, err := fs.ReadFile(migrations, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		truncated[path] = &fstest.MapFile{Data: body}
+	}
+	if len(truncated) == 0 {
+		t.Fatalf("truncated migration catalog is empty below version %d", limit)
+	}
+	return truncated
 }
 
 func TestPayloadRehearsalDeterministicStopResumeScrubRollback(t *testing.T) {


### PR DESCRIPTION
Closes #1749

## What

`PayloadRehearsalAdapter.Preview` sized the corpus with `length()` applied to TEXT columns. SQLite returns **characters** for TEXT and bytes only for BLOB, so every non-ASCII payload was under-counted — up to 3× for CJK, 4× for emoji. Traceary stores Japanese prompts and command output routinely.

The rehearsal is the input to the #1620 gate arithmetic. Under-counting the plaintext side makes the predicted compression saving look smaller than it is, and that prediction is what the gate decision rests on.

## How

Metadata first, bytes as the fallback:

```sql
sum(CASE WHEN body_plaintext_bytes IS NOT NULL
         THEN body_plaintext_bytes
         ELSE length(CAST(body AS BLOB)) END)
```

This is better than casting everything to BLOB, which was my first sketch. Once #1685's backfill has run, a zstd body's BLOB length is the *physical* size, not the plaintext size the rehearsal wants — the same expression would then mean two different things depending on the row's codec. Reading the recorded `*_plaintext_bytes` where it exists keeps `PlaintextBytes` genuinely plaintext on a mixed store, which is the issue's second acceptance criterion.

Legacy rows have no metadata and are identity-encoded, so their stored bytes *are* their plaintext bytes; the fallback is exact rather than approximate.

## The pre-036 target

A rehearsal target only has to be a distinct file from the live store — nothing requires it to be current, and `rehearsalMigrationsPending` exists precisely to detect one that is behind. Such a target has no `*_plaintext_bytes` columns at all, so the aggregate is chosen after a `pragma_table_info` probe.

That branch was reachable (`VerifyStoreCompatibility` returns nil when `store_format_state` is absent, so an old store is not rejected) and untested, which meant a typo in it would have surfaced only as a confusing `no such column` during a real preflight. Added a test that builds the target from a truncated migration catalog — a genuine pre-036 store, not one with columns removed — and asserts the column really is absent before measuring.

One probe covers both tables because migration 036 adds every `*_plaintext_bytes` column in a single step; noted in the code so the asymmetry does not read as an oversight.

## Scope check

`rg 'length\((body|command_text|input_text|output_text)\)'` over non-test code returns only these two sites on `main`. Both are fixed here; the other accounting sites were already converted by #1685's D6 sweep and #1742. `command_audits.command_text` / `input_text` / `output_text` are all `NOT NULL`, so no row is silently dropped from the sum by a NULL propagating through the addition.

## Verification

Three cases, all failing on `main` against a corpus of `あいうえお` / `入力` / `出力` (27 bytes, 9 characters):

```
legacy multibyte text                  -27 +9
encoded row uses recorded plaintext    -27 +6
target predating the codec columns     -27 +9
```

The second is the interesting one: on `main` it reports 6 — the two-byte zstd blob plus 4 characters of audit text — which is neither the plaintext size nor a consistent physical size. That is the ambiguity the issue describes, not just an under-count.

`go build ./...` ✅ / `go test ./...` ✅ / `go tool golangci-lint run` → 0 issues ✅ — run independently of the implementer.

## Review notes

Implementation delegated to gpt-5.6-luna; reviewed by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
