### PR TITLE
fix: adaptively split oversized projection batches

### DIFF
--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -52,8 +52,15 @@ type SearchProjectionBudget struct {
 func (b SearchProjectionBudget) Valid() bool {
 	return b.Rows > 0 && b.WallTime > 0 && b.LockTime > 0 && b.StoredBytes > 0 && b.DecodedBytes > 0 && b.WriteBytes > 0 && b.RecentAge > 0 && b.IndexFamilyBytes > 0
 }
+
+// ConfigHash contains only budgets that define generation contents. DecodedBytes
+// remains semantic because it decides which rows are rejected; RecentAge and
+// IndexFamilyBytes define retention. Rows, WallTime, LockTime, StoredBytes and
+// WriteBytes only bound one batch's working set, so they must stay out of the
+// generation identity: a batch that cannot fit its lock cap must be allowed to
+// resume with a smaller unit of work without discarding durable progress.
 func (b SearchProjectionBudget) ConfigHash() string {
-	return fmt.Sprintf("v2:%d:%d:%d:%d:%d:%d:%d:%d", b.Rows, b.WallTime.Nanoseconds(), b.LockTime.Nanoseconds(), b.StoredBytes, b.DecodedBytes, b.WriteBytes, b.RecentAge.Nanoseconds(), b.IndexFamilyBytes)
+	return fmt.Sprintf("v3:%d:%d:%d", b.DecodedBytes, b.RecentAge.Nanoseconds(), b.IndexFamilyBytes)
 }
 
 type SearchProjectionGeneration struct {
@@ -225,7 +232,17 @@ func (e *SearchProjectionOversizeError) Error() string {
 	return fmt.Sprintf("search projection %s exceeds batch budget (%d > %d)", e.Class, e.Bytes, e.Limit)
 }
 
-type SearchProjectionNoProgressError struct{ Reason string }
+type SearchProjectionNoProgressCode string
+
+const (
+	SearchProjectionNoProgressLockDurationCap          SearchProjectionNoProgressCode = "lock_duration_cap_exceeded"
+	SearchProjectionNoProgressSingleRowLockDurationCap SearchProjectionNoProgressCode = "single_row_lock_duration_cap_exceeded"
+)
+
+type SearchProjectionNoProgressError struct {
+	Code   SearchProjectionNoProgressCode
+	Reason string
+}
 
 func (e *SearchProjectionNoProgressError) Error() string {
 	return "search projection made no progress: " + e.Reason

--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -53,12 +53,21 @@ func (b SearchProjectionBudget) Valid() bool {
 	return b.Rows > 0 && b.WallTime > 0 && b.LockTime > 0 && b.StoredBytes > 0 && b.DecodedBytes > 0 && b.WriteBytes > 0 && b.RecentAge > 0 && b.IndexFamilyBytes > 0
 }
 
-// ConfigHash contains only budgets that define generation contents. DecodedBytes
-// remains semantic because it decides which rows are rejected; RecentAge and
-// IndexFamilyBytes define retention. Rows, WallTime, LockTime, StoredBytes and
-// WriteBytes only bound one batch's working set, so they must stay out of the
-// generation identity: a batch that cannot fit its lock cap must be allowed to
-// resume with a smaller unit of work without discarding durable progress.
+// ConfigHash contains only budgets that define generation contents. RecentAge
+// and IndexFamilyBytes decide what the generation retains, so resuming with a
+// different value would leave an index that no single budget describes.
+//
+// Rows, WallTime, LockTime, StoredBytes and WriteBytes only bound one batch's
+// working set, so they stay out of the generation identity: a batch that cannot
+// fit its lock cap must be allowed to resume with a smaller unit of work rather
+// than discard durable progress. StoredBytes and WriteBytes can reject an
+// oversized row, but rejection fails the generation outright — it never quietly
+// admits a different set of rows — so they change no content either.
+//
+// DecodedBytes is held in by choice, not by that argument. It rejects rows the
+// same way, and #1794 decides what an over-budget row should do instead; until
+// that lands, keeping it here means a widened budget starts a new generation
+// rather than silently changing the meaning of a partial one.
 func (b SearchProjectionBudget) ConfigHash() string {
 	return fmt.Sprintf("v3:%d:%d:%d", b.DecodedBytes, b.RecentAge.Nanoseconds(), b.IndexFamilyBytes)
 }

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -181,6 +181,37 @@ func (s *adaptiveProjectionStore) checkpoint() int64 {
 	return s.checkpoints[len(s.checkpoints)-1]
 }
 
+type adaptiveInventoryProjectionStore struct {
+	adaptiveProjectionStore
+	cursor               int
+	plannedInventoryRows []int
+}
+
+func (s *adaptiveInventoryProjectionStore) SearchProjectionStatus(context.Context) (apptypes.SearchProjectionStatus, error) {
+	return apptypes.SearchProjectionStatus{State: "rebuilding", Phase: "inventory", ConfigHash: s.budget.ConfigHash()}, nil
+}
+
+func (s *adaptiveInventoryProjectionStore) SelectInventory(_ context.Context, b apptypes.SearchProjectionBudget) (apptypes.SearchProjectionInventorySnapshot, error) {
+	s.plannedInventoryRows = append(s.plannedInventoryRows, b.Rows)
+	items := make([]apptypes.SearchProjectionInventoryItem, 0, b.Rows)
+	for id := s.cursor + 1; id <= 3 && len(items) < b.Rows; id++ {
+		items = append(items, apptypes.SearchProjectionInventoryItem{EventID: fmt.Sprintf("e%d", id), LogicalBytes: 1, Missing: true})
+	}
+	return apptypes.SearchProjectionInventorySnapshot{
+		Generation: apptypes.SearchProjectionGeneration{GenerationID: "g", ConfigHash: s.budget.ConfigHash(), SourceRevision: 1},
+		Cursor:     fmt.Sprintf("e%d", s.cursor), CursorStarted: s.cursor > 0,
+		Items: items, Done: s.cursor+len(items) == 3,
+	}, nil
+}
+
+func (s *adaptiveInventoryProjectionStore) ApplyInventoryBatch(_ context.Context, p apptypes.SearchProjectionInventoryPlan, _ time.Duration, _ time.Time) (apptypes.SearchProjectionProgress, error) {
+	if p.Ledger.Rows > s.maxRows {
+		return apptypes.SearchProjectionProgress{}, &apptypes.SearchProjectionNoProgressError{Code: apptypes.SearchProjectionNoProgressLockDurationCap, Reason: "inventory lock duration cap exceeded"}
+	}
+	s.cursor += p.Ledger.Rows
+	return apptypes.SearchProjectionProgress{Selected: p.Ledger.Rows, Written: p.Ledger.Rows, Completed: p.Done, GenerationID: p.GenerationID}, nil
+}
+
 func TestSearchProjectionConfigHashSeparatesSemanticAndThroughputBudgets(t *testing.T) {
 	t.Parallel()
 	base := apptypes.SearchProjectionBudget{Rows: 4, WallTime: time.Second, LockTime: time.Second, StoredBytes: 100, DecodedBytes: 200, WriteBytes: 300, RecentAge: time.Hour, IndexFamilyBytes: 400}
@@ -225,6 +256,22 @@ func TestSearchProjectionResumeUntilShrinksOnlyTheFailedBatch(t *testing.T) {
 	}
 	if diff := cmp.Diff([]int64{2, 3}, store.checkpoints); diff != "" {
 		t.Fatalf("checkpoints (-want +got):\n%s", diff)
+	}
+}
+
+func TestSearchProjectionResumeUntilShrinksInventoryBatch(t *testing.T) {
+	t.Parallel()
+	b := apptypes.SearchProjectionBudget{Rows: 4, WallTime: time.Second, LockTime: time.Second, StoredBytes: 100, DecodedBytes: 100, WriteBytes: 1000, RecentAge: time.Hour, IndexFamilyBytes: 100}
+	store := &adaptiveInventoryProjectionStore{adaptiveProjectionStore: adaptiveProjectionStore{budget: b, maxRows: 2}}
+	result, err := usecase.NewSearchProjectionUsecase(store).ResumeUntil(context.Background(), b, apptypes.SearchProjectionRunOptions{MaxBatches: 2, TotalWallTime: time.Minute}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(2, result.Batches); diff != "" {
+		t.Fatalf("successful batches (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]int{4, 2, 4}, store.plannedInventoryRows); diff != "" {
+		t.Fatalf("planned inventory rows (-want +got):\n%s", diff)
 	}
 }
 

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 )
@@ -135,6 +137,112 @@ type multiBatchProjectionStore struct {
 	budget     apptypes.SearchProjectionBudget
 	checkpoint int64
 	batches    int
+}
+
+type adaptiveProjectionStore struct {
+	budget       apptypes.SearchProjectionBudget
+	maxRows      int
+	checkpoints  []int64
+	plannedRows  []int
+	alwaysTooBig bool
+}
+
+func (s *adaptiveProjectionStore) Start(context.Context, apptypes.SearchProjectionBudget, time.Time) (apptypes.SearchProjectionGeneration, error) {
+	return apptypes.SearchProjectionGeneration{}, nil
+}
+func (s *adaptiveProjectionStore) SearchProjectionStatus(context.Context) (apptypes.SearchProjectionStatus, error) {
+	return apptypes.SearchProjectionStatus{State: "rebuilding", Phase: "source", ConfigHash: s.budget.ConfigHash()}, nil
+}
+func (s *adaptiveProjectionStore) SelectSnapshot(_ context.Context, b apptypes.SearchProjectionBudget, _ time.Time) (apptypes.ProjectionSnapshot, error) {
+	s.plannedRows = append(s.plannedRows, b.Rows)
+	documents := make([]apptypes.ProjectionDocument, 0, b.Rows)
+	for sequence := s.checkpoint() + 1; sequence <= 3 && len(documents) < b.Rows; sequence++ {
+		documents = append(documents, apptypes.ProjectionDocument{Sequence: sequence, EventID: fmt.Sprintf("e%d", sequence), SessionID: "s", CreatedAt: "2026-08-10T00:00:00Z", Text: "body", StoredBytes: 4, DecodedBytes: 4})
+	}
+	return apptypes.ProjectionSnapshot{Generation: apptypes.SearchProjectionGeneration{GenerationID: "g", ConfigHash: s.budget.ConfigHash(), SourceRevision: 1, HighWater: 3, Checkpoint: s.checkpoint()}, Phase: "source", Documents: documents, SourceDone: len(documents) > 0 && documents[len(documents)-1].Sequence == 3, Now: time.Now().UTC()}, nil
+}
+func (s *adaptiveProjectionStore) ApplyBatch(_ context.Context, p apptypes.ProjectionBatchPlan, _ time.Duration, _ time.Time) (apptypes.SearchProjectionProgress, error) {
+	if len(p.Writes) > s.maxRows || s.alwaysTooBig {
+		return apptypes.SearchProjectionProgress{}, &apptypes.SearchProjectionNoProgressError{Code: apptypes.SearchProjectionNoProgressLockDurationCap, Reason: "projection lock duration cap exceeded"}
+	}
+	s.checkpoints = append(s.checkpoints, p.NextCheckpoint)
+	return apptypes.SearchProjectionProgress{Selected: len(p.Writes), Written: len(p.Writes), GenerationID: "g"}, nil
+}
+func (s *adaptiveProjectionStore) CleanupBatch(context.Context, apptypes.ProjectionBatchPlan, time.Duration, time.Time) (apptypes.SearchProjectionProgress, error) {
+	return apptypes.SearchProjectionProgress{}, nil
+}
+func (s *adaptiveProjectionStore) MarkFailed(context.Context, string, int64, string, time.Time) error {
+	return nil
+}
+func (s *adaptiveProjectionStore) checkpoint() int64 {
+	if len(s.checkpoints) == 0 {
+		return 0
+	}
+	return s.checkpoints[len(s.checkpoints)-1]
+}
+
+func TestSearchProjectionConfigHashSeparatesSemanticAndThroughputBudgets(t *testing.T) {
+	t.Parallel()
+	base := apptypes.SearchProjectionBudget{Rows: 4, WallTime: time.Second, LockTime: time.Second, StoredBytes: 100, DecodedBytes: 200, WriteBytes: 300, RecentAge: time.Hour, IndexFamilyBytes: 400}
+	tests := []struct {
+		name   string
+		mutate func(*apptypes.SearchProjectionBudget)
+		match  bool
+	}{
+		{name: "rows", mutate: func(b *apptypes.SearchProjectionBudget) { b.Rows = 1 }, match: true},
+		{name: "lock time", mutate: func(b *apptypes.SearchProjectionBudget) { b.LockTime = 2 * time.Second }, match: true},
+		{name: "wall time", mutate: func(b *apptypes.SearchProjectionBudget) { b.WallTime = 2 * time.Second }, match: true},
+		{name: "stored bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.StoredBytes = 101 }, match: true},
+		{name: "write bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.WriteBytes = 301 }, match: true},
+		{name: "recent age", mutate: func(b *apptypes.SearchProjectionBudget) { b.RecentAge = 2 * time.Hour }, match: false},
+		{name: "index family bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.IndexFamilyBytes = 401 }, match: false},
+		{name: "decoded bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.DecodedBytes = 201 }, match: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := base
+			tt.mutate(&got)
+			if diff := cmp.Diff(tt.match, base.ConfigHash() == got.ConfigHash()); diff != "" {
+				t.Fatalf("hash match (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSearchProjectionResumeUntilShrinksOnlyTheFailedBatch(t *testing.T) {
+	t.Parallel()
+	b := apptypes.SearchProjectionBudget{Rows: 4, WallTime: time.Second, LockTime: time.Second, StoredBytes: 100, DecodedBytes: 100, WriteBytes: 1000, RecentAge: time.Hour, IndexFamilyBytes: 100}
+	store := &adaptiveProjectionStore{budget: b, maxRows: 2}
+	result, err := usecase.NewSearchProjectionUsecase(store).ResumeUntil(context.Background(), b, apptypes.SearchProjectionRunOptions{MaxBatches: 2, TotalWallTime: time.Minute}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(2, result.Batches); diff != "" {
+		t.Fatalf("successful batches (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]int{4, 2, 4}, store.plannedRows); diff != "" {
+		t.Fatalf("planned rows (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]int64{2, 3}, store.checkpoints); diff != "" {
+		t.Fatalf("checkpoints (-want +got):\n%s", diff)
+	}
+}
+
+func TestSearchProjectionResumeUntilReportsSingleRowLockCap(t *testing.T) {
+	t.Parallel()
+	b := apptypes.SearchProjectionBudget{Rows: 4, WallTime: time.Second, LockTime: time.Second, StoredBytes: 100, DecodedBytes: 100, WriteBytes: 1000, RecentAge: time.Hour, IndexFamilyBytes: 100}
+	store := &adaptiveProjectionStore{budget: b, maxRows: 0, alwaysTooBig: true}
+	_, err := usecase.NewSearchProjectionUsecase(store).ResumeUntil(context.Background(), b, apptypes.SearchProjectionRunOptions{MaxBatches: 1, TotalWallTime: time.Minute}, time.Now())
+	var noProgress *apptypes.SearchProjectionNoProgressError
+	if !errors.As(err, &noProgress) {
+		t.Fatalf("error=%v, want no-progress error", err)
+	}
+	if diff := cmp.Diff(apptypes.SearchProjectionNoProgressSingleRowLockDurationCap, noProgress.Code); diff != "" {
+		t.Fatalf("error code (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]int{4, 2, 1}, store.plannedRows); diff != "" {
+		t.Fatalf("planned rows (-want +got):\n%s", diff)
+	}
 }
 
 func (s *multiBatchProjectionStore) Start(context.Context, apptypes.SearchProjectionBudget, time.Time) (apptypes.SearchProjectionGeneration, error) {

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -157,8 +157,26 @@ func (u *SearchProjectionUsecase) ResumeUntil(ctx context.Context, b apptypes.Se
 			result.ElapsedMilliseconds = time.Since(started).Milliseconds()
 			return result, nil
 		}
-		progress, err := u.Resume(runCtx, b, now.UTC())
-		if err != nil {
+		batchBudget := b
+		for {
+			progress, err := u.Resume(runCtx, batchBudget, now.UTC())
+			if err == nil {
+				result.Batches++
+				result.Progress.Selected += progress.Selected
+				result.Progress.Written += progress.Written
+				result.Progress.Evicted += progress.Evicted
+				result.Progress.Cleaned += progress.Cleaned
+				result.Progress.StoredBytes += progress.StoredBytes
+				result.Progress.DecodedBytes += progress.DecodedBytes
+				result.Progress.WrittenBytes += progress.WrittenBytes
+				result.Progress.CleanupBytes += progress.CleanupBytes
+				result.Progress.Completed = progress.Completed
+				result.Progress.GenerationID = progress.GenerationID
+				if progress.Completed {
+					result.StopReason = "complete"
+				}
+				break
+			}
 			if ctx.Err() != nil {
 				return result, xerrors.Errorf("resume projection batches: %w", ctx.Err())
 			}
@@ -167,21 +185,19 @@ func (u *SearchProjectionUsecase) ResumeUntil(ctx context.Context, b apptypes.Se
 				result.ElapsedMilliseconds = time.Since(started).Milliseconds()
 				return result, nil
 			}
-			return result, err
+			var noProgress *apptypes.SearchProjectionNoProgressError
+			if !errors.As(err, &noProgress) || noProgress.Code != apptypes.SearchProjectionNoProgressLockDurationCap {
+				return result, err
+			}
+			if batchBudget.Rows <= 1 {
+				return result, &apptypes.SearchProjectionNoProgressError{
+					Code:   apptypes.SearchProjectionNoProgressSingleRowLockDurationCap,
+					Reason: "a single row exceeded the projection lock duration cap at the minimum batch size",
+				}
+			}
+			batchBudget.Rows /= 2
 		}
-		result.Batches++
-		result.Progress.Selected += progress.Selected
-		result.Progress.Written += progress.Written
-		result.Progress.Evicted += progress.Evicted
-		result.Progress.Cleaned += progress.Cleaned
-		result.Progress.StoredBytes += progress.StoredBytes
-		result.Progress.DecodedBytes += progress.DecodedBytes
-		result.Progress.WrittenBytes += progress.WrittenBytes
-		result.Progress.CleanupBytes += progress.CleanupBytes
-		result.Progress.Completed = progress.Completed
-		result.Progress.GenerationID = progress.GenerationID
-		if progress.Completed {
-			result.StopReason = "complete"
+		if result.StopReason == "complete" {
 			break
 		}
 	}

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -733,7 +733,7 @@ func (d *Database) applyProjectionPlanWithRetry(ctx context.Context, p apptypes.
 			remaining = time.Until(deadline)
 		}
 		if remaining <= 0 {
-			return apptypes.SearchProjectionProgress{}, &apptypes.SearchProjectionNoProgressError{Reason: "projection lock duration cap exceeded"}
+			return apptypes.SearchProjectionProgress{}, &apptypes.SearchProjectionNoProgressError{Code: apptypes.SearchProjectionNoProgressLockDurationCap, Reason: "projection lock duration cap exceeded"}
 		}
 		out, err := d.applyProjectionPlan(lockCtx, p, remaining, now)
 		classified, retry, classifiedErr := classifySearchProjectionApplyResult(out, err)
@@ -742,7 +742,7 @@ func (d *Database) applyProjectionPlanWithRetry(ctx context.Context, p apptypes.
 		}
 		select {
 		case <-lockCtx.Done():
-			return apptypes.SearchProjectionProgress{}, &apptypes.SearchProjectionNoProgressError{Reason: "projection lock duration cap exceeded"}
+			return apptypes.SearchProjectionProgress{}, &apptypes.SearchProjectionNoProgressError{Code: apptypes.SearchProjectionNoProgressLockDurationCap, Reason: "projection lock duration cap exceeded"}
 		case <-time.After(min(5*time.Millisecond, remaining)):
 		}
 	}
@@ -755,7 +755,7 @@ func isSearchProjectionSQLiteBusy(err error) bool {
 
 func classifySearchProjectionApplyResult(out apptypes.SearchProjectionProgress, err error) (apptypes.SearchProjectionProgress, bool, error) {
 	if isSearchProjectionDeadline(err) {
-		return apptypes.SearchProjectionProgress{}, false, &apptypes.SearchProjectionNoProgressError{Reason: "projection lock duration cap exceeded"}
+		return apptypes.SearchProjectionProgress{}, false, &apptypes.SearchProjectionNoProgressError{Code: apptypes.SearchProjectionNoProgressLockDurationCap, Reason: "projection lock duration cap exceeded"}
 	}
 	if err == nil {
 		return out, false, nil

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -361,15 +361,16 @@ func (d *Database) ApplyInventoryBatch(ctx context.Context, p apptypes.SearchPro
 			remaining = time.Until(deadline)
 		}
 		if remaining <= 0 {
-			return out, &apptypes.SearchProjectionNoProgressError{Reason: "inventory lock duration cap exceeded"}
+			return out, &apptypes.SearchProjectionNoProgressError{Code: apptypes.SearchProjectionNoProgressLockDurationCap, Reason: "inventory lock duration cap exceeded"}
 		}
 		out, err = d.applyInventoryBatchOnce(lockCtx, p, remaining, now)
-		if err == nil || !isSearchProjectionSQLiteBusy(err) {
-			return out, err
+		classified, retry, classifiedErr := classifySearchProjectionApplyResult(out, err)
+		if classifiedErr != nil || !retry {
+			return classified, classifiedErr
 		}
 		select {
 		case <-lockCtx.Done():
-			return out, &apptypes.SearchProjectionNoProgressError{Reason: "inventory lock duration cap exceeded"}
+			return out, &apptypes.SearchProjectionNoProgressError{Code: apptypes.SearchProjectionNoProgressLockDurationCap, Reason: "inventory lock duration cap exceeded"}
 		case <-time.After(min(5*time.Millisecond, remaining)):
 		}
 	}

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -293,6 +293,52 @@ func resumeProjection(ctx context.Context, store *Database, budget apptypes.Sear
 	return usecase.NewSearchProjectionUsecase(store).Resume(ctx, budget, now)
 }
 
+func TestSearchProjectionApplyPathsTagLockDurationCap(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(*Database) error
+	}{
+		{
+			name: "inventory batch",
+			apply: func(store *Database) error {
+				_, err := store.ApplyInventoryBatch(context.Background(), apptypes.SearchProjectionInventoryPlan{}, 0, time.Now())
+				return err
+			},
+		},
+		{
+			name: "projection batch",
+			apply: func(store *Database) error {
+				_, err := store.ApplyBatch(context.Background(), apptypes.ProjectionBatchPlan{Phase: "source"}, 0, time.Now())
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			path := filepath.Join(t.TempDir(), "store.db")
+			migrations, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+			if err != nil {
+				t.Fatal(err)
+			}
+			store := NewDatabase(path, migrations)
+			if err := store.initialize(ctx); err != nil {
+				t.Fatal(err)
+			}
+
+			err = tt.apply(store)
+			var noProgress *apptypes.SearchProjectionNoProgressError
+			if !errors.As(err, &noProgress) {
+				t.Fatalf("error=%T %v, want SearchProjectionNoProgressError", err, err)
+			}
+			if diff := cmp.Diff(apptypes.SearchProjectionNoProgressLockDurationCap, noProgress.Code); diff != "" {
+				t.Errorf("no-progress code mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestBundledSQLiteContentlessDeleteSemantics(t *testing.T) {
 	t.Parallel()
 	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "probe.db"))

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -462,7 +462,7 @@ func TestSearchProjectionAbandonIsIdempotentAndRestartKeepsCanonicalHistory(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if second.GenerationID == first.GenerationID || second.ConfigHash == first.ConfigHash {
+	if second.GenerationID == first.GenerationID {
 		t.Fatalf("restart did not create immutable generation: %+v %+v", first, second)
 	}
 }


### PR DESCRIPTION
Closes #1793.

The projection stalled permanently on a real store because a batch that did not fit the write-lock cap had no smaller unit of work to fall back to, and the obvious workaround was refused.

## What was wrong

`applyProjectionPlanWithRetry` retries only SQLite busy/snapshot conflicts. A batch that exceeds the lock deadline returns `SearchProjectionNoProgressError` and `ResumeUntil` propagates it and stops — the same batch, at the same size, forever.

The operator cannot resume with a smaller `--rows`, because `ConfigHash` folded every budget field into the generation identity, so any change to the batch size is read as a different generation and discards all durable progress.

## What changed

**The generation hash now covers only budgets that define generation contents** (`v3:<decodedBytes>:<recentAge>:<indexFamilyBytes>`). `Rows`, `WallTime`, `LockTime`, `StoredBytes` and `WriteBytes` bound one batch's working set and cannot change the resulting index — `StoredBytes` and `WriteBytes` can reject an oversized row, but rejection fails the generation outright rather than quietly admitting a different set of rows. `DecodedBytes` is held in by choice, not by that argument: #1794 decides what an over-budget row should do, and until then a widened budget should start a new generation rather than silently change the meaning of a partial one.

**A batch that exceeds the lock cap now halves and retries**, down to a floor of one row, and the next batch is planned at the caller's original size again — one fat row must not permanently shrink the walk. A single row that still does not fit terminates with a distinct code (`single_row_lock_duration_cap_exceeded`) so it is not confused with "the batch was merely too big". `SearchProjectionNoProgressError` gained a typed `Code` for this; comparing free-text reasons across the layer boundary would have been fragile.

**The inventory phase shrinks too.** Its lock-cap error was untagged, so it kept the stall this PR removes — and it is the first phase every existing store enters on upgrade, over its whole history, at the same default cap. Its raw-deadline path now goes through the same classifier as the source path rather than returning a bare driver error. Found by gpt-5.6-sol in review.

Identifying *which* row is out of scope here — that is #1794.

## Verified on the store that reproduced it

The rehearsal copy of the live store (408,970 rows, 7.16 GB), at the **default** `--lock-time 250ms` that previously stalled the walk permanently:

```
{"batches":10,"progress":{"selected":896,"written":896,...},"stop_reason":"max_batches"}
```

896 rows over 10 batches — below the 128-per-batch default, so the shrink engaged — and the checkpoint advanced 1792 → 2688 with `rc=0`. Before this change the same store returned `projection lock duration cap exceeded` on every invocation and never moved.

`--wall-time` had to be raised to 20s to run that at all, for a reason unrelated to this PR: opening a store this size costs 10-18 s and the 1 s default wall budget covers the open. Filed as **#1798**, which also means an end-to-end default-budget build cannot be demonstrated until that is fixed.

## Tests

Injectable rather than timing-dependent — a test that depends on how long a real SQLite write takes on a loaded runner is a flake, not a test.

- `TestSearchProjectionBudgetConfigHash` — table-driven over every budget field, asserting which ones change the generation identity and which do not.
- `TestSearchProjectionResumeUntilShrinksOnlyTheFailedBatch` — asserts the planned row sizes are `[4, 2, 4]`: the failed batch halves, the next one is back at full size.
- `TestSearchProjectionResumeUntilReportsSingleRowLockCap` — `[4, 2, 1]` then the distinct terminal code, rather than looping.
- `TestSearchProjectionResumeUntilShrinksInventoryBatch` — the same `[4, 2, 4]` for the inventory phase.
- `TestSearchProjectionApplyPathsTagLockDurationCap` — at the sqlite layer, because the usecase tests fake the store and so assert nothing about what it returns; that is how the missing inventory tag survived the first round.

`go build` / `go vet` / `go tool golangci-lint run` clean, `go test ./...` green.

Implementation by gpt-5.6-luna; review, the comment correction in `0ba5b68d`, and the store verification by Claude Opus 5.
