### PR TITLE
fix: skip and record oversized search projection rows instead of failing the generation

### DIFF
--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -152,6 +152,7 @@ const (
 	ProjectionDispositionAdmitted ProjectionDisposition = "admitted"
 	ProjectionDispositionDeleted  ProjectionDisposition = "deleted"
 	ProjectionDispositionExcluded ProjectionDisposition = "excluded"
+	ProjectionDispositionBatchFull ProjectionDisposition = ""
 )
 
 type ProjectionSnapshot struct {
@@ -195,7 +196,7 @@ type ProjectionWrite struct {
 }
 
 type ProjectionExclusion struct {
-	Sequence, SourceBytes, ByteLimit int64
+	Sequence, MeasuredBytes, ByteLimit int64
 	EventID, Class                   string
 }
 
@@ -241,7 +242,7 @@ func (l *BudgetLedger) AdmitSource(b SearchProjectionBudget, stored, decoded int
 		return ProjectionDispositionExcluded, nil
 	}
 	if !l.ReserveSource(b, stored, decoded) {
-		return "", nil
+		return ProjectionDispositionBatchFull, nil
 	}
 	return ProjectionDispositionAdmitted, nil
 }
@@ -354,7 +355,7 @@ type SearchProjectionExclusion struct {
 	Sequence int64 `json:"sequence"`
 	EventID string `json:"event_id"`
 	Class string `json:"class"`
-	SourceBytes int64 `json:"source_bytes"`
+	MeasuredBytes int64 `json:"measured_bytes"`
 	ByteLimit int64 `json:"byte_limit"`
 }
 

--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -53,23 +53,17 @@ func (b SearchProjectionBudget) Valid() bool {
 	return b.Rows > 0 && b.WallTime > 0 && b.LockTime > 0 && b.StoredBytes > 0 && b.DecodedBytes > 0 && b.WriteBytes > 0 && b.RecentAge > 0 && b.IndexFamilyBytes > 0
 }
 
-// ConfigHash contains only budgets that define generation contents. RecentAge
-// and IndexFamilyBytes decide what the generation retains, so resuming with a
-// different value would leave an index that no single budget describes.
+// ConfigHash contains only budgets that define generation contents. StoredBytes,
+// DecodedBytes, WriteBytes, RecentAge and IndexFamilyBytes decide what the
+// generation contains, so resuming with a different value would leave an index
+// that no single budget describes.
 //
