### PR TITLE
feat: inject wake summaries on Antigravity PreInvocation

### DIFF
--- a/.ai/spec/1606.md
+++ b/.ai/spec/1606.md
@@ -90,7 +90,7 @@ Supersedes `docs/architecture/hot-cold-segmented-history.md` (+ `.ja.md`), which
 | Codex CLI | ● `SessionStart` stdout / additionalContext | ● `{"decision":"block","reason":...}` → continuation prompt | ✕ 注入不可 | 39.9% |
 | Kimi Code | ✕ SessionStart は fire-and-forget → **初回 `UserPromptSubmit`** を使う | ● exit 2 →「a message can be appended to let the model continue」 | ✕「return values are completely ignored」 | 38.0% |
 | Grok Build | ● SessionStart | ● Stop | ✕ | 2.4% |
-| Antigravity | ○ PreInvocation（#1714 — 本 issue #1684 では未実装。stdout が JSON で context 載せ先が未検証） | ● Stop | **✕ compact hook 自体が無い** | 1.2% |
+| Antigravity | ● PreInvocation（`injectSteps.ephemeralMessage`、#1714 で実装） | ● Stop | **✕ compact hook 自体が無い** | 1.2% |
 | Gemini CLI | ● SessionStart | ● AfterAgent | ✕ | ~0% |
 
 **結論.**
@@ -311,7 +311,7 @@ stop(畳む) ── やりとり ── stop(スルー) ── compact
 | 起床注入 | 要約が 3 件ある | SessionStart | additionalContext に要約のみ。生本文を含まない | integration |
 | 要約なしは無音 | 要約 0 件 | SessionStart | 何も出力しない | unit |
 | Kimi の注入先 | Kimi ホスト | SessionStart | 何も出さない。初回 UserPromptSubmit で出す | integration |
-| Antigravity の注入先 | Antigravity ホスト | PreInvocation | **#1714 で扱う**（#1684 では未実装。stdout JSON の context フィールドが未検証） | integration |
+| Antigravity の注入先 | Antigravity ホスト | PreInvocation | **`injectSteps.ephemeralMessage` で実装済み（#1714）** | integration |
 | 索引退避で本文は残る | 窓外の event | projection rebuild | 全文検索に出ない。`show` では本文が読める | integration |
 | まだ畳めるうちは捨てない | 継続中で stale でないセッションの未精製 transcript | gc | 本文が残る | unit |
 | 終了済みなら畳めないので捨てる | 終了済み・要約なし（`covers_to` 無し）のセッション | gc | セッション全体が orphan になり `degraded=1` 要約後に本文が捨てられる | unit |

--- a/docs/integrations/antigravity.ja.md
+++ b/docs/integrations/antigravity.ja.md
@@ -12,12 +12,22 @@ Antigravity の `hooks.json` は *hook-group 名* から event config への top
 
 | Antigravity event | Traceary の効果 |
 | --- | --- |
-| `PreInvocation` | `conversationId` を key にした冪等な session 開始/更新（Antigravity に `SessionStart` はありません）。最初の workspace path を workspace とする |
+| `PreInvocation` | `conversationId` を key にした冪等な session 開始/更新（Antigravity に `SessionStart` はありません）。最初の workspace path を workspace とし、最初の対象発火で `injectSteps` を通じて想起要約を注入する |
 | `PreToolUse` (`run_command`) | 提案された `{CommandLine, Cwd}` を `conversationId + stepIdx` で永続化。ブロックしない（`{"decision":"allow"}`） |
 | `PostToolUse` (`run_command`) | 同一 step の `PreToolUse` が永続化した command を突き合わせ、`command_executed` audit を記録（step の `error` 付き）。pending が無ければ fail soft |
 | `Stop` | `transcriptPath` から最新の user prompt と model response を復元し、`prompt` + `transcript`、続いて turn 境界を記録。session は**閉じない** |
 
 Antigravity の payload は camelCase フィールド（`conversationId`, `workspacePaths`, `transcriptPath`, `toolCall.name`, `toolCall.args.CommandLine`, `toolCall.args.Cwd`, `stepIdx`, `terminationReason`）を使います。Traceary は共有 runtime（session / audit / transcript）を再利用する前に、これらを内部形式へ正規化します。
