### PR TITLE
fix: anchor payload backfill checkpoints per transition

### DIFF
--- a/infrastructure/sqlite/payload_backfill.go
+++ b/infrastructure/sqlite/payload_backfill.go
@@ -58,6 +58,9 @@ const payloadBackfillCheckpointTimeout = 10 * time.Second
 // codec: events.body and command_audits.{command_text,input_text,output_text}.
 type PayloadBackfillDatasource struct {
 	db *Database
+	// checkpointTimeout bounds test-injected checkpoint windows. Production
+	// leaves it zero, which uses payloadBackfillCheckpointTimeout.
+	checkpointTimeout time.Duration
 	// onBeforeCommitBatch is a test hook that fires after a batch is selected
 	// and before the verify/encode transaction. Production leaves it nil.
 	onBeforeCommitBatch func(batch []backfillCandidate)
@@ -237,23 +240,10 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 		return apptypes.PayloadBackfillResult{}, err
 	}
 
-	// Checkpoint writes outlive the cancellation that triggers them. Every
-	// terminal transition — complete, reset, pause, fail — records what the
-	// worker already did durably, so running it on the caller's context would
-	// lose that record exactly when the run needs it most.
-	//
-	// Bounded, though: WithoutCancel drops the deadline too, and acquiring the
-	// store lease waits on nothing but the context. An unbounded checkpoint
-	// would turn "someone else holds the store" into a process that never
-	// returns. Losing the checkpoint is recoverable — resume reads the cursor
-	// the last committed batch left — and hanging is not.
-	closeCtx, cancelClose := context.WithTimeout(context.WithoutCancel(ctx), payloadBackfillCheckpointTimeout)
-	defer cancelClose()
-
 	var batchCount int64
 	for {
 		if err = ctx.Err(); err != nil {
-			return d.abortRun(ctx, closeCtx, db, run, batchCount, err)
+			return d.abortRun(ctx, db, run, batchCount, err)
 		}
 
 		// Begin a new pass when the cursor is at the origin.
@@ -268,7 +258,7 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 		}
 		batch, selectErr := d.selectBackfillBatch(ctx, db, run.CursorRowID, ceilings, c.BatchRows)
 		if selectErr != nil {
-			return d.abortRun(ctx, closeCtx, db, run, batchCount, selectErr)
+			return d.abortRun(ctx, db, run, batchCount, selectErr)
 		}
 		if d.onSelectedBatch != nil {
 			batch = d.onSelectedBatch(batch)
@@ -286,18 +276,22 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 			if !run.passDirty {
 				remaining, countErr := countEligibleBackfillRows(ctx, db, run.CursorRowID, ceilings)
 				if countErr != nil {
-					return d.abortRun(ctx, closeCtx, db, run, batchCount, countErr)
+					return d.abortRun(ctx, db, run, batchCount, countErr)
 				}
 				if remaining > 0 {
-					return d.abortRun(ctx, closeCtx, db, run, batchCount, xerrors.Errorf(
+					return d.abortRun(ctx, db, run, batchCount, xerrors.Errorf(
 						"payload backfill selection returned no candidates while %d eligible fields remain past cursor %d",
 						remaining, run.CursorRowID,
 					))
 				}
-				if completeErr := completeBackfillRun(closeCtx, db, run); completeErr != nil {
+				checkpointCtx, cancelCheckpoint := d.checkpointContext(ctx)
+				completeErr := completeBackfillRun(checkpointCtx, db, run)
+				if completeErr != nil {
+					cancelCheckpoint()
 					return apptypes.PayloadBackfillResult{}, completeErr
 				}
-				loaded, loadErr := loadBackfillRun(closeCtx, db, run.RunID)
+				loaded, loadErr := loadBackfillRun(checkpointCtx, db, run.RunID)
+				cancelCheckpoint()
 				if loadErr != nil {
 					return apptypes.PayloadBackfillResult{}, loadErr
 				}
@@ -305,7 +299,10 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 			}
 			// Conflicts or rewrites this pass: restart from rowid 0 under the
 			// same high-waters so skipped rows are not stranded.
-			if resetErr := resetBackfillCursor(closeCtx, db, run); resetErr != nil {
+			checkpointCtx, cancelCheckpoint := d.checkpointContext(ctx)
+			resetErr := resetBackfillCursor(checkpointCtx, db, run)
+			cancelCheckpoint()
+			if resetErr != nil {
 				return apptypes.PayloadBackfillResult{}, resetErr
 			}
 			run.CursorRowID = 0
@@ -318,13 +315,15 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 		stats, commitErr := commitBackfillBatch(ctx, db, run, batch)
 		if commitErr != nil {
 			if errors.Is(commitErr, ErrPayloadBackfillPartialMetadata) {
-				failed, failErr := failBackfillRun(closeCtx, db, run, stats.PartialEventID, stats.PartialReason, stats)
+				checkpointCtx, cancelCheckpoint := d.checkpointContext(ctx)
+				failed, failErr := failBackfillRun(checkpointCtx, db, run, stats.PartialEventID, stats.PartialReason, stats)
+				cancelCheckpoint()
 				if failErr != nil {
 					return apptypes.PayloadBackfillResult{}, failErr
 				}
 				return resultFromRun(failed, batchCount, false), xerrors.Errorf("%w: event %s: %s", ErrPayloadBackfillPartialMetadata, stats.PartialEventID, stats.PartialReason)
 			}
-			return d.abortRun(ctx, closeCtx, db, run, batchCount, commitErr)
+			return d.abortRun(ctx, db, run, batchCount, commitErr)
 		}
 		batchCount++
 		if d.onAfterCommitBatch != nil {
@@ -344,16 +343,40 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 		}
 
 		if c.StopAfterBatches > 0 && batchCount >= c.StopAfterBatches {
-			if pauseErr := pauseBackfillRun(closeCtx, db, run); pauseErr != nil {
+			checkpointCtx, cancelCheckpoint := d.checkpointContext(ctx)
+			pauseErr := pauseBackfillRun(checkpointCtx, db, run)
+			if pauseErr != nil {
+				cancelCheckpoint()
 				return apptypes.PayloadBackfillResult{}, pauseErr
 			}
-			loaded, loadErr := loadBackfillRun(closeCtx, db, run.RunID)
+			loaded, loadErr := loadBackfillRun(checkpointCtx, db, run.RunID)
+			cancelCheckpoint()
 			if loadErr != nil {
 				return apptypes.PayloadBackfillResult{}, loadErr
 			}
 			return resultFromRun(loaded, batchCount, true), nil
 		}
 	}
+}
+
+func (d *PayloadBackfillDatasource) checkpointContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	// Checkpoint writes outlive the cancellation that triggers them. Every
+	// terminal transition — complete, reset, pause, fail — records what the
+	// worker already did durably, so running it on the caller's context would
+	// lose that record exactly when the run needs it most. Derive this context
+	// when the transition is taken, not when the run starts, so the budget is
+	// not consumed by the preceding work.
+	//
+	// Bounded, though: WithoutCancel drops the deadline too, and acquiring the
+	// store lease waits on nothing but the context. An unbounded checkpoint
+	// would turn "someone else holds the store" into a process that never
+	// returns. Losing the checkpoint is recoverable — resume reads the cursor
+	// the last committed batch left — and hanging is not.
+	timeout := d.checkpointTimeout
+	if timeout == 0 {
+		timeout = payloadBackfillCheckpointTimeout
+	}
+	return context.WithTimeout(context.WithoutCancel(ctx), timeout)
 }
 
 // abortRun ends the loop on an error that reached it. When the run was
@@ -368,7 +391,6 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 // Only a cause that is itself a context error is reported as a cancellation.
 func (d *PayloadBackfillDatasource) abortRun(
 	ctx context.Context,
-	closeCtx context.Context,
 	db *sql.DB,
 	run backfillRunHandle,
 	batchCount int64,
@@ -377,13 +399,15 @@ func (d *PayloadBackfillDatasource) abortRun(
 	if ctx.Err() == nil {
 		return apptypes.PayloadBackfillResult{}, cause
 	}
-	if pauseErr := pauseBackfillRun(closeCtx, db, run); pauseErr != nil {
+	checkpointCtx, cancelCheckpoint := d.checkpointContext(ctx)
+	defer cancelCheckpoint()
+	if pauseErr := pauseBackfillRun(checkpointCtx, db, run); pauseErr != nil {
 		return apptypes.PayloadBackfillResult{}, xerrors.Errorf("%v; pause payload backfill: %w", cause, pauseErr)
 	}
 	if !errors.Is(cause, context.Canceled) && !errors.Is(cause, context.DeadlineExceeded) {
 		return apptypes.PayloadBackfillResult{}, cause
 	}
-	loaded, loadErr := loadBackfillRun(closeCtx, db, run.RunID)
+	loaded, loadErr := loadBackfillRun(checkpointCtx, db, run.RunID)
 	if loadErr != nil {
 		return apptypes.PayloadBackfillResult{}, loadErr
 	}

--- a/infrastructure/sqlite/payload_backfill_test.go
+++ b/infrastructure/sqlite/payload_backfill_test.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -1087,6 +1089,61 @@ func TestPayloadBackfillPersistsPauseOnCancellation(t *testing.T) {
 	}
 }
 
+func TestPayloadBackfillCheckpointWindowStartsAtEachTransition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		stopAfterBatch int64
+		wantState      string
+	}{
+		{
+			name:      "completion after a slow committed batch",
+			wantState: string(apptypes.PayloadBackfillCompleted),
+		},
+		{
+			name:           "pause after a slow committed batch",
+			stopAfterBatch: 1,
+			wantState:      string(apptypes.PayloadBackfillPaused),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, ds, _ := openPayloadBackfillFixture(t)
+			defer closePayloadBackfillFixture(t, db)
+			insertIdentityEvent(t, db, eventSeed{
+				ID: "checkpoint-window", Kind: "note", Body: compressibleBody("checkpoint-window"),
+			})
+
+			ds.checkpointTimeout = 5 * time.Millisecond
+			var once sync.Once
+			ds.onAfterCommitBatch = func(int64) {
+				once.Do(func() { time.Sleep(25 * time.Millisecond) })
+			}
+
+			result, err := ds.Run(context.Background(), apptypes.PayloadBackfillConfig{
+				BatchRows:        1,
+				StopAfterBatches: tt.stopAfterBatch,
+			})
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if diff := cmp.Diff(tt.wantState, result.State); diff != "" {
+				t.Fatalf("result state mismatch (-want +got):\n%s", diff)
+			}
+
+			var persistedState string
+			if err := db.QueryRow(`SELECT state FROM payload_backfill_runs`).Scan(&persistedState); err != nil {
+				t.Fatalf("read persisted state: %v", err)
+			}
+			if diff := cmp.Diff(tt.wantState, persistedState); diff != "" {
+				t.Fatalf("persisted state mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 // Identity bodies are bound as TEXT to preserve the column affinity readers
 // and triggers expect. SQLite TEXT is a byte string, not validated UTF-8, but
 // the rewrite has to prove it: a legacy body is arbitrary bytes and losing any
@@ -1296,7 +1353,7 @@ func TestPayloadBackfillReportsTheRealErrorThatRacedACancellation(t *testing.T) 
 	cancel()
 
 	diskFull := errors.New("disk I/O error")
-	result, got := ds.abortRun(ctx, context.WithoutCancel(ctx), db, run, 1, diskFull)
+	result, got := ds.abortRun(ctx, db, run, 1, diskFull)
 	if !errors.Is(got, diskFull) {
 		t.Fatalf("abortRun error = %v, want the disk I/O error", got)
 	}

--- a/infrastructure/sqlite/payload_backfill_test.go
+++ b/infrastructure/sqlite/payload_backfill_test.go
@@ -1116,10 +1116,13 @@ func TestPayloadBackfillCheckpointWindowStartsAtEachTransition(t *testing.T) {
 				ID: "checkpoint-window", Kind: "note", Body: compressibleBody("checkpoint-window"),
 			})
 
-			ds.checkpointTimeout = 5 * time.Millisecond
+			// The window has to outlast two SQLite writes on a loaded runner
+			// while the sleep still overruns it several times over. Shrinking
+			// both further would test the scheduler rather than the anchoring.
+			ds.checkpointTimeout = 150 * time.Millisecond
 			var once sync.Once
 			ds.onAfterCommitBatch = func(int64) {
-				once.Do(func() { time.Sleep(25 * time.Millisecond) })
+				once.Do(func() { time.Sleep(750 * time.Millisecond) })
 			}
 
 			result, err := ds.Run(context.Background(), apptypes.PayloadBackfillConfig{


### PR DESCRIPTION
Closes #1789

## What

Found by rehearsing the #1620 release gate against a 30 GB copy of the live store. `store payload-backfill run` is the compression lever the store-size row depends on, and it could not report completion on any real store.

`infrastructure/sqlite/payload_backfill.go` derived the checkpoint context **once, at `execute()` entry**, then ran every terminal transition on it — `completeBackfillRun`, `resetBackfillCursor`, `failBackfillRun`, and both `pauseBackfillRun` call sites. The window is 10 seconds. Any run longer than that consumed its own checkpoint budget doing the work the checkpoint exists to record.

The comment above it was right about why the checkpoint must outlive cancellation and why it must be bounded. Only the anchoring was wrong, and the anchoring was easy to get wrong because `abortRun` took the context as a parameter.

## Measured, before

30 GB rehearsal store, `--batch-rows 2048`, binary built from `50b953e9`:

```
Error: failed to execute CLI command: payload backfill run failed: run payload backfill:
       advance payload backfill run: context deadline exceeded
6:23.71 total
```

```
"state": "running",   "pass_count": 1,   "more_pending": true,
"high_water_rowid": 796522,   "cursor_rowid": 796522,
"scanned_rows": 1279931,   "rewritten_rows": 1279931,
"plaintext_bytes": 3340966020,   "stored_bytes": 1307244443
```

Cursor at the high-water mark, so this is `resetBackfillCursor` at the end of a dirty pass — the pass restart is what could not be recorded.

Note what did work: batches commit on the caller's context, so 1,279,931 fields were rewritten and 3.34 GB of plaintext became 1.31 GB stored. Only the bookkeeping was lost. The operator saw a non-zero exit, a run stuck at `running`, and no way to tell that from a genuine failure.

## Measured, after

Same store, same run row, binary built from this branch:

```
"state": "completed",   "pass_count": 2,   "more_pending": false,
"completed_at": "2026-08-10T17:47:08.950515Z",
"scanned_rows": 1962377,   "rewritten_rows": 1279931
```

Exit 0. The stranded run resumed, walked the second (clean) pass, and completed.

## The change

`checkpointContext()` derives the budget when a transition is taken rather than when the run starts, and `abortRun` derives its own instead of receiving one. The window is overridable through a `checkpointTimeout` field in the style of the existing `onSelectedBatch` / `onBeforeCommitBatch` / `onAfterCommitBatch` test seams — no flag, environment variable or config surface.

## Non-vacuity

Verified independently of the implementer, by restoring the shared context on the two paths the test covers:

```
--- FAIL: TestPayloadBackfillCheckpointWindowStartsAtEachTransition
    --- FAIL: .../completion_after_a_slow_committed_batch
        payload_backfill_test.go:1130: Run: advance payload backfill run: context deadline exceeded
    --- FAIL: .../pause_after_a_slow_committed_batch
        payload_backfill_test.go:1130: Run: advance payload backfill run: context deadline exceeded
```

Same error string as the 30 GB run. The test does not sleep ten seconds: it shrinks the window and sleeps past it inside a committed batch.

Every pre-existing checkpoint test cancels within milliseconds, which is why none of them ever reached the window.

## The other WithoutCancel sites

Checked, and none has this defect — each derives its context immediately before the work it bounds:

- `search_projection_rebuild.go:1356` / `:1438` — budgets are explicitly `measureTimeout() + evidenceWriteTimeout`, sized for the measure-and-write they wrap.
- `application/usecase/payload_rehearsal.go:99-176` — derived inside the loop, at the point of use.

`payload_rehearsal.go` did turn up something adjacent: the same `Pause` / `ReleaseScrub` call is bounded at 1s on three paths and completely unbounded on three others. That is a separate decision on a separate file — filed as #1791, deliberately not touched here.

## Verification

`go build ./...` ✅ / `go test ./... -count=1` ✅ / `go tool golangci-lint run` → 0 issues ✅ — run independently of the implementer.

No schema change, no new command, subcommand, flag or MCP tool.

## Review notes

Implementation delegated to gpt-5.6-luna; reviewed by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
