### PR TITLE
fix: stop spool replay consuming the wake-injection marker

### DIFF
--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -183,6 +183,10 @@ func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) 
 	return result
 }
 
+// Spool replay passes a nil writer, not io.Discard: wake injection (#1684) marks
+// the session as injected once it has written, so a discarded write would
+// consume the marker and silence the live firing. A nil writer makes injection
+// a no-op.
 func (c *RootCLI) replayHookSpoolRecord(ctx context.Context, record hookSpoolRecord) error {
 	input := newExplicitHookPayloadReader([]byte(record.Payload))
 	dbPath := record.DBPath
@@ -190,11 +194,11 @@ func (c *RootCLI) replayHookSpoolRecord(ctx context.Context, record hookSpoolRec
 	action := record.Action
 	switch strings.TrimSpace(record.Command) {
 	case "session":
-		return c.runHookSession(ctx, io.Discard, input, client, action, dbPath)
+		return c.runHookSession(ctx, nil, input, client, action, dbPath)
 	case "audit":
 		return c.runHookAudit(ctx, input, client, dbPath)
 	case "compact":
-		return c.runHookCompact(ctx, io.Discard, input, client, action, dbPath)
+		return c.runHookCompact(ctx, nil, input, client, action, dbPath)
 	case "subagent-start":
 		return c.runHookSubagentStart(ctx, input, client, dbPath)
 	case "subagent-stop":
@@ -232,14 +236,6 @@ func (c *RootCLI) replayAntigravitySpoolRecord(ctx context.Context, input io.Rea
 	}
 }
 
-// Spool replay passes a nil writer, not io.Discard: wake injection (#1684) marks
-// the session as injected once it has written, so a discarded write would
-// consume the marker and silence the live firing. A nil writer makes injection
-// a no-op.
-//
-// The generic session replay above is the one exception left, and it is a
-// defect rather than a decision: it still passes io.Discard and consumes the
-// marker for Claude, Gemini and Codex. Tracked by #1785.
 func (c *RootCLI) replayGrokSpoolRecord(ctx context.Context, input io.Reader, action, dbPath string) error {
 	switch strings.TrimSpace(action) {
 	case "session-start":

--- a/presentation/cli/hook_wake_injection_test.go
+++ b/presentation/cli/hook_wake_injection_test.go
@@ -346,6 +346,56 @@ func TestHookAntigravityPreInvocationWakeInjectionSurvivesSpoolReplay(t *testing
 	}
 }
 
+func TestHookSessionStartWakeInjectionSurvivesSpoolReplay(t *testing.T) {
+	const workspace = "github.com/duck8823/traceary"
+	const replaySessionID = "sess-generic-replay"
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stateDir := t.TempDir()
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+	t.Setenv("TRACEARY_WORKSPACE", workspace)
+
+	fx := newWakeInjectionFixture(t)
+	fx.seedSummary(context.Background(), t, "sess-wake-source", workspace, time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC), "replayed session summary", false, "")
+	if _, err := fx.sessionUC.Start(context.Background(), types.Client("hook"), types.Agent("codex"), types.SessionID(replaySessionID), types.Workspace(workspace), ""); err != nil {
+		t.Fatalf("seed replay session: %v", err)
+	}
+
+	spoolRecord := map[string]any{
+		"schema_version": 1,
+		"command":        "session",
+		"client":         "codex",
+		"action":         "start",
+		"db_path":        fx.dbPath,
+		"payload":        `{"session_id":"` + replaySessionID + `","cwd":"/tmp","hook_event_name":"SessionStart"}`,
+		"created_at":     time.Now().UTC(),
+	}
+	recordJSON, err := json.Marshal(spoolRecord)
+	if err != nil {
+		t.Fatalf("marshal spool record: %v", err)
+	}
+	spoolDir := filepath.Join(stateDir, "spool")
+	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
+		t.Fatalf("create spool directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(spoolDir, "session-replay.json"), recordJSON, 0o600); err != nil {
+		t.Fatalf("write spool record: %v", err)
+	}
+
+	if _, err := runHookSessionStart(t, fx, "sess-drain-trigger", workspace); err != nil {
+		t.Fatalf("drain-trigger SessionStart error = %v", err)
+	}
+
+	stdout, err := runHookSessionStart(t, fx, replaySessionID, workspace)
+	if err != nil {
+		t.Fatalf("live SessionStart after spool replay error = %v", err)
+	}
+	if diff := cmp.Diff(true, strings.Contains(stdout, "replayed session summary")); diff != "" {
+		t.Fatalf("live SessionStart after spool replay did not emit the summary (-want +got):\n%s\nstdout=%q", diff, stdout)
+	}
+}
+
 func TestHookSessionStart_MissingRefinementsTableInjectsNothing(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
Closes #1785

## What

Spool replay of a `session` hook passed `io.Discard`. `runHookSession` injects wake summaries on the `start` action (`hook_session.go:106`, `:149`), and `maybeInjectWakeSummaries` returns early only when `output == nil` — `io.Discard` is not nil.

So a replayed session start selected the summaries, wrote them into `io.Discard`, and then wrote the marker. The marker is consumed, the text is gone, and every later `SessionStart` for that client and session returns nothing because the marker says the injection already happened.

The session never receives its wake summaries. Not one lost injection — all of them, permanently.

Claude, Gemini and Codex were affected. Grok, Kimi and Antigravity already pass `nil`; Antigravity was fixed in #1714, which is where this defect was found.

## Not a rare path

`hook_session.go:95-98` says so itself:

> Spool replay (and hosts that re-fire SessionStart) often hit a session that already committed before the kill.

The `ErrInvalidSessionState` branch that comment describes is the branch containing the injection at line 106.

## The fix

`replayHookSpoolRecord` passes `nil` for `session` and for `compact`, matching what the Grok, Kimi and Antigravity replays already do. `runHookCompact` does not inject, but it already carries its own `output == nil` guard for exactly these callers, so switching it costs nothing and leaves the file with one convention instead of two.

The comment stating the rule moves to `replayHookSpoolRecord`, where it governs every replay rather than reading as documentation for one host's helper.

## Test

`TestHookSessionStartWakeInjectionSurvivesSpoolReplay` drives a real spool record through the replay entry point and then asserts a subsequent live `SessionStart` still emits the summary text. Verified non-vacuous by restoring `io.Discard`:

```
--- FAIL: TestHookSessionStartWakeInjectionSurvivesSpoolReplay
    - true
    + false
    stdout=""
```

The empty `stdout` is the defect exactly: the live firing produces nothing because the replay consumed the marker.

## Why now rather than after the release

"Wake injection on every host" is a #1620 gate row. It cannot be measured honestly while three hosts silently drop it whenever their session hook spools.

## Verification

`go build ./...` ✅ / `go test ./...` ✅ / `go tool golangci-lint run` → 0 issues ✅ — run independently of the implementer.

No new command, subcommand, flag or MCP tool.

## Review notes

Found by Claude Opus 5 while checking a gpt-5.6-sol finding on #1714; implementation delegated to gpt-5.6-luna; reviewed by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