+
+### hook の出力語彙
+
+Antigravity は hook の stdout を JSON として解釈します。Traceary が使う出力語彙は次のとおりです。
+
+- `PreInvocation`: `{ "injectSteps": [...] }`。各 step は `toolCall`、`userMessage`、`ephemeralMessage` のいずれかです。Traceary は想起した wake summary を 1 つの `ephemeralMessage` で注入します。これは user が入力した本文ではないため、`userMessage` は使いません。
+- `PreToolUse`: `{ "decision": "allow" }`。
+- `Stop`: `{ "decision": "" }`。
+
+`PreInvocation` contract は、Antigravity CLI に同梱された vendor 文書 `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/hooks.md` で確認しました（公開版は [Antigravity hooks](https://antigravity.google/docs/hooks) にもあります）。contract の例は `injectSteps` と `ephemeralMessage` を使っています。matcher は無視され、handler は flat list で、既定の handler timeout は 30 秒です。
 
 packaged plugin は `mcp_config.json` を通じてローカルの `traceary mcp-server` も公開し、`traceary-session-history`、`traceary-memory-review`、`traceary-memory-remember` の文脈 skill を同梱します。`traceary hooks install` の直接設定は hook のみを導入します。Antigravity に MCP tool と skill を自動検出させる場合は packaged plugin を使用してください。
 

--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -12,12 +12,22 @@ Antigravity's `hooks.json` is a top-level map of *hook-group name* to event conf
 
 | Antigravity event | Traceary effect |
 | --- | --- |
-| `PreInvocation` | Idempotent session start/refresh keyed by `conversationId` (Antigravity has no `SessionStart`); the first workspace path becomes the workspace |
+| `PreInvocation` | Idempotent session start/refresh keyed by `conversationId` (Antigravity has no `SessionStart`); the first workspace path becomes the workspace; on the first eligible firing, injects recalled summaries through `injectSteps` |
 | `PreToolUse` (`run_command`) | Persists the proposed `{CommandLine, Cwd}` keyed by `conversationId + stepIdx`; never blocks (`{"decision":"allow"}`) |
 | `PostToolUse` (`run_command`) | Pairs the command persisted by `PreToolUse` for the same step and records a `command_executed` audit (with the step `error`); fails soft when no pending command exists |
 | `Stop` | Recovers the latest user prompt and model response from `transcriptPath`, records `prompt` + `transcript`, then records a turn boundary; **does not** close the session |
 
 Antigravity payloads use camelCase fields (`conversationId`, `workspacePaths`, `transcriptPath`, `toolCall.name`, `toolCall.args.CommandLine`, `toolCall.args.Cwd`, `stepIdx`, `terminationReason`). Traceary normalizes these into its internal shape before reusing the shared session / audit / transcript runtime.
+
+### Hook output vocabulary
+
+Antigravity parses hook stdout as JSON. The output vocabulary used by Traceary is:
+
+- `PreInvocation`: `{ "injectSteps": [...] }`, where each step may be a `toolCall`, `userMessage`, or `ephemeralMessage`. Traceary uses one `ephemeralMessage` for recalled wake summaries, not `userMessage`, because the text is not something the user typed.
+- `PreToolUse`: `{ "decision": "allow" }`.
+- `Stop`: `{ "decision": "" }`.
+
+The `PreInvocation` contract was confirmed in the vendor documentation shipped with the Antigravity CLI at `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/hooks.md` (the public contract is also documented at [Antigravity hooks](https://antigravity.google/docs/hooks)). Its contract example uses `injectSteps` with `ephemeralMessage`; the matcher is ignored, handlers are a flat list, and the default handler timeout is 30 seconds.
 
 The packaged plugin also exposes the local `traceary mcp-server` through `mcp_config.json` and includes the `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember` contextual skills. Direct `traceary hooks install` routes install hooks only; use the packaged plugin when Antigravity should discover the MCP tools and skills automatically.
 

--- a/presentation/cli/hook_antigravity.go
+++ b/presentation/cli/hook_antigravity.go
@@ -114,10 +114,12 @@ const antigravityHookClient = "antigravity"
 
 // runHookAntigravityPreInvocation starts or refreshes a Traceary session keyed
 // by conversationId. PreInvocation fires before every model call, so this is
-// idempotent: an existing session is treated as already started. Output is an
-// empty object so Antigravity injects no steps.
+// idempotent: an existing session is treated as already started. Wake
+// summaries are returned as a transient system message at most once per
+// conversation.
 func (c *RootCLI) runHookAntigravityPreInvocation(ctx context.Context, output io.Writer, input io.Reader, dbPath string) error {
-	defer func() { _ = writeAntigravityJSON(output, map[string]any{}) }()
+	response := map[string]any{}
+	defer func() { _ = writeAntigravityJSON(output, response) }()
 
 	if c.storeManagement == nil || c.session == nil {
 		return nil
@@ -201,6 +203,14 @@ func (c *RootCLI) runHookAntigravityPreInvocation(ctx context.Context, output io
 		}
 	}
 	c.runOpportunisticSessionGC(ctx, resolvedDBPath, sessionID)
+	var wakeText string
+	c.injectWakeSummaries(ctx, antigravityHookClient, sessionID, workspace, resolvedDBPath, func(text string) error {
+		wakeText = text
+		return nil
+	})
+	if wakeText != "" {
+		response["injectSteps"] = []map[string]any{{"ephemeralMessage": wakeText}}
+	}
 	return nil
 }
 

--- a/presentation/cli/hook_antigravity.go
+++ b/presentation/cli/hook_antigravity.go
@@ -203,6 +203,9 @@ func (c *RootCLI) runHookAntigravityPreInvocation(ctx context.Context, output io
 		}
 	}
 	c.runOpportunisticSessionGC(ctx, resolvedDBPath, sessionID)
+	if output == nil {
+		return nil
+	}
 	var wakeText string
 	c.injectWakeSummaries(ctx, antigravityHookClient, sessionID, workspace, resolvedDBPath, func(text string) error {
 		wakeText = text

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -236,6 +236,10 @@ func (c *RootCLI) replayAntigravitySpoolRecord(ctx context.Context, input io.Rea
 // the session as injected once it has written, so a discarded write would
 // consume the marker and silence the live firing. A nil writer makes injection
 // a no-op.
+//
+// The generic session replay above is the one exception left, and it is a
+// defect rather than a decision: it still passes io.Discard and consumes the
+// marker for Claude, Gemini and Codex. Tracked by #1785.
 func (c *RootCLI) replayGrokSpoolRecord(ctx context.Context, input io.Reader, action, dbPath string) error {
 	switch strings.TrimSpace(action) {
 	case "session-start":

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -220,21 +220,22 @@ func (c *RootCLI) replayHookSpoolRecord(ctx context.Context, record hookSpoolRec
 func (c *RootCLI) replayAntigravitySpoolRecord(ctx context.Context, input io.Reader, action, dbPath string) error {
 	switch strings.TrimSpace(action) {
 	case "pre-invocation":
-		return c.runHookAntigravityPreInvocation(ctx, io.Discard, input, dbPath)
+		return c.runHookAntigravityPreInvocation(ctx, nil, input, dbPath)
 	case "pre-tool-use":
-		return c.runHookAntigravityPreToolUse(ctx, io.Discard, input, dbPath)
+		return c.runHookAntigravityPreToolUse(ctx, nil, input, dbPath)
 	case "post-tool-use":
-		return c.runHookAntigravityPostToolUse(ctx, io.Discard, input, dbPath)
+		return c.runHookAntigravityPostToolUse(ctx, nil, input, dbPath)
 	case "stop":
-		return c.runHookAntigravityStop(ctx, io.Discard, input, dbPath)
+		return c.runHookAntigravityStop(ctx, nil, input, dbPath)
 	default:
 		return xerrors.Errorf("unsupported antigravity spool action: %s", action)
 	}
 }
 
-// Replay passes a nil writer, not io.Discard: wake injection (#1684) marks the
-// session as injected once it has written, so a discarded write would consume
-// the marker and silence the live firing. A nil writer makes injection a no-op.
+// Spool replay passes a nil writer, not io.Discard: wake injection (#1684) marks
+// the session as injected once it has written, so a discarded write would
+// consume the marker and silence the live firing. A nil writer makes injection
+// a no-op.
 func (c *RootCLI) replayGrokSpoolRecord(ctx context.Context, input io.Reader, action, dbPath string) error {
 	switch strings.TrimSpace(action) {
 	case "session-start":

--- a/presentation/cli/hook_wake_injection.go
+++ b/presentation/cli/hook_wake_injection.go
@@ -88,6 +88,30 @@ func (c *RootCLI) maybeInjectWakeSummaries(
 	if output == nil {
 		return
 	}
+	c.injectWakeSummaries(ctx, client, sessionID, workspace, dbPath, func(text string) error {
+		_, err := io.WriteString(output, text)
+		if err != nil {
+			return xerrors.Errorf("failed to write wake injection: %w", err)
+		}
+		return nil
+	})
+}
+
+// injectWakeSummaries selects and delivers finished session summaries at most
+// once per client+session. The sink lets structured-output hosts embed the
+// same text without duplicating selection or marker semantics. Failures are
+// swallowed: injection must never fail the hook.
+func (c *RootCLI) injectWakeSummaries(
+	ctx context.Context,
+	client string,
+	sessionID types.SessionID,
+	workspace types.Workspace,
+	dbPath string,
+	sink func(string) error,
+) {
+	if sink == nil {
+		return
+	}
 	if strings.TrimSpace(sessionID.String()) == "" {
 		return
 	}
@@ -117,7 +141,7 @@ func (c *RootCLI) maybeInjectWakeSummaries(
 	}
 
 	if text != "" {
-		if _, err := io.WriteString(output, text); err != nil {
+		if err := sink(text); err != nil {
 			slog.Debug("wake injection write failed", "error", err, "session_id", sessionID.String())
 			// Do not mark: a failed write may be retried on the next firing.
 			return

--- a/presentation/cli/hook_wake_injection_test.go
+++ b/presentation/cli/hook_wake_injection_test.go
@@ -293,6 +293,59 @@ func TestHookAntigravityPreInvocationWakeInjection(t *testing.T) {
 	}
 }
 
+func TestHookAntigravityPreInvocationWakeInjectionSurvivesSpoolReplay(t *testing.T) {
+	const workspace = "github.com/duck8823/traceary"
+	const conversationID = "conv-antigravity-replay"
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stateDir := t.TempDir()
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+	t.Setenv("TRACEARY_WORKSPACE", workspace)
+
+	fx := newWakeInjectionFixture(t)
+	fx.seedSummary(context.Background(), t, "sess-antigravity-replay", workspace, time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC), "replayed summary", false, "")
+
+	spoolRecord := map[string]any{
+		"schema_version": 1,
+		"command":        "antigravity",
+		"client":         "antigravity",
+		"action":         "pre-invocation",
+		"db_path":        fx.dbPath,
+		"payload":        `{"conversationId":"` + conversationID + `","workspacePaths":["/repo"]}`,
+		"created_at":     time.Now().UTC(),
+	}
+	recordJSON, err := json.Marshal(spoolRecord)
+	if err != nil {
+		t.Fatalf("marshal spool record: %v", err)
+	}
+	spoolDir := filepath.Join(stateDir, "spool")
+	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
+		t.Fatalf("create spool directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(spoolDir, "antigravity-replay.json"), recordJSON, 0o600); err != nil {
+		t.Fatalf("write spool record: %v", err)
+	}
+
+	wantText, err := runHookSessionStart(t, fx, "conv-session-start-reference", workspace)
+	if err != nil {
+		t.Fatalf("SessionStart formatter reference error = %v", err)
+	}
+	gotJSON := runHookAntigravityWithWake(t, fx, conversationID)
+	var got map[string]any
+	if err := json.Unmarshal([]byte(gotJSON), &got); err != nil {
+		t.Fatalf("live PreInvocation output is invalid JSON: %v; output=%q", err, gotJSON)
+	}
+	want := map[string]any{
+		"injectSteps": []any{
+			map[string]any{"ephemeralMessage": wantText},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("live PreInvocation JSON mismatch after spool replay (-want +got):\n%s", diff)
+	}
+}
+
 func TestHookSessionStart_MissingRefinementsTableInjectsNothing(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/presentation/cli/hook_wake_injection_test.go
+++ b/presentation/cli/hook_wake_injection_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -200,6 +201,96 @@ func TestHookSessionStart_WakeInjection(t *testing.T) {
 			t.Fatalf("expected injection content, got %q", outs[0])
 		}
 	})
+}
+
+func TestHookAntigravityPreInvocationWakeInjection(t *testing.T) {
+	const workspace = "github.com/duck8823/traceary"
+
+	tests := []struct {
+		name       string
+		seed       func(context.Context, *testing.T, *wakeInjectionFixture)
+		budgetJSON string
+		secondCall bool
+		wantText   bool
+	}{
+		{
+			name: "eligible summaries use ephemeral message",
+			seed: func(ctx context.Context, t *testing.T, fx *wakeInjectionFixture) {
+				fx.seedSummary(ctx, t, "sess-antigravity", workspace, time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC), "recalled summary", false, "")
+			},
+			wantText: true,
+		},
+		{
+			name: "second PreInvocation is empty",
+			seed: func(ctx context.Context, t *testing.T, fx *wakeInjectionFixture) {
+				fx.seedSummary(ctx, t, "sess-antigravity", workspace, time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC), "recalled summary", false, "")
+			},
+			secondCall: true,
+			wantText:   true,
+		},
+		{
+			name: "no eligible summaries are empty",
+		},
+		{
+			name:       "zero budget is empty",
+			budgetJSON: "0",
+		},
+		{
+			name:       "negative budget is empty",
+			budgetJSON: "-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+			t.Setenv("TRACEARY_WORKSPACE", workspace)
+			if tt.budgetJSON != "" {
+				writeWakeAndConsolidationConfig(t, home, tt.budgetJSON, "")
+			}
+
+			fx := newWakeInjectionFixture(t)
+			if tt.seed != nil {
+				tt.seed(context.Background(), t, fx)
+			}
+			var wantText string
+			if tt.wantText {
+				var err error
+				wantText, err = runHookSessionStart(t, fx, "conv-session-start", workspace)
+				if err != nil {
+					t.Fatalf("SessionStart formatter reference error = %v", err)
+				}
+			}
+			first := runHookAntigravityWithWake(t, fx, "conv-antigravity")
+			var got map[string]any
+			if err := json.Unmarshal([]byte(first), &got); err != nil {
+				t.Fatalf("first PreInvocation output is invalid JSON: %v; output=%q", err, first)
+			}
+
+			want := map[string]any{}
+			if tt.wantText {
+				want["injectSteps"] = []any{
+					map[string]any{"ephemeralMessage": wantText},
+				}
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("first PreInvocation JSON mismatch (-want +got):\n%s", diff)
+			}
+
+			if tt.secondCall {
+				second := runHookAntigravityWithWake(t, fx, "conv-antigravity")
+				var gotSecond map[string]any
+				if err := json.Unmarshal([]byte(second), &gotSecond); err != nil {
+					t.Fatalf("second PreInvocation output is invalid JSON: %v; output=%q", err, second)
+				}
+				if diff := cmp.Diff(map[string]any{}, gotSecond); diff != "" {
+					t.Fatalf("second PreInvocation JSON mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
 }
 
 func TestHookSessionStart_MissingRefinementsTableInjectsNothing(t *testing.T) {
@@ -529,6 +620,25 @@ func runHookKimi(t *testing.T, fx *wakeInjectionFixture, action, sessionID, work
 	rootCmd.SetArgs([]string{"hook", "kimi", action, "--db-path", fx.dbPath})
 	err := rootCmd.Execute()
 	return stdout.String(), err
+}
+
+func runHookAntigravityWithWake(t *testing.T, fx *wakeInjectionFixture, conversationID string) string {
+	t.Helper()
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(fx.storeUC),
+		cli.WithSession(fx.sessionUC),
+		cli.WithSessionWakeSummary(fx.wake),
+		cli.WithDatabasePathSetter(fx.database.SetPath),
+	).Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"conversationId":"` + conversationID + `","workspacePaths":["/repo"]}`))
+	rootCmd.SetArgs([]string{"hook", "antigravity", "pre-invocation", "--db-path", fx.dbPath})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(hook antigravity pre-invocation) error = %v", err)
+	}
+	return stdout.String()
 }
 
 func assertWakeStdout(t *testing.T, stdout string, wantSub, wantAbsent []string, wantEmpty bool, maxLen int64) {


### PR DESCRIPTION
Closes #1714

## What

#1684 shipped wake-time injection on every host except Antigravity, and left this issue behind for a specific reason: Antigravity parses `PreInvocation` stdout as JSON, and the only output vocabulary this repository had verified was `decision` plus "an empty object so Antigravity injects no steps". Guessing a field name would have shipped a hook that `doctor` reports as installed while it silently injects nothing — the issue says outright that this is worse than not shipping it.

So the first half of this issue was research, not code.

## The contract, confirmed rather than guessed

The field is **`injectSteps`**. Confirmed in the vendor's own hook documentation, shipped with the Antigravity CLI at `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/hooks.md`, whose `PreInvocation` section is titled *"Use to inject context or instructions before the model runs"* and gives:

```json
{
  "injectSteps": [
    { "ephemeralMessage": "Remember to check for lint errors before proposing changes." }
  ]
}
```

`injectSteps` is optional; the supported step types are `toolCall`, `userMessage` and `ephemeralMessage`, the last documented as a transient system message.

This resolves #1714 to its **"if a field exists"** branch, so the spec's host table entry `Antigravity | ● PreInvocation` stands and is now stated positively rather than as an open question.

**`ephemeralMessage`, not `userMessage`.** The payload is recalled context — `hook_wake_injection.go` says so on its own first line — and `userMessage` would present Traceary's text to the model as something the operator typed.

Also recorded from the same document, because it constrains this hook: `PreInvocation` ignores the matcher, takes a flat handler list, and handlers default to a **30-second** timeout. This is the path that blocks every model call.

## Implementation

The obstacle was that `maybeInjectWakeSummaries` writes text straight to an `io.Writer`, which a JSON-parsing host cannot use. Rather than duplicate the selection, budget and marker logic, the shared part is factored into `injectWakeSummaries` behind a sink: the existing hosts pass a sink that writes to stdout, and Antigravity passes one that captures the text for embedding.

Nothing about selection, the byte budget, or the once-per-session marker changed. That matters because `PreInvocation` fires **before every model call** — the marker is the only thing standing between one injection and one per model call, and it is the same marker the other hosts use.

With nothing to inject the response stays exactly `{}`, which the vendor contract treats as valid and which is what this handler emitted before.

## The review finding this PR nearly shipped with

Independent review (gpt-5.6-sol) found a HIGH issue that the first implementation introduced, and it was worse than the one already named below.

`hook_spool.go` replayed a spooled Antigravity `PreInvocation` with `io.Discard`. Grok and Kimi pass `nil` instead, with a comment three lines away explaining exactly why: `maybeInjectWakeSummaries` returns early on `output == nil`, so replay cannot consume the marker. This branch's handler called the shared function directly, so it had no such guard — and `io.Discard` is not nil anyway.

The result: a failed `PreInvocation` gets spooled, a later hook replays it, the replay selects the summaries, the capture sink succeeds, the marker is written, and the JSON carrying `injectSteps` goes to `io.Discard`. Every subsequent `PreInvocation` for that conversation then returns `{}`. The conversation never receives its wake summaries **at all** — not once lost, permanently silenced.

Before this branch the same replay was harmless, because the handler never injected anything.

Fixed on both halves, because neither alone is sufficient: replay passes `nil`, and the handler returns before touching selection, the budget or the marker when the writer is nil.

`TestHookAntigravityPreInvocationWakeInjectionSurvivesSpoolReplay` drives a real spool record through the replay entry point. It was verified against both mutations independently:

```
# guard removed from the handler
--- FAIL: TestHookAntigravityPreInvocationWakeInjectionSurvivesSpoolReplay
# io.Discard restored in hook_spool.go
--- FAIL: TestHookAntigravityPreInvocationWakeInjectionSurvivesSpoolReplay
```

## The same defect exists elsewhere, and is not fixed here

Checking the finding turned up that the **generic** spool replay still passes `io.Discard` for `session` records, and `runHookSession` injects on `start` (`hook_session.go:106`, `:149`). So Claude, Gemini and Codex lose wake injection permanently for any session whose hook spools — and `hook_session.go:95` says replay of an already-committed session start is a common path, not a rare one.

That is pre-existing, on a path this branch does not touch, and it affects a different set of hosts, so it is #1785 rather than a widening of this PR. The comment stating the nil-writer rule names the exception so the file does not claim something untrue.

It is a #1620 gate item: "wake injection on every host" cannot be measured honestly while three hosts silently drop it.

## Verification

The injection test was mutation-verified rather than trusted: deleting the `response["injectSteps"] = ...` assignment fails both meaningful subtests.

```
--- FAIL: TestHookAntigravityPreInvocationWakeInjection/eligible_summaries_use_ephemeral_message
--- FAIL: TestHookAntigravityPreInvocationWakeInjection/second_PreInvocation_is_empty
```

Covered: eligible summaries produce one `ephemeralMessage` carrying exactly the text the shared formatter produces; the **second** firing for the same conversation produces `{}`; no eligible summaries, a zero budget and a negative budget all produce `{}`; and a spool replay does not consume the injection. Assertions decode the JSON and compare structure, not the encoding.

`go build ./...` ✅ / `go test ./...` ✅ / `go tool golangci-lint run` → 0 issues ✅ — run independently of the implementer.

## One behaviour worth naming

The shared code marks the session as injected after the **sink** succeeds, and for Antigravity the sink only captures the text; the JSON write happens afterwards in the handler's deferred writer. So a failure of that final write would lose the injection for that conversation, where the plaintext hosts would retry on the next firing. The comment in the shared code — *"a failed write may be retried on the next firing"* — is therefore slightly weaker for this host. Left as is: the alternative is marking after the response is serialised, which would push marker state into the hook's exit path for a failure mode that costs one injection.

That is a different and much smaller problem than the spool replay one above, which cost every injection rather than one.

## Review notes

Contract research by Claude Opus 5; implementation delegated to gpt-5.6-luna; reviewed by Claude Opus 5 and gpt-5.6-sol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