-// Rows, WallTime, LockTime, StoredBytes and WriteBytes only bound one batch's
-// working set, so they stay out of the generation identity: a batch that cannot
-// fit its lock cap must be allowed to resume with a smaller unit of work rather
-// than discard durable progress. StoredBytes and WriteBytes can reject an
-// oversized row, but rejection fails the generation outright — it never quietly
-// admits a different set of rows — so they change no content either.
-//
-// DecodedBytes is held in by choice, not by that argument. It rejects rows the
-// same way, and #1794 decides what an over-budget row should do instead; until
-// that lands, keeping it here means a widened budget starts a new generation
-// rather than silently changing the meaning of a partial one.
+// Rows, WallTime and LockTime only bound the cost of one batch, so they stay out
+// of the generation identity: a batch that cannot fit its lock cap must be
+// allowed to resume with a smaller unit of work rather than discard durable
+// progress.
 func (b SearchProjectionBudget) ConfigHash() string {
-	return fmt.Sprintf("v3:%d:%d:%d", b.DecodedBytes, b.RecentAge.Nanoseconds(), b.IndexFamilyBytes)
+	return fmt.Sprintf("v4:%d:%d:%d:%d:%d", b.StoredBytes, b.DecodedBytes, b.WriteBytes, b.RecentAge.Nanoseconds(), b.IndexFamilyBytes)
 }
 
 type SearchProjectionGeneration struct {
@@ -332,8 +326,9 @@ type SearchProjectionStatus struct {
 	// whether automatic catch-up may start a replacement: a deterministic class
 	// would fail the same way on every open.
 	FailureClass string `json:"failure_class,omitempty"`
-	ExclusionCount int64 `json:"exclusion_count"`
-	Exclusions []SearchProjectionExclusion `json:"exclusions,omitempty"`
+	ExclusionGenerationID string                       `json:"exclusion_generation_id,omitempty"`
+	ExclusionCount        int64                        `json:"exclusion_count"`
+	Exclusions             []SearchProjectionExclusion `json:"exclusions,omitempty"`
 	// CutoverIndexFamily names which physical family CutoverFamilyBytes*
 	// measure. Always "bounded_search_projection" when set — never the
 	// legacy migration-032 event_search_* family (that is #1718).

--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -141,7 +141,18 @@ type ProjectionDocument struct {
 	StoredBytes, DecodedBytes                            int64
 	Deleted                                              bool
 	CommandCount, FailureCount                           int
+	Disposition                                           ProjectionDisposition
 }
+
+// ProjectionDisposition distinguishes a deliberately unindexed source row
+// from a deleted row that merely advances the checkpoint.
+type ProjectionDisposition string
+
+const (
+	ProjectionDispositionAdmitted ProjectionDisposition = "admitted"
+	ProjectionDispositionDeleted  ProjectionDisposition = "deleted"
+	ProjectionDispositionExcluded ProjectionDisposition = "excluded"
+)
 
 type ProjectionSnapshot struct {
 	Generation    SearchProjectionGeneration
@@ -183,12 +194,18 @@ type ProjectionWrite struct {
 	LiteralFingerprints []string
 }
 
+type ProjectionExclusion struct {
+	Sequence, SourceBytes, ByteLimit int64
+	EventID, Class                   string
+}
+
 // ProjectionBatchPlan is a pure application-owned decision. Adapters may only
 // persist this decision; they must not extend it with additional rows.
 type ProjectionBatchPlan struct {
 	GenerationID, Phase                                  string
 	ExpectedRevision, ExpectedCheckpoint, NextCheckpoint int64
 	Writes                                               []ProjectionWrite
+	Exclusions                                           []ProjectionExclusion
 	Cleanup                                              []ProjectionCleanupCandidate
 	NextPhase                                            string
 	Completed                                            bool
@@ -215,15 +232,18 @@ func (l *BudgetLedger) ReserveSource(b SearchProjectionBudget, stored, decoded i
 	return true
 }
 
-// AdmitSource distinguishes an impossible first row from a resumable prefix.
-func (l *BudgetLedger) AdmitSource(b SearchProjectionBudget, stored, decoded int64) (bool, error) {
+// AdmitSource returns a disposition without hydrating an over-limit source row.
+func (l *BudgetLedger) AdmitSource(b SearchProjectionBudget, stored, decoded int64) (ProjectionDisposition, error) {
 	if stored > b.StoredBytes {
-		return false, &SearchProjectionOversizeError{Class: "stored_bytes", Bytes: stored, Limit: b.StoredBytes}
+		return ProjectionDispositionExcluded, nil
 	}
 	if decoded > b.DecodedBytes {
-		return false, &SearchProjectionOversizeError{Class: "decoded_bytes", Bytes: decoded, Limit: b.DecodedBytes}
+		return ProjectionDispositionExcluded, nil
 	}
-	return l.ReserveSource(b, stored, decoded), nil
+	if !l.ReserveSource(b, stored, decoded) {
+		return "", nil
+	}
+	return ProjectionDispositionAdmitted, nil
 }
 
 // RetentionPlan is the pure eviction/old-generation cleanup decision.
@@ -311,6 +331,8 @@ type SearchProjectionStatus struct {
 	// whether automatic catch-up may start a replacement: a deterministic class
 	// would fail the same way on every open.
 	FailureClass string `json:"failure_class,omitempty"`
+	ExclusionCount int64 `json:"exclusion_count"`
+	Exclusions []SearchProjectionExclusion `json:"exclusions,omitempty"`
 	// CutoverIndexFamily names which physical family CutoverFamilyBytes*
 	// measure. Always "bounded_search_projection" when set — never the
 	// legacy migration-032 event_search_* family (that is #1718).
@@ -326,6 +348,14 @@ type SearchProjectionStatus struct {
 	// yet.
 	CutoverBeforeEvidence CapacityEvidence `json:"cutover_before_evidence"`
 	CutoverAfterEvidence  CapacityEvidence `json:"cutover_after_evidence"`
+}
+
+type SearchProjectionExclusion struct {
+	Sequence int64 `json:"sequence"`
+	EventID string `json:"event_id"`
+	Class string `json:"class"`
+	SourceBytes int64 `json:"source_bytes"`
+	ByteLimit int64 `json:"byte_limit"`
 }
 
 // SearchProjectionControlStatus contains only persisted state-machine data.

--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -149,9 +149,9 @@ type ProjectionDocument struct {
 type ProjectionDisposition string
 
 const (
-	ProjectionDispositionAdmitted ProjectionDisposition = "admitted"
-	ProjectionDispositionDeleted  ProjectionDisposition = "deleted"
-	ProjectionDispositionExcluded ProjectionDisposition = "excluded"
+	ProjectionDispositionAdmitted  ProjectionDisposition = "admitted"
+	ProjectionDispositionDeleted   ProjectionDisposition = "deleted"
+	ProjectionDispositionExcluded  ProjectionDisposition = "excluded"
 	ProjectionDispositionBatchFull ProjectionDisposition = ""
 )
 
@@ -197,7 +197,7 @@ type ProjectionWrite struct {
 
 type ProjectionExclusion struct {
 	Sequence, MeasuredBytes, ByteLimit int64
-	EventID, Class                   string
+	EventID, Class                     string
 }
 
 // ProjectionBatchPlan is a pure application-owned decision. Adapters may only

--- a/application/usecase/search_projection_plan.go
+++ b/application/usecase/search_projection_plan.go
@@ -51,21 +51,32 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		return p, nil
 	}
 	summaries := map[string]string{}
+	// recordExclusion charges the exclusion row against the same WriteBytes
+	// budget as every other mutation, so the ledger stays the whole account of
+	// what the transaction writes. It reports whether the batch can hold the
+	// row; blockedExclusionBytes then lets the batch-level check tell "this
+	// batch is full" apart from "no progress was ever possible".
 	var blockedExclusionBytes int64
+	recordExclusion := func(e apptypes.ProjectionExclusion) bool {
+		cost := projectionExclusionLogicalBytes(p.GenerationID, e)
+		if p.Ledger.LogicalWriteBytes+cost > b.WriteBytes {
+			blockedExclusionBytes = cost
+			return false
+		}
+		p.Exclusions = append(p.Exclusions, e)
+		p.Ledger.LogicalWriteBytes += cost
+		p.NextCheckpoint = e.Sequence
+		return true
+	}
 	for _, d := range s.Documents {
 		class, bytes, limit, err := classifyProjectionExclusion(d, b)
 		if err != nil {
 			return p, err
 		}
 		if class != "" {
-			exclusion := apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: class, MeasuredBytes: bytes, ByteLimit: limit}
-			if p.Ledger.LogicalWriteBytes+projectionExclusionLogicalBytes(p.GenerationID, exclusion) > b.WriteBytes {
-				blockedExclusionBytes = projectionExclusionLogicalBytes(p.GenerationID, exclusion)
+			if !recordExclusion(apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: class, MeasuredBytes: bytes, ByteLimit: limit}) {
 				break
 			}
-			p.Exclusions = append(p.Exclusions, exclusion)
-			p.Ledger.LogicalWriteBytes += projectionExclusionLogicalBytes(p.GenerationID, exclusion)
-			p.NextCheckpoint = d.Sequence
 			continue
 		}
 		if p.Ledger.Rows >= b.Rows || p.Ledger.StoredBytes+d.StoredBytes > b.StoredBytes || p.Ledger.DecodedBytes+d.DecodedBytes > b.DecodedBytes {
@@ -94,14 +105,9 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		}
 		w.LogicalBytes = projectionWriteLogicalBytes(p.GenerationID, w)
 		if checkpointBytes+w.LogicalBytes > b.WriteBytes {
-			exclusion := apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: "write_bytes", MeasuredBytes: w.LogicalBytes, ByteLimit: b.WriteBytes}
-			if p.Ledger.LogicalWriteBytes+projectionExclusionLogicalBytes(p.GenerationID, exclusion) > b.WriteBytes {
-				blockedExclusionBytes = projectionExclusionLogicalBytes(p.GenerationID, exclusion)
+			if !recordExclusion(apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: "write_bytes", MeasuredBytes: w.LogicalBytes, ByteLimit: b.WriteBytes}) {
 				break
 			}
-			p.Exclusions = append(p.Exclusions, exclusion)
-			p.Ledger.LogicalWriteBytes += projectionExclusionLogicalBytes(p.GenerationID, exclusion)
-			p.NextCheckpoint = d.Sequence
 			continue
 		}
 		if p.Ledger.LogicalWriteBytes+w.LogicalBytes > b.WriteBytes {

--- a/application/usecase/search_projection_plan.go
+++ b/application/usecase/search_projection_plan.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	apptypes "github.com/duck8823/traceary/application/types"
+	"golang.org/x/xerrors"
 	"sort"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		p.ContinueState = "drifted"
 	}
 	p.Ledger.LogicalWriteBytes = projectionCheckpointLogicalBytes(p)
+	checkpointBytes := p.Ledger.LogicalWriteBytes
 	if p.Ledger.LogicalWriteBytes > b.WriteBytes {
 		return p, &apptypes.SearchProjectionOversizeError{Class: "write_bytes", Bytes: p.Ledger.LogicalWriteBytes, Limit: b.WriteBytes}
 	}
@@ -50,14 +52,17 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 	}
 	summaries := map[string]string{}
 	for _, d := range s.Documents {
-		class, bytes, limit := "", int64(0), int64(0)
-		if d.Disposition == apptypes.ProjectionDispositionExcluded || d.StoredBytes > b.StoredBytes {
-			class, bytes, limit = "stored_bytes", d.StoredBytes, b.StoredBytes
-		} else if d.DecodedBytes > b.DecodedBytes {
-			class, bytes, limit = "decoded_bytes", d.DecodedBytes, b.DecodedBytes
+		class, bytes, limit, err := classifyProjectionExclusion(d, b)
+		if err != nil {
+			return p, err
 		}
 		if class != "" {
-			p.Exclusions = append(p.Exclusions, apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: class, SourceBytes: bytes, ByteLimit: limit})
+			exclusion := apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: class, MeasuredBytes: bytes, ByteLimit: limit}
+			if p.Ledger.LogicalWriteBytes+projectionExclusionLogicalBytes(p.GenerationID, exclusion) > b.WriteBytes {
+				break
+			}
+			p.Exclusions = append(p.Exclusions, exclusion)
+			p.Ledger.LogicalWriteBytes += projectionExclusionLogicalBytes(p.GenerationID, exclusion)
 			p.NextCheckpoint = d.Sequence
 			continue
 		}
@@ -82,23 +87,25 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 			base = d.PreviousSummary
 		}
 		w.Summary = truncateProjection(strings.TrimSpace(base+"\n"+d.Text), 4096)
-		summaries[d.SessionID] = w.Summary
 		for _, k := range projectionTokens(strings.ToLower(d.Text)) {
 			w.Keywords[k]++
 		}
 		w.LogicalBytes = projectionWriteLogicalBytes(p.GenerationID, w)
-		if w.LogicalBytes > b.WriteBytes {
-			p.Exclusions = append(p.Exclusions, apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: "write_bytes", SourceBytes: w.LogicalBytes, ByteLimit: b.WriteBytes})
+		if checkpointBytes+w.LogicalBytes > b.WriteBytes {
+			exclusion := apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: "write_bytes", MeasuredBytes: w.LogicalBytes, ByteLimit: b.WriteBytes}
+			if p.Ledger.LogicalWriteBytes+projectionExclusionLogicalBytes(p.GenerationID, exclusion) > b.WriteBytes {
+				break
+			}
+			p.Exclusions = append(p.Exclusions, exclusion)
+			p.Ledger.LogicalWriteBytes += projectionExclusionLogicalBytes(p.GenerationID, exclusion)
 			p.NextCheckpoint = d.Sequence
 			continue
 		}
 		if p.Ledger.LogicalWriteBytes+w.LogicalBytes > b.WriteBytes {
-			if len(p.Writes) == 0 {
-				return p, &apptypes.SearchProjectionOversizeError{Class: "write_bytes", Bytes: p.Ledger.LogicalWriteBytes + w.LogicalBytes, Limit: b.WriteBytes}
-			}
 			break
 		}
 		p.Writes = append(p.Writes, w)
+		summaries[d.SessionID] = w.Summary
 		p.NextCheckpoint = d.Sequence
 		p.Ledger.Rows++
 		p.Ledger.StoredBytes += d.StoredBytes
@@ -112,6 +119,25 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		p.NextPhase = "eviction"
 	}
 	return p, nil
+}
+
+// classifyProjectionExclusion derives the durable reason from measured values.
+// Disposition only prevents hydration; it does not identify the exceeded limit.
+func classifyProjectionExclusion(d apptypes.ProjectionDocument, b apptypes.SearchProjectionBudget) (string, int64, int64, error) {
+	if d.StoredBytes > b.StoredBytes {
+		return "stored_bytes", d.StoredBytes, b.StoredBytes, nil
+	}
+	if d.DecodedBytes > b.DecodedBytes {
+		return "decoded_bytes", d.DecodedBytes, b.DecodedBytes, nil
+	}
+	if d.Disposition == apptypes.ProjectionDispositionExcluded {
+		return "", 0, 0, xerrors.Errorf("excluded projection row %q exceeds no source budget", d.EventID)
+	}
+	return "", 0, 0, nil
+}
+
+func projectionExclusionLogicalBytes(generation string, e apptypes.ProjectionExclusion) int64 {
+	return int64(len(generation) + len(e.EventID) + len(e.Class) + 32)
 }
 
 // PlanProjectionRetention creates a bounded, deterministic cleanup decision.

--- a/application/usecase/search_projection_plan.go
+++ b/application/usecase/search_projection_plan.go
@@ -51,6 +51,7 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		return p, nil
 	}
 	summaries := map[string]string{}
