### PR TITLE
fix: keep whole-family measurement off the projection control path

### DIFF
--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -328,6 +328,22 @@ type SearchProjectionStatus struct {
 	CutoverAfterEvidence  CapacityEvidence `json:"cutover_after_evidence"`
 }
 
+// SearchProjectionControlStatus contains only persisted state-machine data.
+// It deliberately excludes derived measurements so lifecycle operations cannot
+// accidentally put whole-family scans on their control path.
+type SearchProjectionControlStatus struct {
+	State                    string
+	Phase                    string
+	ConfigHash               string
+	CapacitySemanticsVersion int
+	FailureClass             string
+	CutoverIndexFamily       string
+	CutoverFamilyBytesBefore int64
+	CutoverFamilyBytesAfter  int64
+	CutoverBeforeEvidence    CapacityEvidence
+	CutoverAfterEvidence     CapacityEvidence
+}
+
 // SearchProjectionCatchUpResult is one bounded unit of automatic generation
 // work performed during store initialization. It mirrors the event-search
 // backfill shape: a single open does a bounded amount of work and resumes

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -10,16 +10,21 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 )
 
 type wallBudgetStore struct {
-	budget      apptypes.SearchProjectionBudget
-	applied     bool
-	delayStatus bool
-	selected    bool
+	budget             apptypes.SearchProjectionBudget
+	applied            bool
+	delayStatus        bool
+	delayControlStatus bool
+	selected           bool
+	controlReads       int
+	measuredReads      int
+	state              string
 }
 
 func (s *wallBudgetStore) Start(context.Context, apptypes.SearchProjectionBudget, time.Time) (apptypes.SearchProjectionGeneration, error) {
@@ -28,11 +33,25 @@ func (s *wallBudgetStore) Start(context.Context, apptypes.SearchProjectionBudget
 
 //nolint:wrapcheck // Test fake preserves context cancellation identity.
 func (s *wallBudgetStore) SearchProjectionStatus(ctx context.Context) (apptypes.SearchProjectionStatus, error) {
+	s.measuredReads++
 	if s.delayStatus {
 		<-ctx.Done()
 		return apptypes.SearchProjectionStatus{}, ctx.Err()
 	}
 	return apptypes.SearchProjectionStatus{State: "rebuilding", ConfigHash: s.budget.ConfigHash()}, nil
+}
+
+func (s *wallBudgetStore) SearchProjectionControlStatus(ctx context.Context) (apptypes.SearchProjectionControlStatus, error) {
+	s.controlReads++
+	if s.delayControlStatus {
+		<-ctx.Done()
+		return apptypes.SearchProjectionControlStatus{}, xerrors.Errorf("control status: %w", ctx.Err())
+	}
+	state := s.state
+	if state == "" {
+		state = "rebuilding"
+	}
+	return apptypes.SearchProjectionControlStatus{State: state, ConfigHash: s.budget.ConfigHash()}, nil
 }
 
 //nolint:wrapcheck // Test fake preserves context cancellation identity.
@@ -78,7 +97,7 @@ func TestProjectionBatchPlanEnforcesStrictLogicalMutationByteCap(t *testing.T) {
 func TestResumeStatusConsumesSameWallBudgetAndPreventsSelectionOrMutation(t *testing.T) {
 	t.Parallel()
 	b := apptypes.SearchProjectionBudget{Rows: 1, WallTime: time.Millisecond, LockTime: time.Second, StoredBytes: 1, DecodedBytes: 1, WriteBytes: 1, RecentAge: time.Hour, IndexFamilyBytes: 1}
-	store := &wallBudgetStore{budget: b, delayStatus: true}
+	store := &wallBudgetStore{budget: b, delayControlStatus: true}
 	_, err := usecase.NewSearchProjectionUsecase(store).Resume(context.Background(), b, time.Now())
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("error=%v", err)
@@ -153,6 +172,9 @@ func (s *adaptiveProjectionStore) Start(context.Context, apptypes.SearchProjecti
 func (s *adaptiveProjectionStore) SearchProjectionStatus(context.Context) (apptypes.SearchProjectionStatus, error) {
 	return apptypes.SearchProjectionStatus{State: "rebuilding", Phase: "source", ConfigHash: s.budget.ConfigHash()}, nil
 }
+func (s *adaptiveProjectionStore) SearchProjectionControlStatus(context.Context) (apptypes.SearchProjectionControlStatus, error) {
+	return apptypes.SearchProjectionControlStatus{State: "rebuilding", Phase: "source", ConfigHash: s.budget.ConfigHash()}, nil
+}
 func (s *adaptiveProjectionStore) SelectSnapshot(_ context.Context, b apptypes.SearchProjectionBudget, _ time.Time) (apptypes.ProjectionSnapshot, error) {
 	s.plannedRows = append(s.plannedRows, b.Rows)
 	documents := make([]apptypes.ProjectionDocument, 0, b.Rows)
@@ -189,6 +211,9 @@ type adaptiveInventoryProjectionStore struct {
 
 func (s *adaptiveInventoryProjectionStore) SearchProjectionStatus(context.Context) (apptypes.SearchProjectionStatus, error) {
 	return apptypes.SearchProjectionStatus{State: "rebuilding", Phase: "inventory", ConfigHash: s.budget.ConfigHash()}, nil
+}
+func (s *adaptiveInventoryProjectionStore) SearchProjectionControlStatus(context.Context) (apptypes.SearchProjectionControlStatus, error) {
+	return apptypes.SearchProjectionControlStatus{State: "rebuilding", Phase: "inventory", ConfigHash: s.budget.ConfigHash()}, nil
 }
 
 func (s *adaptiveInventoryProjectionStore) SelectInventory(_ context.Context, b apptypes.SearchProjectionBudget) (apptypes.SearchProjectionInventorySnapshot, error) {
@@ -297,6 +322,9 @@ func (s *multiBatchProjectionStore) Start(context.Context, apptypes.SearchProjec
 }
 func (s *multiBatchProjectionStore) SearchProjectionStatus(context.Context) (apptypes.SearchProjectionStatus, error) {
 	return apptypes.SearchProjectionStatus{State: "rebuilding", Phase: "source", ConfigHash: s.budget.ConfigHash()}, nil
+}
+func (s *multiBatchProjectionStore) SearchProjectionControlStatus(context.Context) (apptypes.SearchProjectionControlStatus, error) {
+	return apptypes.SearchProjectionControlStatus{State: "rebuilding", Phase: "source", ConfigHash: s.budget.ConfigHash()}, nil
 }
 func (s *multiBatchProjectionStore) SelectSnapshot(context.Context, apptypes.SearchProjectionBudget, time.Time) (apptypes.ProjectionSnapshot, error) {
 	next := s.checkpoint + 1

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -25,6 +25,7 @@ type wallBudgetStore struct {
 	controlReads       int
 	measuredReads      int
 	state              string
+	resumeReady        bool
 }
 
 func (s *wallBudgetStore) Start(context.Context, apptypes.SearchProjectionBudget, time.Time) (apptypes.SearchProjectionGeneration, error) {
@@ -51,12 +52,15 @@ func (s *wallBudgetStore) SearchProjectionControlStatus(ctx context.Context) (ap
 	if state == "" {
 		state = "rebuilding"
 	}
-	return apptypes.SearchProjectionControlStatus{State: state, ConfigHash: s.budget.ConfigHash()}, nil
+	return apptypes.SearchProjectionControlStatus{State: state, ConfigHash: s.budget.ConfigHash(), CapacitySemanticsVersion: apptypes.SearchProjectionCapacitySemanticsVersion}, nil
 }
 
 //nolint:wrapcheck // Test fake preserves context cancellation identity.
 func (s *wallBudgetStore) SelectSnapshot(ctx context.Context, _ apptypes.SearchProjectionBudget, _ time.Time) (apptypes.ProjectionSnapshot, error) {
 	s.selected = true
+	if s.resumeReady {
+		return apptypes.ProjectionSnapshot{Generation: apptypes.SearchProjectionGeneration{GenerationID: "generation"}, Phase: "source", Now: time.Now()}, nil
+	}
 	<-ctx.Done()
 	return apptypes.ProjectionSnapshot{}, ctx.Err()
 }

--- a/application/usecase/search_projection_status_routing_test.go
+++ b/application/usecase/search_projection_status_routing_test.go
@@ -1,0 +1,63 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+)
+
+func TestSearchProjectionStatusRoutingKeepsMeasurementsOffControlPaths(t *testing.T) {
+	t.Parallel()
+	budget := apptypes.SearchProjectionBudget{
+		Rows: 1, WallTime: time.Second, LockTime: time.Second, StoredBytes: 1,
+		DecodedBytes: 1, WriteBytes: 1, RecentAge: time.Hour, IndexFamilyBytes: 1,
+	}
+	tests := []struct {
+		name              string
+		run               func(*usecase.SearchProjectionUsecase, apptypes.SearchProjectionBudget) error
+		wantControlReads  int
+		wantMeasuredReads int
+	}{
+		{
+			name: "start uses control status",
+			run: func(u *usecase.SearchProjectionUsecase, b apptypes.SearchProjectionBudget) error {
+				_, err := u.StartGeneration(context.Background(), b, time.Now())
+				if err != nil {
+					return xerrors.Errorf("start generation: %w", err)
+				}
+				return nil
+			},
+			wantControlReads: 1,
+		},
+		{
+			name: "inspect uses measured status",
+			run: func(u *usecase.SearchProjectionUsecase, _ apptypes.SearchProjectionBudget) error {
+				_, err := u.Inspect(context.Background())
+				if err != nil {
+					return xerrors.Errorf("inspect projection: %w", err)
+				}
+				return nil
+			},
+			wantMeasuredReads: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &wallBudgetStore{budget: budget, state: "idle"}
+			if err := tt.run(usecase.NewSearchProjectionUsecase(store), budget); err != nil {
+				t.Fatal(err)
+			}
+			got := [2]int{store.controlReads, store.measuredReads}
+			want := [2]int{tt.wantControlReads, tt.wantMeasuredReads}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("status reads (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/application/usecase/search_projection_status_routing_test.go
+++ b/application/usecase/search_projection_status_routing_test.go
@@ -16,16 +16,19 @@ func TestSearchProjectionStatusRoutingKeepsMeasurementsOffControlPaths(t *testin
 	t.Parallel()
 	budget := apptypes.SearchProjectionBudget{
 		Rows: 1, WallTime: time.Second, LockTime: time.Second, StoredBytes: 1,
-		DecodedBytes: 1, WriteBytes: 1, RecentAge: time.Hour, IndexFamilyBytes: 1,
+		DecodedBytes: 1, WriteBytes: 1000, RecentAge: time.Hour, IndexFamilyBytes: 1,
 	}
 	tests := []struct {
 		name              string
 		run               func(*usecase.SearchProjectionUsecase, apptypes.SearchProjectionBudget) error
+		state             string
+		resumeReady       bool
 		wantControlReads  int
 		wantMeasuredReads int
 	}{
 		{
-			name: "start uses control status",
+			name:  "start uses control status",
+			state: "idle",
 			run: func(u *usecase.SearchProjectionUsecase, b apptypes.SearchProjectionBudget) error {
 				_, err := u.StartGeneration(context.Background(), b, time.Now())
 				if err != nil {
@@ -36,7 +39,8 @@ func TestSearchProjectionStatusRoutingKeepsMeasurementsOffControlPaths(t *testin
 			wantControlReads: 1,
 		},
 		{
-			name: "inspect uses measured status",
+			name:  "inspect uses measured status",
+			state: "idle",
 			run: func(u *usecase.SearchProjectionUsecase, _ apptypes.SearchProjectionBudget) error {
 				_, err := u.Inspect(context.Background())
 				if err != nil {
@@ -46,10 +50,36 @@ func TestSearchProjectionStatusRoutingKeepsMeasurementsOffControlPaths(t *testin
 			},
 			wantMeasuredReads: 1,
 		},
+		{
+			name:        "resume uses control status",
+			state:       "rebuilding",
+			resumeReady: true,
+			run: func(u *usecase.SearchProjectionUsecase, b apptypes.SearchProjectionBudget) error {
+				_, err := u.Resume(context.Background(), b, time.Now())
+				if err != nil {
+					return xerrors.Errorf("resume projection: %w", err)
+				}
+				return nil
+			},
+			wantControlReads: 1,
+		},
+		{
+			name:        "catch-up uses control status before and after the batch",
+			state:       "rebuilding",
+			resumeReady: true,
+			run: func(u *usecase.SearchProjectionUsecase, b apptypes.SearchProjectionBudget) error {
+				_, err := u.CatchUp(context.Background(), b, time.Now())
+				if err != nil {
+					return xerrors.Errorf("catch up projection: %w", err)
+				}
+				return nil
+			},
+			wantControlReads: 3,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			store := &wallBudgetStore{budget: budget, state: "idle"}
+			store := &wallBudgetStore{budget: budget, state: tt.state, resumeReady: tt.resumeReady}
 			if err := tt.run(usecase.NewSearchProjectionUsecase(store), budget); err != nil {
 				t.Fatal(err)
 			}

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -22,6 +22,7 @@ type SearchProjectionStore interface {
 	CleanupBatch(context.Context, apptypes.ProjectionBatchPlan, time.Duration, time.Time) (apptypes.SearchProjectionProgress, error)
 	MarkFailed(context.Context, string, int64, string, time.Time) error
 	SearchProjectionStatus(context.Context) (apptypes.SearchProjectionStatus, error)
+	SearchProjectionControlStatus(context.Context) (apptypes.SearchProjectionControlStatus, error)
 }
 
 type SearchProjectionInventoryStore interface {
@@ -51,7 +52,7 @@ func (u *SearchProjectionUsecase) StartGeneration(ctx context.Context, b apptype
 	if !b.Valid() {
 		return apptypes.SearchProjectionGeneration{}, &apptypes.SearchProjectionNoProgressError{Reason: "invalid generation budget"}
 	}
-	status, err := u.store.SearchProjectionStatus(ctx)
+	status, err := u.store.SearchProjectionControlStatus(ctx)
 	if err != nil {
 		return apptypes.SearchProjectionGeneration{}, xerrors.Errorf("inspect projection before start: %w", err)
 	}
@@ -65,7 +66,7 @@ func (u *SearchProjectionUsecase) StartGeneration(ctx context.Context, b apptype
 func (u *SearchProjectionUsecase) Resume(ctx context.Context, b apptypes.SearchProjectionBudget, now time.Time) (apptypes.SearchProjectionProgress, error) {
 	wallCtx, cancel := context.WithTimeout(ctx, b.WallTime)
 	defer cancel()
-	status, err := u.store.SearchProjectionStatus(wallCtx)
+	status, err := u.store.SearchProjectionControlStatus(wallCtx)
 	if err != nil {
 		return apptypes.SearchProjectionProgress{}, xerrors.Errorf("inspect projection before resume: %w", err)
 	}
@@ -268,7 +269,7 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	if !b.Valid() {
 		return out, &apptypes.SearchProjectionNoProgressError{Reason: "invalid generation budget"}
 	}
-	status, err := u.store.SearchProjectionStatus(ctx)
+	status, err := u.store.SearchProjectionControlStatus(ctx)
 	if err != nil {
 		return out, xerrors.Errorf("inspect projection before catch-up: %w", err)
 	}
@@ -385,7 +386,7 @@ func (u *SearchProjectionUsecase) finishCatchUpProgress(ctx context.Context, out
 	out.Written = progress.Written
 	out.Completed = progress.Completed
 	out.GenerationID = progress.GenerationID
-	statusAfter, inspectErr := u.store.SearchProjectionStatus(ctx)
+	statusAfter, inspectErr := u.store.SearchProjectionControlStatus(ctx)
 	if inspectErr != nil {
 		if progress.Completed {
 			return out, xerrors.Errorf("inspect projection after catch-up complete: %w", inspectErr)
@@ -403,7 +404,7 @@ func (u *SearchProjectionUsecase) finishCatchUpProgress(ctx context.Context, out
 	out.CutoverAfterEvidence = statusAfter.CutoverAfterEvidence
 	if progress.Completed {
 		out.SessionTierVerified = true
-		out.Completed = statusAfter.Completed
+		out.Completed = statusAfter.State == "complete"
 	}
 	return out, nil
 }

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -1068,13 +1068,7 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	if e != nil {
 		return s, e
 	}
-	// Method is not persisted: dbstat is the only way this figure is ever
-	// produced, so it is derived rather than stored per row.
-	for _, evidence := range []*apptypes.CapacityEvidence{&s.CutoverBeforeEvidence, &s.CutoverAfterEvidence, &s.CapacityEvidence} {
-		if evidence.Status != "" {
-			evidence.Method = "dbstat"
-		}
-	}
+	enrichCapacityEvidenceMethod(&s.CutoverBeforeEvidence, &s.CutoverAfterEvidence, &s.CapacityEvidence)
 	var inventoryState string
 	if e = db.QueryRowContext(ctx, `SELECT state FROM search_projection_inventory_state WHERE singleton=1`).Scan(&inventoryState); e != nil {
 		return s, e

--- a/infrastructure/sqlite/search_projection_status.go
+++ b/infrastructure/sqlite/search_projection_status.go
@@ -13,6 +13,15 @@ import (
 //go:embed sql/select_search_projection_control_status.sql
 var selectSearchProjectionControlStatusSQL string
 
+func enrichCapacityEvidenceMethod(evidence ...*apptypes.CapacityEvidence) {
+	// The method is derived because persisted capacity figures only come from dbstat.
+	for _, item := range evidence {
+		if item.Status != "" {
+			item.Method = "dbstat"
+		}
+	}
+}
+
 // SearchProjectionControlStatus reads only the singleton state-machine rows.
 // Keeping this query separate prevents lifecycle control paths from paying for
 // operator-facing measurement queries.
@@ -42,6 +51,7 @@ func (d *Database) SearchProjectionControlStatus(ctx context.Context) (s apptype
 	if err != nil {
 		return s, xerrors.Errorf("scan projection control status: %w", err)
 	}
+	enrichCapacityEvidenceMethod(&s.CutoverBeforeEvidence, &s.CutoverAfterEvidence)
 	if err = tx.Commit(); err != nil {
 		return s, xerrors.Errorf("commit projection control status read: %w", err)
 	}

--- a/infrastructure/sqlite/search_projection_status.go
+++ b/infrastructure/sqlite/search_projection_status.go
@@ -1,0 +1,49 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+//go:embed sql/select_search_projection_control_status.sql
+var selectSearchProjectionControlStatusSQL string
+
+// SearchProjectionControlStatus reads only the singleton state-machine rows.
+// Keeping this query separate prevents lifecycle control paths from paying for
+// operator-facing measurement queries.
+func (d *Database) SearchProjectionControlStatus(ctx context.Context) (s apptypes.SearchProjectionControlStatus, err error) {
+	db, err := d.openReadOnly(ctx)
+	if err != nil {
+		return s, err
+	}
+	defer func() { _ = db.Close() }()
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return s, xerrors.Errorf("begin projection control status read: %w", err)
+	}
+	defer func() {
+		if rollbackErr := tx.Rollback(); err == nil && rollbackErr != nil && rollbackErr != sql.ErrTxDone {
+			err = xerrors.Errorf("rollback projection control status read: %w", rollbackErr)
+		}
+	}()
+
+	err = tx.QueryRowContext(ctx, selectSearchProjectionControlStatusSQL).Scan(
+		&s.State, &s.Phase, &s.ConfigHash, &s.CapacitySemanticsVersion, &s.FailureClass,
+		&s.CutoverIndexFamily, &s.CutoverFamilyBytesBefore, &s.CutoverFamilyBytesAfter,
+		&s.CutoverBeforeEvidence.Status, &s.CutoverBeforeEvidence.Reason,
+		&s.CutoverAfterEvidence.Status, &s.CutoverAfterEvidence.Reason,
+	)
+	if err != nil {
+		return s, xerrors.Errorf("scan projection control status: %w", err)
+	}
+	if err = tx.Commit(); err != nil {
+		return s, xerrors.Errorf("commit projection control status read: %w", err)
+	}
+	return s, nil
+}

--- a/infrastructure/sqlite/search_projection_status_query_plan_internal_test.go
+++ b/infrastructure/sqlite/search_projection_status_query_plan_internal_test.go
@@ -1,0 +1,111 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	_ "modernc.org/sqlite"
+)
+
+func TestSearchProjectionControlStatusQueryReadsOnlySingletonState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+selectSearchProjectionControlStatusSQL)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	t.Cleanup(func() { _ = rows.Close() })
+	var plan []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+
+	for _, test := range []struct {
+		name string
+		want []string
+	}{
+		{
+			name: "referenced objects",
+			want: []string{"search_projection_inventory_state", "search_projection_state"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := referencedSearchProjectionControlStatusObjects(selectSearchProjectionControlStatusSQL, strings.Join(plan, "\n"))
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Fatalf("query plan referenced unexpected objects (-want +got):\n%s\nplan:\n%s", diff, strings.Join(plan, "\n"))
+			}
+		})
+	}
+}
+
+func referencedSearchProjectionControlStatusObjects(query, plan string) []string {
+	queryTokens := strings.FieldsFunc(query, func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_'
+	})
+	planTokens := make(map[string]struct{})
+	for _, token := range strings.FieldsFunc(plan, func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_'
+	}) {
+		planTokens[strings.ToLower(token)] = struct{}{}
+	}
+
+	objects := make([]string, 0)
+	for index := 0; index < len(queryTokens); index++ {
+		if !strings.EqualFold(queryTokens[index], "from") && !strings.EqualFold(queryTokens[index], "join") {
+			continue
+		}
+		if index+1 >= len(queryTokens) {
+			continue
+		}
+		object := queryTokens[index+1]
+		aliases := []string{object}
+		if index+3 < len(queryTokens) && strings.EqualFold(queryTokens[index+2], "as") {
+			aliases = append(aliases, queryTokens[index+3])
+		} else if index+2 < len(queryTokens) && !isSearchProjectionControlStatusSQLKeyword(queryTokens[index+2]) {
+			aliases = append(aliases, queryTokens[index+2])
+		}
+		for _, alias := range aliases {
+			if _, ok := planTokens[strings.ToLower(alias)]; ok {
+				objects = append(objects, object)
+				break
+			}
+		}
+	}
+	sort.Strings(objects)
+	return objects
+}
+
+func isSearchProjectionControlStatusSQLKeyword(token string) bool {
+	switch strings.ToLower(token) {
+	case "where", "join", "left", "right", "inner", "outer", "on", "group", "order", "limit", "union":
+		return true
+	default:
+		return false
+	}
+}

--- a/infrastructure/sqlite/sql/select_search_projection_control_status.sql
+++ b/infrastructure/sqlite/sql/select_search_projection_control_status.sql
@@ -1,0 +1,16 @@
+SELECT
+    s.state,
+    CASE WHEN s.state = 'rebuilding' AND i.state = 'rebuilding' THEN 'inventory' ELSE s.phase END,
+    s.config_hash,
+    s.capacity_semantics_version,
+    COALESCE(s.failure_class, ''),
+    COALESCE(s.cutover_index_family, ''),
+    s.cutover_family_bytes_before,
+    s.cutover_family_bytes_after,
+    COALESCE(s.cutover_before_evidence_status, ''),
+    COALESCE(s.cutover_before_evidence_reason, ''),
+    COALESCE(s.cutover_after_evidence_status, ''),
+    COALESCE(s.cutover_after_evidence_reason, '')
+FROM search_projection_state AS s
+JOIN search_projection_inventory_state AS i ON i.singleton = s.singleton
+WHERE s.singleton = 1


### PR DESCRIPTION
Closes #1798.

`traceary list --limit 1` took 15 seconds on a 7 GB store. So did every other write-capable command, including ones that then did nothing.

## What was wrong

`Database.initializeAt` runs `catchUpSearchProjection` on every store open, and that reads `SearchProjectionStatus` before deciding whether there is any work. `SearchProjectionStatus` performs two whole-family scans:

| query | time on the 7.16 GB rehearsal store |
|---|---|
| `selectSearchProjectionFTSLogicalBytesSQL` | 6.26 s |
| `selectSearchProjectionFamilyTotalSQL` (`dbstat` walk) | 6.48 s |

Everything else in the open is noise by comparison — `migrate` 0.002 s, the compatibility check 0.000 s, the workspace-observation catch-up 1.1 s. The rehearsal store's generation is `failed`, so the catch-up parks it and does no work at all; it still paid 15 s to find that out.

The original issue ruled the projection catch-up out by indirect measurement. That was wrong, and the correction is in the issue thread: it is not the projecting that costs, it is the status read before it.

## What changed

The measured fields — `FTSLogicalBytes`, `PhysicalBytes`, `PhysicalEvidence`, `MatchProbeMilliseconds`, `InspectionMilliseconds`, and the per-generation aggregates — have exactly one consumer, `Inspect`, which backs the operator-facing `store search-projection status` and `probe` output. Every other caller reads persisted control columns only:

| caller | reads |
|---|---|
| `StartGeneration` | `State` |
| `Resume` | `State`, `Phase`, `ConfigHash` |
| `CatchUp` | `State`, `Phase`, `ConfigHash`, `CapacitySemanticsVersion`, `FailureClass`, cutover columns |
| `finishCatchUpProgress` | `State`, `Phase`, cutover columns |

Those four now use `SearchProjectionControlStatus`, one read of the two singleton rows in a single read-only transaction so a half-applied transition cannot be observed. `Inspect` keeps the measured read.

A narrower return type rather than a `measure bool`: the type is what stops a future control path from quietly reintroducing the scans, and it makes the usecase's dependency on the store honest about what it actually needs. No new command, subcommand or flag — the surface should shrink, not grow.

`finishCatchUpProgress` also read `statusAfter.Completed`, which is the SQL expression `state='complete'`, so it becomes `statusAfter.State == "complete"` rather than a field on the control type.

## Measured

`traceary list --limit 1` on the 7.16 GB rehearsal store, same binary flags, alternating runs:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| `main` | 15.08 s | 14.61 s | |
| this branch | 1.82 s | 0.85 s | 0.66 s |

`store search-projection resume` at its own 1 s `--wall-time` default now reaches its batch instead of expiring during the pre-batch status read.

## Tests

`TestSearchProjectionStatusRoutingKeepsMeasurementsOffControlPaths` counts control vs measured reads for `StartGeneration`, `Resume`, `CatchUp` (including its post-batch read) and `Inspect`. The compiler cannot hold this on its own: `SearchProjectionStatus` carries every field the control paths read, so routing one back to the measured call still compiles.

Review found the control read dropped `Method: "dbstat"` from the cutover evidence it copies into the catch-up result, which is JSON-serialised — the derivation is now a shared helper used by both reads.

`go build` / `go vet` / `go tool golangci-lint run` clean, `go test ./...` green.

## Not in this PR

The store open still sits inside `Resume`'s per-batch wall budget. With the status read down to milliseconds the 1 s default is workable, so that boundary is worth re-measuring rather than changing on the same speculation that produced the original diagnosis.

Implementation by gpt-5.6-luna; profiling, review and the store measurements by Claude Opus 5.