+	var blockedExclusionBytes int64
 	for _, d := range s.Documents {
 		class, bytes, limit, err := classifyProjectionExclusion(d, b)
 		if err != nil {
@@ -59,6 +60,7 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		if class != "" {
 			exclusion := apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: class, MeasuredBytes: bytes, ByteLimit: limit}
 			if p.Ledger.LogicalWriteBytes+projectionExclusionLogicalBytes(p.GenerationID, exclusion) > b.WriteBytes {
+				blockedExclusionBytes = projectionExclusionLogicalBytes(p.GenerationID, exclusion)
 				break
 			}
 			p.Exclusions = append(p.Exclusions, exclusion)
@@ -94,6 +96,7 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		if checkpointBytes+w.LogicalBytes > b.WriteBytes {
 			exclusion := apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: "write_bytes", MeasuredBytes: w.LogicalBytes, ByteLimit: b.WriteBytes}
 			if p.Ledger.LogicalWriteBytes+projectionExclusionLogicalBytes(p.GenerationID, exclusion) > b.WriteBytes {
+				blockedExclusionBytes = projectionExclusionLogicalBytes(p.GenerationID, exclusion)
 				break
 			}
 			p.Exclusions = append(p.Exclusions, exclusion)
@@ -113,6 +116,9 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		p.Ledger.LogicalWriteBytes += w.LogicalBytes
 	}
 	if len(s.Documents) > 0 && len(p.Writes) == 0 && len(p.Exclusions) == 0 {
+		if blockedExclusionBytes > 0 {
+			return p, &apptypes.SearchProjectionOversizeError{Class: "write_bytes", Bytes: p.Ledger.LogicalWriteBytes + blockedExclusionBytes, Limit: b.WriteBytes}
+		}
 		return p, &apptypes.SearchProjectionNoProgressError{Reason: "resource budget prevented the first row"}
 	}
 	if s.SourceDone && len(p.Writes)+len(p.Exclusions) == len(s.Documents) {

--- a/application/usecase/search_projection_plan.go
+++ b/application/usecase/search_projection_plan.go
@@ -50,14 +50,19 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 	}
 	summaries := map[string]string{}
 	for _, d := range s.Documents {
+		class, bytes, limit := "", int64(0), int64(0)
+		if d.Disposition == apptypes.ProjectionDispositionExcluded || d.StoredBytes > b.StoredBytes {
+			class, bytes, limit = "stored_bytes", d.StoredBytes, b.StoredBytes
+		} else if d.DecodedBytes > b.DecodedBytes {
+			class, bytes, limit = "decoded_bytes", d.DecodedBytes, b.DecodedBytes
+		}
+		if class != "" {
+			p.Exclusions = append(p.Exclusions, apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: class, SourceBytes: bytes, ByteLimit: limit})
+			p.NextCheckpoint = d.Sequence
+			continue
+		}
 		if p.Ledger.Rows >= b.Rows || p.Ledger.StoredBytes+d.StoredBytes > b.StoredBytes || p.Ledger.DecodedBytes+d.DecodedBytes > b.DecodedBytes {
 			break
-		}
-		if d.StoredBytes > b.StoredBytes {
-			return p, &apptypes.SearchProjectionOversizeError{Class: "stored_bytes", Bytes: d.StoredBytes, Limit: b.StoredBytes}
-		}
-		if d.DecodedBytes > b.DecodedBytes {
-			return p, &apptypes.SearchProjectionOversizeError{Class: "decoded_bytes", Bytes: d.DecodedBytes, Limit: b.DecodedBytes}
 		}
 		w := apptypes.ProjectionWrite{Document: d, Keywords: map[string]int{}}
 		w.LiteralFingerprints = apptypes.CharacterizeLiteralQuery(d.Text).Fingerprints()
@@ -83,7 +88,9 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		}
 		w.LogicalBytes = projectionWriteLogicalBytes(p.GenerationID, w)
 		if w.LogicalBytes > b.WriteBytes {
-			return p, &apptypes.SearchProjectionOversizeError{Class: "write_bytes", Bytes: w.LogicalBytes, Limit: b.WriteBytes}
+			p.Exclusions = append(p.Exclusions, apptypes.ProjectionExclusion{Sequence: d.Sequence, EventID: d.EventID, Class: "write_bytes", SourceBytes: w.LogicalBytes, ByteLimit: b.WriteBytes})
+			p.NextCheckpoint = d.Sequence
+			continue
 		}
 		if p.Ledger.LogicalWriteBytes+w.LogicalBytes > b.WriteBytes {
 			if len(p.Writes) == 0 {
@@ -98,10 +105,10 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		p.Ledger.DecodedBytes += d.DecodedBytes
 		p.Ledger.LogicalWriteBytes += w.LogicalBytes
 	}
-	if len(s.Documents) > 0 && len(p.Writes) == 0 {
+	if len(s.Documents) > 0 && len(p.Writes) == 0 && len(p.Exclusions) == 0 {
 		return p, &apptypes.SearchProjectionNoProgressError{Reason: "resource budget prevented the first row"}
 	}
-	if s.SourceDone && len(p.Writes) == len(s.Documents) {
+	if s.SourceDone && len(p.Writes)+len(p.Exclusions) == len(s.Documents) {
 		p.NextPhase = "eviction"
 	}
 	return p, nil

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -323,8 +323,8 @@ func TestSearchProjectionConfigHashSeparatesSemanticAndThroughputBudgets(t *test
 		{name: "rows", mutate: func(b *apptypes.SearchProjectionBudget) { b.Rows = 1 }, match: true},
 		{name: "lock time", mutate: func(b *apptypes.SearchProjectionBudget) { b.LockTime = 2 * time.Second }, match: true},
 		{name: "wall time", mutate: func(b *apptypes.SearchProjectionBudget) { b.WallTime = 2 * time.Second }, match: true},
-		{name: "stored bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.StoredBytes = 101 }, match: true},
-		{name: "write bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.WriteBytes = 301 }, match: true},
+		{name: "stored bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.StoredBytes = 101 }, match: false},
+		{name: "write bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.WriteBytes = 301 }, match: false},
 		{name: "recent age", mutate: func(b *apptypes.SearchProjectionBudget) { b.RecentAge = 2 * time.Hour }, match: false},
 		{name: "index family bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.IndexFamilyBytes = 401 }, match: false},
 		{name: "decoded bytes", mutate: func(b *apptypes.SearchProjectionBudget) { b.DecodedBytes = 201 }, match: false},
@@ -337,6 +337,39 @@ func TestSearchProjectionConfigHashSeparatesSemanticAndThroughputBudgets(t *test
 				t.Fatalf("hash match (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestSearchProjectionResumeRejectsChangedStoredBytes(t *testing.T) {
+	t.Parallel()
+	base := apptypes.SearchProjectionBudget{Rows: 1, WallTime: time.Second, LockTime: time.Second, StoredBytes: 100, DecodedBytes: 100, WriteBytes: 100, RecentAge: time.Hour, IndexFamilyBytes: 100}
+	changed := base
+	changed.StoredBytes++
+	store := &wallBudgetStore{budget: base}
+	_, err := usecase.NewSearchProjectionUsecase(store).Resume(context.Background(), changed, time.Now())
+	if diff := cmp.Diff("search projection made no progress: budget does not match generation configuration", err.Error()); diff != "" {
+		t.Fatalf("error (-want +got):\n%s", diff)
+	}
+}
+
+func TestPlanProjectionBatchFailsWhenOnlyTheExclusionCannotFit(t *testing.T) {
+	t.Parallel()
+	b := apptypes.SearchProjectionBudget{Rows: 1, WallTime: time.Second, LockTime: time.Second, StoredBytes: 1, DecodedBytes: 100, WriteBytes: 120, RecentAge: time.Hour, IndexFamilyBytes: 100}
+	s := apptypes.ProjectionSnapshot{
+		Generation: apptypes.SearchProjectionGeneration{GenerationID: "generation"},
+		Phase:      "source",
+		Documents:  []apptypes.ProjectionDocument{{Sequence: 1, EventID: "event", StoredBytes: 2, DecodedBytes: 2}},
+	}
+	_, err := usecase.PlanProjectionBatch(s, b)
+	var oversized *apptypes.SearchProjectionOversizeError
+	if !errors.As(err, &oversized) {
+		t.Fatalf("error=%T %v, want SearchProjectionOversizeError", err, err)
+	}
+	if diff := cmp.Diff("write_bytes", oversized.Class); diff != "" {
+		t.Fatalf("class (-want +got):\n%s", diff)
+	}
+	if oversized.Bytes <= oversized.Limit {
+		t.Fatalf("error bytes=%d limit=%d, want required total above limit", oversized.Bytes, oversized.Limit)
 	}
 }
 

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -80,13 +80,15 @@ func TestProjectionBatchPlanEnforcesStrictLogicalMutationByteCap(t *testing.T) {
 	t.Parallel()
 	b := apptypes.SearchProjectionBudget{Rows: 10, WallTime: time.Second, LockTime: time.Second, StoredBytes: 1000, DecodedBytes: 1000, WriteBytes: 100, RecentAge: time.Hour, IndexFamilyBytes: 1000}
 	s := apptypes.ProjectionSnapshot{Generation: apptypes.SearchProjectionGeneration{GenerationID: "g", SourceRevision: 1}, Phase: "source", Now: time.Now(), Documents: []apptypes.ProjectionDocument{{Sequence: 1, Text: "small", StoredBytes: 5, DecodedBytes: 5}}}
-	_, err := usecase.PlanProjectionBatch(s, b)
-	var oversized *apptypes.SearchProjectionOversizeError
-	if !errors.As(err, &oversized) || oversized.Bytes <= b.WriteBytes {
-		t.Fatalf("error = %T %v, want required-total oversize", err, err)
+	p, err := usecase.PlanProjectionBatch(s, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Exclusions) != 1 || p.Exclusions[0].Class != "write_bytes" || p.NextCheckpoint != 1 {
+		t.Fatalf("exclusions = %+v checkpoint=%d, want one write_bytes exclusion at checkpoint 1", p.Exclusions, p.NextCheckpoint)
 	}
 	b.WriteBytes = 1000
-	p, err := usecase.PlanProjectionBatch(s, b)
+	p, err = usecase.PlanProjectionBatch(s, b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -109,9 +109,9 @@ func TestProjectionBatchPlanClassifiesAndSkipsRowsAtSourceBoundaries(t *testing.
 		wantClass               string
 		wantMeasured, wantLimit int64
 	}{
-		{name: "stored boundary admitted", stored: 10, decoded: 10},
+		{name: "stored boundary admitted", stored: 10, decoded: 5},
 		{name: "stored one over excluded", stored: 11, decoded: 10, wantClass: "stored_bytes", wantMeasured: 11, wantLimit: 10},
-		{name: "decoded boundary admitted", stored: 10, decoded: 10},
+		{name: "decoded boundary admitted", stored: 5, decoded: 10},
 		{name: "decoded one over excluded", stored: 5, decoded: 11, wantClass: "decoded_bytes", wantMeasured: 11, wantLimit: 10},
 	}
 	for _, tt := range tests {

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -78,7 +78,7 @@ func (*wallBudgetStore) MarkFailed(context.Context, string, int64, string, time.
 
 func TestProjectionBatchPlanEnforcesStrictLogicalMutationByteCap(t *testing.T) {
 	t.Parallel()
-	b := apptypes.SearchProjectionBudget{Rows: 10, WallTime: time.Second, LockTime: time.Second, StoredBytes: 1000, DecodedBytes: 1000, WriteBytes: 100, RecentAge: time.Hour, IndexFamilyBytes: 1000}
+	b := apptypes.SearchProjectionBudget{Rows: 10, WallTime: time.Second, LockTime: time.Second, StoredBytes: 1000, DecodedBytes: 1000, WriteBytes: 110, RecentAge: time.Hour, IndexFamilyBytes: 1000}
 	s := apptypes.ProjectionSnapshot{Generation: apptypes.SearchProjectionGeneration{GenerationID: "g", SourceRevision: 1}, Phase: "source", Now: time.Now(), Documents: []apptypes.ProjectionDocument{{Sequence: 1, Text: "small", StoredBytes: 5, DecodedBytes: 5}}}
 	p, err := usecase.PlanProjectionBatch(s, b)
 	if err != nil {
@@ -97,6 +97,65 @@ func TestProjectionBatchPlanEnforcesStrictLogicalMutationByteCap(t *testing.T) {
 	}
 	if len(p.Writes) != 1 || p.Writes[0].LogicalBytes != 146 {
 		t.Fatalf("logical formula = %+v, want one 146-byte mutation including fingerprints", p.Writes)
+	}
+}
+
+func TestProjectionBatchPlanClassifiesAndSkipsRowsAtSourceBoundaries(t *testing.T) {
+	t.Parallel()
+	base := apptypes.SearchProjectionBudget{Rows: 10, WallTime: time.Second, LockTime: time.Second, StoredBytes: 10, DecodedBytes: 10, WriteBytes: 10_000, RecentAge: time.Hour, IndexFamilyBytes: 1000}
+	tests := []struct {
+		name                    string
+		stored, decoded         int64
+		wantClass               string
+		wantMeasured, wantLimit int64
+	}{
+		{name: "stored boundary admitted", stored: 10, decoded: 10},
+		{name: "stored one over excluded", stored: 11, decoded: 10, wantClass: "stored_bytes", wantMeasured: 11, wantLimit: 10},
+		{name: "decoded boundary admitted", stored: 10, decoded: 10},
+		{name: "decoded one over excluded", stored: 5, decoded: 11, wantClass: "decoded_bytes", wantMeasured: 11, wantLimit: 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := apptypes.ProjectionSnapshot{Generation: apptypes.SearchProjectionGeneration{GenerationID: "g", SourceRevision: 1}, Phase: "source", Now: time.Now(), Documents: []apptypes.ProjectionDocument{{Sequence: 1, EventID: "e", SessionID: "s", Text: "body", StoredBytes: tt.stored, DecodedBytes: tt.decoded, Disposition: apptypes.ProjectionDispositionAdmitted}}}
+			p, err := usecase.PlanProjectionBatch(s, base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.wantClass, func() string {
+				if len(p.Exclusions) == 0 {
+					return ""
+				}
+				return p.Exclusions[0].Class
+			}()); diff != "" {
+				t.Fatalf("class (-want +got):\n%s", diff)
+			}
+			if tt.wantClass != "" {
+				got := p.Exclusions[0]
+				if diff := cmp.Diff([]int64{tt.wantMeasured, tt.wantLimit}, []int64{got.MeasuredBytes, got.ByteLimit}); diff != "" {
+					t.Fatalf("measurements (-want +got):\n%s", diff)
+				}
+			} else if len(p.Writes) != 1 {
+				t.Fatalf("writes=%d, want 1", len(p.Writes))
+			}
+		})
+	}
+}
+
+func TestProjectionBatchPlanExcludedRowDoesNotChainSummary(t *testing.T) {
+	b := apptypes.SearchProjectionBudget{Rows: 10, WallTime: time.Second, LockTime: time.Second, StoredBytes: 100, DecodedBytes: 10, WriteBytes: 10_000, RecentAge: time.Hour, IndexFamilyBytes: 1000}
+	s := apptypes.ProjectionSnapshot{Generation: apptypes.SearchProjectionGeneration{GenerationID: "g", SourceRevision: 1}, Phase: "source", Now: time.Now(), Documents: []apptypes.ProjectionDocument{
+		{Sequence: 1, EventID: "excluded", SessionID: "s", Text: strings.Repeat("x", 148), StoredBytes: 5, DecodedBytes: 11, Disposition: apptypes.ProjectionDispositionExcluded},
+		{Sequence: 2, EventID: "small", SessionID: "s", Text: "tiny", StoredBytes: 5, DecodedBytes: 5, Disposition: apptypes.ProjectionDispositionAdmitted},
+	}}
+	p, err := usecase.PlanProjectionBatch(s, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Exclusions) != 1 || len(p.Writes) != 1 {
+		t.Fatalf("plan=%+v", p)
+	}
+	if strings.Contains(p.Writes[0].Summary, "xxx") {
+		t.Fatalf("excluded text leaked into summary: %q", p.Writes[0].Summary)
 	}
 }
 

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -71,7 +71,7 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	55: {55, "000055_add_search_projection_index_family_budget.sql", "501846cc12b93c78a90791b5460adccbbcad48fa1ac18e138077dc64d27eb1b5", MigrationConstantInPlace},
 	// 56 only drops and recreates two body-derivation insert triggers (no data scan).
 	56: {56, "000056_codec_aware_body_derivations_on_insert.sql", "266a02e9be0509b3067050319f4d5654c0623034f0ed4c18920e6b0ff8ae7f32", MigrationConstantInPlace},
-	57: {57, "000057_add_search_projection_exclusions.sql", "39b49676db4b2e101e21eb0b37795bd7ce9418ea113333a68bae67bc19583045", MigrationConstantInPlace},
+	57: {57, "000057_add_search_projection_exclusions.sql", "8d7c63f873ef1d0358078a03a3704e8ae95615035d6521f466f23aba94283435", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -71,6 +71,7 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	55: {55, "000055_add_search_projection_index_family_budget.sql", "501846cc12b93c78a90791b5460adccbbcad48fa1ac18e138077dc64d27eb1b5", MigrationConstantInPlace},
 	// 56 only drops and recreates two body-derivation insert triggers (no data scan).
 	56: {56, "000056_codec_aware_body_derivations_on_insert.sql", "266a02e9be0509b3067050319f4d5654c0623034f0ed4c18920e6b0ff8ae7f32", MigrationConstantInPlace},
+	57: {57, "000057_add_search_projection_exclusions.sql", "39b49676db4b2e101e21eb0b37795bd7ce9418ea113333a68bae67bc19583045", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 56 || len(plan.Pending) != 22 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 57 || len(plan.Pending) != 23 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -54,6 +54,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		54: MigrationConstantInPlace,
 		55: MigrationConstantInPlace,
 		56: MigrationConstantInPlace,
+		57: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 56 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 57 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/search_projection_catchup.go
+++ b/infrastructure/sqlite/search_projection_catchup.go
@@ -73,6 +73,7 @@ var searchProjectionObjects = []string{
 	"literal_search_projection_state",
 	"search_projection_command_aggregates",
 	"search_projection_generation_lifecycle",
+	"search_projection_exclusions",
 	"search_projection_inventory_compat",
 	"search_projection_inventory_state",
 	"search_projection_recent_documents",

--- a/infrastructure/sqlite/search_projection_exclusion_status.go
+++ b/infrastructure/sqlite/search_projection_exclusion_status.go
@@ -17,12 +17,13 @@ const searchProjectionExclusionReportLimit = 20
 
 func measureSearchProjectionExclusions(ctx context.Context, db *sql.DB, status *apptypes.SearchProjectionStatus) error {
 	var generation string
-	if err := db.QueryRowContext(ctx, `SELECT COALESCE(active_generation_id,'') FROM search_projection_state WHERE singleton=1`).Scan(&generation); err != nil {
-		return xerrors.Errorf("read active projection generation for exclusions: %w", err)
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(generation_id,'') FROM search_projection_state WHERE singleton=1`).Scan(&generation); err != nil {
+		return xerrors.Errorf("read projection generation for exclusions: %w", err)
 	}
 	if generation == "" {
 		return nil
 	}
+	status.ExclusionGenerationID = generation
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM search_projection_exclusions WHERE generation_id=?`, generation).Scan(&status.ExclusionCount); err != nil {
 		return xerrors.Errorf("count search projection exclusions: %w", err)
 	}

--- a/infrastructure/sqlite/search_projection_exclusion_status.go
+++ b/infrastructure/sqlite/search_projection_exclusion_status.go
@@ -1,0 +1,41 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+const searchProjectionExclusionReportLimit = 20
+
+func measureSearchProjectionExclusions(ctx context.Context, db *sql.DB, status *apptypes.SearchProjectionStatus) error {
+	var generation string
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(active_generation_id,'') FROM search_projection_state WHERE singleton=1`).Scan(&generation); err != nil {
+		return xerrors.Errorf("read active projection generation for exclusions: %w", err)
+	}
+	if generation == "" {
+		return nil
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM search_projection_exclusions WHERE generation_id=?`, generation).Scan(&status.ExclusionCount); err != nil {
+		return xerrors.Errorf("count search projection exclusions: %w", err)
+	}
+	rows, err := db.QueryContext(ctx, `SELECT source_sequence,event_id,class,source_bytes,byte_limit FROM search_projection_exclusions WHERE generation_id=? ORDER BY source_sequence LIMIT ?`, generation, searchProjectionExclusionReportLimit)
+	if err != nil {
+		return xerrors.Errorf("query search projection exclusions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var exclusion apptypes.SearchProjectionExclusion
+		if err := rows.Scan(&exclusion.Sequence, &exclusion.EventID, &exclusion.Class, &exclusion.SourceBytes, &exclusion.ByteLimit); err != nil {
+			return xerrors.Errorf("scan search projection exclusion: %w", err)
+		}
+		status.Exclusions = append(status.Exclusions, exclusion)
+	}
+	if err := rows.Err(); err != nil {
+		return xerrors.Errorf("iterate search projection exclusions: %w", err)
+	}
+	return nil
+}

--- a/infrastructure/sqlite/search_projection_exclusion_status.go
+++ b/infrastructure/sqlite/search_projection_exclusion_status.go
@@ -3,11 +3,15 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 )
+
+//go:embed sql/select_search_projection_exclusions.sql
+var selectSearchProjectionExclusionsSQL string
 
 const searchProjectionExclusionReportLimit = 20
 
@@ -22,14 +26,14 @@ func measureSearchProjectionExclusions(ctx context.Context, db *sql.DB, status *
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM search_projection_exclusions WHERE generation_id=?`, generation).Scan(&status.ExclusionCount); err != nil {
 		return xerrors.Errorf("count search projection exclusions: %w", err)
 	}
-	rows, err := db.QueryContext(ctx, `SELECT source_sequence,event_id,class,source_bytes,byte_limit FROM search_projection_exclusions WHERE generation_id=? ORDER BY source_sequence LIMIT ?`, generation, searchProjectionExclusionReportLimit)
+	rows, err := db.QueryContext(ctx, selectSearchProjectionExclusionsSQL, generation, searchProjectionExclusionReportLimit)
 	if err != nil {
 		return xerrors.Errorf("query search projection exclusions: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var exclusion apptypes.SearchProjectionExclusion
-		if err := rows.Scan(&exclusion.Sequence, &exclusion.EventID, &exclusion.Class, &exclusion.SourceBytes, &exclusion.ByteLimit); err != nil {
+		if err := rows.Scan(&exclusion.Sequence, &exclusion.EventID, &exclusion.Class, &exclusion.MeasuredBytes, &exclusion.ByteLimit); err != nil {
 			return xerrors.Errorf("scan search projection exclusion: %w", err)
 		}
 		status.Exclusions = append(status.Exclusions, exclusion)

--- a/infrastructure/sqlite/search_projection_exclusions.go
+++ b/infrastructure/sqlite/search_projection_exclusions.go
@@ -1,0 +1,19 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// insertSearchProjectionExclusion keeps the exclusion write beside the
+// checkpoint mutation performed by ApplyBatch; the caller owns the transaction.
+func insertSearchProjectionExclusion(ctx context.Context, tx *sql.Tx, generation string, exclusion apptypes.ProjectionExclusion) error {
+	if _, err := tx.ExecContext(ctx, `INSERT INTO search_projection_exclusions(generation_id,source_sequence,event_id,class,source_bytes,byte_limit) VALUES(?,?,?,?,?,?)`, generation, exclusion.Sequence, exclusion.EventID, exclusion.Class, exclusion.SourceBytes, exclusion.ByteLimit); err != nil {
+		return xerrors.Errorf("insert search projection exclusion: %w", err)
+	}
+	return nil
+}

--- a/infrastructure/sqlite/search_projection_exclusions.go
+++ b/infrastructure/sqlite/search_projection_exclusions.go
@@ -3,16 +3,20 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 )
 
+//go:embed sql/insert_search_projection_exclusion.sql
+var insertSearchProjectionExclusionSQL string
+
 // insertSearchProjectionExclusion keeps the exclusion write beside the
 // checkpoint mutation performed by ApplyBatch; the caller owns the transaction.
 func insertSearchProjectionExclusion(ctx context.Context, tx *sql.Tx, generation string, exclusion apptypes.ProjectionExclusion) error {
-	if _, err := tx.ExecContext(ctx, `INSERT INTO search_projection_exclusions(generation_id,source_sequence,event_id,class,source_bytes,byte_limit) VALUES(?,?,?,?,?,?)`, generation, exclusion.Sequence, exclusion.EventID, exclusion.Class, exclusion.SourceBytes, exclusion.ByteLimit); err != nil {
+	if _, err := tx.ExecContext(ctx, insertSearchProjectionExclusionSQL, generation, exclusion.Sequence, exclusion.EventID, exclusion.Class, exclusion.MeasuredBytes, exclusion.ByteLimit); err != nil {
 		return xerrors.Errorf("insert search projection exclusion: %w", err)
 	}
 	return nil

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -603,12 +603,17 @@ func (d *Database) SelectSnapshot(ctx context.Context, b apptypes.SearchProjecti
 		if e = rows.Scan(&x.Sequence, &x.EventID, &x.SessionID, &x.CreatedAt, &avail, &x.Deleted, &x.StoredBytes, &x.DecodedBytes); e != nil {
 			return out, e
 		}
-		admitted, admissionErr := selection.AdmitSource(b, x.StoredBytes, x.DecodedBytes)
+		disposition, admissionErr := selection.AdmitSource(b, x.StoredBytes, x.DecodedBytes)
 		if admissionErr != nil {
 			return out, admissionErr
 		}
-		if !admitted {
+		if disposition == "" {
 			break
+		}
+		x.Disposition = disposition
+		if disposition == apptypes.ProjectionDispositionExcluded {
+			out.Documents = append(out.Documents, x)
+			continue
 		}
 		if !x.Deleted {
 			var body string
@@ -644,6 +649,9 @@ func (d *Database) SelectSnapshot(ctx context.Context, b apptypes.SearchProjecti
 			_ = db.QueryRowContext(ctx, `SELECT COALESCE(failed,0) FROM command_audits WHERE event_id=?`, x.EventID).Scan(&x.FailureCount)
 			_ = db.QueryRowContext(ctx, `SELECT summary_text FROM search_projection_session_summaries WHERE generation_id=? AND session_id=?`, out.Generation.GenerationID, x.SessionID).Scan(&x.PreviousSummary)
 		}
+		if x.Deleted {
+			x.Disposition = apptypes.ProjectionDispositionDeleted
+		}
 		out.Documents = append(out.Documents, x)
 	}
 	if e = rows.Err(); e != nil {
@@ -672,11 +680,11 @@ func selectProjectionCleanup(ctx context.Context, db *sql.DB, out apptypes.Proje
  ORDER BY created_at_norm,event_id,document_id LIMIT ?`
 		args = []any{out.Generation.GenerationID, projectionCutoff(now.Add(-b.RecentAge)), ceiling, b.Rows + 1}
 	} else if out.CleanupAll {
-		q = `SELECT 'recent',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(created_at_norm AS BLOB))+2*length(CAST(body_text AS BLOB))+32 FROM search_projection_recent_documents UNION ALL SELECT 'summary',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(summary_text AS BLOB))+24 FROM search_projection_session_summaries UNION ALL SELECT 'aggregate',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+16 FROM search_projection_command_aggregates UNION ALL SELECT 'keyword',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(keyword AS BLOB))+16 FROM search_projection_session_keywords UNION ALL SELECT 'fingerprint',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16 FROM literal_search_fingerprints LIMIT ?`
+		q = `SELECT 'recent',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(created_at_norm AS BLOB))+2*length(CAST(body_text AS BLOB))+32 FROM search_projection_recent_documents UNION ALL SELECT 'summary',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(summary_text AS BLOB))+24 FROM search_projection_session_summaries UNION ALL SELECT 'aggregate',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+16 FROM search_projection_command_aggregates UNION ALL SELECT 'keyword',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(keyword AS BLOB))+16 FROM search_projection_session_keywords UNION ALL SELECT 'fingerprint',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16 FROM literal_search_fingerprints UNION ALL SELECT 'exclusion',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(class AS BLOB))+32 FROM search_projection_exclusions LIMIT ?`
 		args = []any{b.Rows + 1}
 	} else {
-		q = `SELECT 'recent',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(created_at_norm AS BLOB))+2*length(CAST(body_text AS BLOB))+32 FROM search_projection_recent_documents WHERE generation_id<>? UNION ALL SELECT 'summary',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(summary_text AS BLOB))+24 FROM search_projection_session_summaries WHERE generation_id<>? UNION ALL SELECT 'aggregate',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+16 FROM search_projection_command_aggregates WHERE generation_id<>? UNION ALL SELECT 'keyword',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(keyword AS BLOB))+16 FROM search_projection_session_keywords WHERE generation_id<>? UNION ALL SELECT 'fingerprint',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16 FROM literal_search_fingerprints WHERE generation_id<>? LIMIT ?`
-		args = []any{out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, b.Rows + 1}
+		q = `SELECT 'recent',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(created_at_norm AS BLOB))+2*length(CAST(body_text AS BLOB))+32 FROM search_projection_recent_documents WHERE generation_id<>? UNION ALL SELECT 'summary',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(summary_text AS BLOB))+24 FROM search_projection_session_summaries WHERE generation_id<>? UNION ALL SELECT 'aggregate',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+16 FROM search_projection_command_aggregates WHERE generation_id<>? UNION ALL SELECT 'keyword',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(keyword AS BLOB))+16 FROM search_projection_session_keywords WHERE generation_id<>? UNION ALL SELECT 'fingerprint',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16 FROM literal_search_fingerprints WHERE generation_id<>? UNION ALL SELECT 'exclusion',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(class AS BLOB))+32 FROM search_projection_exclusions WHERE generation_id<>? LIMIT ?`
+		args = []any{out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, b.Rows + 1}
 	}
 	rows, e := db.QueryContext(ctx, q, args...)
 	if e != nil {
@@ -843,6 +851,12 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 		}
 		return out, &apptypes.SearchProjectionDriftError{}
 	}
+	for _, exclusion := range p.Exclusions {
+		if e = insertSearchProjectionExclusion(lockCtx, tx, p.GenerationID, exclusion); e != nil {
+			return out, e
+		}
+		out.Selected++
+	}
 	for _, w := range p.Writes {
 		d := w.Document
 		if !d.Deleted {
@@ -891,6 +905,8 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 			table = "search_projection_session_keywords"
 		case "fingerprint":
 			table = "literal_search_fingerprints"
+		case "exclusion":
+			table = "search_projection_exclusions"
 		default:
 			continue
 		}
@@ -1043,6 +1059,9 @@ func (d *Database) AbandonSearchProjection(ctx context.Context, now time.Time) (
 	if _, e = tx.ExecContext(ctx, `UPDATE literal_search_projection_state SET state='stale',updated_at=? WHERE singleton=1 AND generation_id=?`, formatTimestamp(now), generation); e != nil {
 		return out, e
 	}
+	if _, e = tx.ExecContext(ctx, `DELETE FROM search_projection_exclusions WHERE generation_id=?`, generation); e != nil {
+		return out, e
+	}
 	return out, tx.Commit()
 }
 
@@ -1086,6 +1105,9 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 		return s, e
 	}
 	if e = db.QueryRowContext(ctx, `SELECT COUNT(*),COALESCE(SUM(length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16),0) FROM literal_search_fingerprints WHERE generation_id=(SELECT active_generation_id FROM search_projection_state)`).Scan(&s.FingerprintRows, &s.FingerprintLogicalBytes); e != nil {
+		return s, e
+	}
+	if e = measureSearchProjectionExclusions(ctx, db, &s); e != nil {
 		return s, e
 	}
 	if e = db.QueryRowContext(ctx, selectSearchProjectionFTSLogicalBytesSQL).Scan(&s.FTSLogicalBytes); e != nil {

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -607,7 +607,7 @@ func (d *Database) SelectSnapshot(ctx context.Context, b apptypes.SearchProjecti
 		if admissionErr != nil {
 			return out, admissionErr
 		}
-		if disposition == "" {
+		if disposition == apptypes.ProjectionDispositionBatchFull {
 			break
 		}
 		x.Disposition = disposition

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -920,7 +920,7 @@ func TestConcurrentApplyBatchFencesSameCheckpoint(t *testing.T) {
 	}
 }
 
-func TestSearchProjectionOversizeRowIsExcludedAndLargerGenerationCanStart(t *testing.T) {
+func TestSearchProjectionOversizeRowIsExcludedAndGenerationCompletes(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "store.db")
 	migrations, _ := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -484,6 +484,9 @@ func TestSearchProjectionAbandonIsIdempotentAndRestartKeepsCanonicalHistory(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, err = db.Exec(`INSERT INTO search_projection_exclusions(generation_id,source_sequence,event_id,class,measured_bytes,byte_limit) VALUES(?,?,?,?,?,?)`, first.GenerationID, 1, "canonical", "stored_bytes", 2, 1); err != nil {
+		t.Fatal(err)
+	}
 	abandoned, err := store.AbandonSearchProjection(ctx, time.Now())
 	if err != nil {
 		t.Fatal(err)
@@ -502,6 +505,10 @@ func TestSearchProjectionAbandonIsIdempotentAndRestartKeepsCanonicalHistory(t *t
 	}
 	if active.Valid || count != 1 {
 		t.Fatalf("active=%v canonical=%d", active, count)
+	}
+	var exclusions int
+	if err = db.QueryRow(`SELECT COUNT(*) FROM search_projection_exclusions WHERE generation_id=?`, first.GenerationID).Scan(&exclusions); err != nil || exclusions != 0 {
+		t.Fatalf("abandoned exclusions=%d err=%v, want 0", exclusions, err)
 	}
 	b.Rows = 2
 	second, err := store.Start(ctx, b, time.Now())
@@ -738,6 +745,10 @@ func TestSearchProjectionUnavailableBodyAndOversizeArePublicBehavior(t *testing.
 	if err != nil || status.ExclusionCount != 1 || len(status.Exclusions) != 1 || status.Exclusions[0].EventID != "hidden" {
 		t.Fatalf("status=%+v err=%v, want one hidden exclusion", status, err)
 	}
+	var fingerprints int
+	if err = db.QueryRow(`SELECT COUNT(*) FROM literal_search_fingerprints WHERE event_id='hidden'`).Scan(&fingerprints); err != nil || fingerprints != 0 {
+		t.Fatalf("excluded fingerprints=%d err=%v, want none", fingerprints, err)
+	}
 }
 
 func TestSearchProjectionResumeSurvivesVacuumAndExcludesThinking(t *testing.T) {
@@ -909,7 +920,7 @@ func TestConcurrentApplyBatchFencesSameCheckpoint(t *testing.T) {
 	}
 }
 
-func TestSearchProjectionOversizeFailureAllowsLargerGeneration(t *testing.T) {
+func TestSearchProjectionOversizeRowIsExcludedAndLargerGenerationCanStart(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "store.db")
 	migrations, _ := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
@@ -948,7 +959,7 @@ func TestSearchProjectionOversizeFailureAllowsLargerGeneration(t *testing.T) {
 	}
 }
 
-func TestSearchProjectionWritePlusCheckpointOversizeIsRecoverable(t *testing.T) {
+func TestSearchProjectionWritePlusCheckpointOversizeIsExcluded(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "store.db")
 	migrations, _ := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
@@ -963,26 +974,21 @@ func TestSearchProjectionWritePlusCheckpointOversizeIsRecoverable(t *testing.T) 
 		t.Fatal(err)
 	}
 	b := projectionBudget()
-	b.WriteBytes = 250
+	b.WriteBytes = 180
 	if _, err := store.Start(ctx, b, now); err != nil {
 		t.Fatal(err)
 	}
-	_, err := resumeProjection(ctx, store, b, now)
-	var oversized *apptypes.SearchProjectionOversizeError
-	if !errors.As(err, &oversized) || oversized.Bytes <= b.WriteBytes {
-		t.Fatalf("error=%T %+v", err, oversized)
+	progress, err := resumeProjection(ctx, store, b, now)
+	if err != nil || progress.Selected != 1 || progress.Written != 0 {
+		t.Fatalf("progress=%+v err=%v, want one exclusion", progress, err)
 	}
 	var state string
-	if err = db.QueryRow(`SELECT state FROM search_projection_state`).Scan(&state); err != nil || state != "failed" {
+	if err = db.QueryRow(`SELECT state FROM search_projection_state`).Scan(&state); err != nil || state == "failed" {
 		t.Fatalf("state=%q err=%v", state, err)
 	}
-	b.WriteBytes = 1000
-	if _, err = store.Start(ctx, b, now); err != nil {
-		t.Fatalf("larger start: %v", err)
-	}
-	p, err := resumeProjection(ctx, store, b, now)
-	if err != nil || p.Written != 1 {
-		t.Fatalf("larger resume=%+v err=%v", p, err)
+	var exclusions int
+	if err = db.QueryRow(`SELECT COUNT(*) FROM search_projection_exclusions WHERE event_id='e' AND class='write_bytes'`).Scan(&exclusions); err != nil || exclusions != 1 {
+		t.Fatalf("exclusions=%d err=%v", exclusions, err)
 	}
 }
 

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -695,8 +695,14 @@ func TestSearchProjectionUnavailableBodyAndOversizeArePublicBehavior(t *testing.
 	if _, err = store.Start(ctx, b, now); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = resumeProjection(ctx, store, b, now); err != nil {
-		t.Fatal(err)
+	for i := 0; i < 8; i++ {
+		progress, resumeErr := resumeProjection(ctx, store, b, now)
+		if resumeErr != nil {
+			t.Fatal(resumeErr)
+		}
+		if progress.Completed {
+			break
+		}
 	}
 	for i := 0; i < 4; i++ {
 		status, statusErr := store.SearchProjectionStatus(ctx)
@@ -719,10 +725,18 @@ func TestSearchProjectionUnavailableBodyAndOversizeArePublicBehavior(t *testing.
 	if _, err = store.Start(ctx, b, now); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resumeProjection(ctx, store, b, now)
-	var oversized *apptypes.SearchProjectionOversizeError
-	if !errors.As(err, &oversized) {
-		t.Fatalf("error=%T %v", err, err)
+	for i := 0; i < 8; i++ {
+		progress, resumeErr := resumeProjection(ctx, store, b, now)
+		if resumeErr != nil {
+			t.Fatal(resumeErr)
+		}
+		if progress.Completed {
+			break
+		}
+	}
+	status, err := store.SearchProjectionStatus(ctx)
+	if err != nil || status.ExclusionCount != 1 || len(status.Exclusions) != 1 || status.Exclusions[0].EventID != "hidden" {
+		t.Fatalf("status=%+v err=%v, want one hidden exclusion", status, err)
 	}
 }
 
@@ -914,18 +928,23 @@ func TestSearchProjectionOversizeFailureAllowsLargerGeneration(t *testing.T) {
 	if _, err := store.Start(ctx, b, now); err != nil {
 		t.Fatal(err)
 	}
-	_, err := resumeProjection(ctx, store, b, now)
-	var oversized *apptypes.SearchProjectionOversizeError
-	if !errors.As(err, &oversized) {
-		t.Fatalf("error=%T %v", err, err)
+	for i := 0; i < 4; i++ {
+		progress, resumeErr := resumeProjection(ctx, store, b, now)
+		if resumeErr != nil {
+			t.Fatal(resumeErr)
+		}
+		if progress.Completed {
+			break
+		}
 	}
+	var err error
 	var state string
-	if err = db.QueryRow(`SELECT state FROM search_projection_state`).Scan(&state); err != nil || state != "failed" {
+	if err = db.QueryRow(`SELECT state FROM search_projection_state`).Scan(&state); err != nil || state != "complete" {
 		t.Fatalf("state=%q err=%v", state, err)
 	}
-	b.StoredBytes = 1 << 20
-	if _, err = store.Start(ctx, b, now); err != nil {
-		t.Fatalf("larger start: %v", err)
+	var exclusions int
+	if err = db.QueryRow(`SELECT COUNT(*) FROM search_projection_exclusions WHERE event_id='large'`).Scan(&exclusions); err != nil || exclusions != 1 {
+		t.Fatalf("exclusions=%d err=%v", exclusions, err)
 	}
 }
 

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -751,6 +751,47 @@ func TestSearchProjectionUnavailableBodyAndOversizeArePublicBehavior(t *testing.
 	}
 }
 
+func TestSearchProjectionStatusReportsRebuildingGenerationExclusions(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	migrations, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewDatabase(path, migrations)
+	if err = store.initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err = db.Exec(`
+		INSERT INTO search_projection_generation_lifecycle(generation_id,state,config_hash,source_revision,high_water)
+		VALUES('generation-a','complete','hash-a',0,0),('generation-b','rebuilding','hash-b',0,1);
+		UPDATE search_projection_state
+		SET generation_id='generation-b',active_generation_id='generation-a',state='rebuilding',phase='source',config_hash='hash-b'
+		WHERE singleton=1;
+		INSERT INTO search_projection_exclusions(generation_id,source_sequence,event_id,class,measured_bytes,byte_limit)
+		VALUES('generation-a',1,'old-event','stored_bytes',10,1),('generation-b',2,'new-event','write_bytes',200,100);`); err != nil {
+		t.Fatal(err)
+	}
+	status, err := store.SearchProjectionStatus(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff("generation-b", status.ExclusionGenerationID); diff != "" {
+		t.Fatalf("exclusion generation (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(int64(1), status.ExclusionCount); diff != "" {
+		t.Fatalf("exclusion count (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("new-event", status.Exclusions[0].EventID); diff != "" {
+		t.Fatalf("exclusion event (-want +got):\n%s", diff)
+	}
+}
+
 func TestSearchProjectionResumeSurvivesVacuumAndExcludesThinking(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "store.db")

--- a/infrastructure/sqlite/sql/insert_search_projection_exclusion.sql
+++ b/infrastructure/sqlite/sql/insert_search_projection_exclusion.sql
@@ -1,0 +1,2 @@
+INSERT INTO search_projection_exclusions(generation_id,source_sequence,event_id,class,measured_bytes,byte_limit)
+VALUES(?,?,?,?,?,?)

--- a/infrastructure/sqlite/sql/select_search_projection_exclusions.sql
+++ b/infrastructure/sqlite/sql/select_search_projection_exclusions.sql
@@ -1,0 +1,5 @@
+SELECT source_sequence,event_id,class,measured_bytes,byte_limit
+FROM search_projection_exclusions
+WHERE generation_id=?
+ORDER BY source_sequence
+LIMIT ?

--- a/schema/sqlite/migrations/000057_add_search_projection_exclusions.sql
+++ b/schema/sqlite/migrations/000057_add_search_projection_exclusions.sql
@@ -3,7 +3,7 @@ CREATE TABLE search_projection_exclusions(
  source_sequence INTEGER NOT NULL,
  event_id TEXT NOT NULL,
  class TEXT NOT NULL CHECK(class IN('stored_bytes','decoded_bytes','write_bytes')),
- source_bytes INTEGER NOT NULL,
+ measured_bytes INTEGER NOT NULL,
  byte_limit INTEGER NOT NULL,
  PRIMARY KEY(generation_id,source_sequence)
 );

--- a/schema/sqlite/migrations/000057_add_search_projection_exclusions.sql
+++ b/schema/sqlite/migrations/000057_add_search_projection_exclusions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE search_projection_exclusions(
+ generation_id TEXT NOT NULL,
+ source_sequence INTEGER NOT NULL,
+ event_id TEXT NOT NULL,
+ class TEXT NOT NULL CHECK(class IN('stored_bytes','decoded_bytes','write_bytes')),
+ source_bytes INTEGER NOT NULL,
+ byte_limit INTEGER NOT NULL,
+ PRIMARY KEY(generation_id,source_sequence)
+);
+CREATE INDEX idx_search_projection_exclusions_event ON search_projection_exclusions(generation_id,event_id);


### PR DESCRIPTION
Closes #1794

## The defect

A single event over a **per-row** budget failed the entire generation. On the 7 GB rehearsal store the walk reached 36.1% and stopped on two transcripts of exactly 8,388,646 bytes — 38 bytes over the 8 MiB `DecodedBytes` default, both already truncated at 8 MiB by the host. No batch size helps: the unit is one row. Recovery meant `abort` + `start` with a wider budget, discarding everything built, and the next 8 MiB transcript hits the same wall at the new number.

## The design — skip, record, advance

Decided after a design consultation with gpt-5.6-sol on the alternative (index a truncated prefix). Truncation was rejected because it breaks three things in this codebase:

- `projectionTokens` would emit tokens cut mid-word that do not exist in the source, and session keyword hits have **no canonical re-verification**, so a truncated row produces false positives nothing catches.
- A partial fingerprint set reads as a complete one. `literal_search_fingerprints` is fail-open only when a row is *absent*; rows present and non-matching are dropped before canonical verification.
- The benefit was illusory: normal event search does not treat the recent FTS as its authority — it walks `events` and verifies candidates against the canonical body. An excluded row stays in `search_projection_source_sequence` and remains findable. Excluding it means "do not build an incomplete accelerator entry", not "remove the row from search".

So the row is detected at metadata admission **before hydration**, skipped, recorded, and the checkpoint advances past it.

- An explicit `excluded` disposition, distinct from `deleted` — an excluded row is present and deliberately unindexed, and conflating the two would lose that in every future reader.
- No document, no summary contribution, no keywords and specifically **no fingerprint** for an excluded row.
- The exclusion record and the checkpoint advance commit in the same transaction (`search_projection_exclusions`, migration `000057`, keyed by generation and source sequence).
- Exclusions are cleaned up with their generation, by both the cleanup phase and `abort`.
- `status` reports `exclusion_count` and up to 20 named rows for the active generation, on the **measured** read only — #1798 exists because measurement leaked onto the control path.
- All three per-row classes are covered: `stored_bytes`, `decoded_bytes`, `write_bytes`. Batch-level oversize errors are unchanged; `markFailed` is still right for those.

## Review findings fixed before this PR opened

Two defects were reproduced during review of the first implementation and fixed in `4ffac7c2`:

- **A `decoded_bytes` exclusion was recorded as `stored_bytes`.** The disposition was the first disjunct of the classifier and `AdmitSource` does not say which budget tripped, so every upstream exclusion was labelled `stored_bytes` and the `decoded_bytes` branch was unreachable. A document `{stored: 5, decoded: 11}` against `{stored: 1000, decoded: 10}` produced `{class: stored_bytes, measured: 5, limit: 1000}` — a durable record asserting 5 bytes exceeded a 1000-byte limit, on exactly the row #1794 exists for. The class is now derived from the measured values, and an `excluded` row matching no class is an error rather than a silent empty document.
- **An excluded row still fed the session summary chain, which cascaded exclusions onto later rows.** The running summary map was written before the `write_bytes` check. A row of `Text: "tiny"` alone is admitted; preceded in the same session by one excluded 148-character row it measured 269 bytes against a 260 limit and was excluded too. The map is now written only where the write is accepted.

Three more, also fixed:

- The `len(p.Writes) == 0` branch of the write-bytes check was **not** dead — `LogicalWriteBytes` is seeded with the checkpoint mutation — and it was the last per-row landmine: a row fitting under `WriteBytes` alone but not with the fixed checkpoint cost still failed the generation deterministically, discarding any exclusions already planned. The per-row test now includes the fixed cost and records an exclusion; what remains is a plain batch-full `break`.
- `source_bytes` was renamed to `measured_bytes`: for the `write_bytes` class the value is a projected write size, not a source byte count. Both the migration and the JSON are unreleased, so this was free now.
- Exclusion INSERTs are charged to the ledger, so `WriteBytes` still bounds what the transaction actually mutates.

## Tests

Boundary (exactly at each limit admitted, one byte over excluded), each of the three classes with its own numbers, no summary chaining from an excluded row, no fingerprint row for an excluded row, exclusion records removed by `abort`, and the generation reaching `complete` with the oversized row recorded.

`go build ./...`, `go vet ./...`, `go tool golangci-lint run` (0 issues) and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
