### PR TITLE
fix: order sessions and rehearsal runs by normalized timestamps

### DIFF
--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -456,6 +456,50 @@ func TestDatasource_ListSummaries(t *testing.T) {
 
 }
 
+func TestDatasource_ListSummariesOrdersSubsecondStartedAtAfterWholeSecond(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		limit int
+		want  []string
+	}{
+		{name: "limited listing selects genuinely latest session", limit: 1, want: []string{"sess-b"}},
+		{name: "listing orders all selected sessions by normalized timestamp", limit: 2, want: []string{"sess-b", "sess-a"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newListSessionsFixture(t, filepath.Join(t.TempDir(), "traceary.db"), listSessionsTestMigrations())
+			ctx := context.Background()
+			if err := fixture.storeManager.Initialize(ctx); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+			for _, session := range []struct {
+				id      string
+				started time.Time
+			}{
+				{id: "sess-a", started: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+				{id: "sess-b", started: time.Date(2026, 1, 1, 0, 0, 0, 500_000_000, time.UTC)},
+			} {
+				saveTestSession(ctx, t, fixture.sessionDS, session.id, session.started, types.None[time.Time](), "codex", "workspace")
+			}
+
+			got, err := fixture.sessionDS.ListSummaries(ctx, tt.limit, 0, types.SessionID(""), types.Workspace(""), types.Client(""), types.Agent(""), "", false, types.None[time.Time](), types.None[time.Time]())
+			if err != nil {
+				t.Fatalf("ListSummaries() error = %v", err)
+			}
+			gotIDs := make([]string, 0, len(got))
+			for _, summary := range got {
+				gotIDs = append(gotIDs, summary.SessionID().String())
+			}
+			if diff := cmp.Diff(tt.want, gotIDs); diff != "" {
+				t.Fatalf("session IDs mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestDatasource_LineageOfCycleDetection(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -700,7 +700,7 @@ func (a *PayloadRehearsalAdapter) PrepareScrub(ctx context.Context, c apptypes.P
 		return nil, apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("disable scrub WAL autocheckpoint: %w", err)
 	}
 	var run, recordedFingerprint, recordedDevice, recordedInode string
-	if err = db.QueryRowContext(ctx, `SELECT run_id,target_fingerprint,target_device,target_inode FROM payload_rehearsal_runs WHERE state='completed' ORDER BY started_at DESC LIMIT 1`).Scan(&run, &recordedFingerprint, &recordedDevice, &recordedInode); err != nil {
+	if err = db.QueryRowContext(ctx, `SELECT run_id,target_fingerprint,target_device,target_inode FROM payload_rehearsal_runs WHERE state='completed' ORDER BY ts_norm(started_at) DESC, run_id DESC LIMIT 1`).Scan(&run, &recordedFingerprint, &recordedDevice, &recordedInode); err != nil {
 		return nil, apptypes.PayloadRehearsalMetrics{}, errors.New("no completed rehearsal run")
 	}
 	if recordedFingerprint != id.opaque || recordedDevice != id.device || recordedInode != id.inode {
@@ -932,7 +932,7 @@ func (a *PayloadRehearsalAdapter) Rollback(ctx context.Context, c apptypes.Paylo
 	}
 	var recordedDigest, runState string
 	var activeLease int
-	stateErr := currentDB.QueryRowContext(ctx, `SELECT rollback_digest,state,lease_token IS NOT NULL FROM payload_rehearsal_runs ORDER BY started_at DESC LIMIT 1`).Scan(&recordedDigest, &runState, &activeLease)
+	stateErr := currentDB.QueryRowContext(ctx, `SELECT rollback_digest,state,lease_token IS NOT NULL FROM payload_rehearsal_runs ORDER BY ts_norm(started_at) DESC, run_id DESC LIMIT 1`).Scan(&recordedDigest, &runState, &activeLease)
 	_ = currentDB.Close()
 	safeState := runState == "paused" || runState == "completed" || runState == "scrubbed" || runState == "failed"
 	if stateErr != nil || !safeState || activeLease != 0 || recordedDigest != digest {

--- a/infrastructure/sqlite/payload_rehearsal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/xerrors"
 	_ "modernc.org/sqlite"
 
 	apptypes "github.com/duck8823/traceary/application/types"
@@ -328,6 +329,93 @@ func TestPayloadRehearsalDeterministicStopResumeScrubRollback(t *testing.T) {
 	rolledBack, err := u.Rollback(ctx, config)
 	if err != nil || !rolledBack.RollbackVerified {
 		t.Fatalf("rollback=%+v err=%v", rolledBack, err)
+	}
+}
+
+func TestPayloadRehearsalSelectsLatestRunByNormalizedStartedAt(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  string
+		invoke func(context.Context, *infra.PayloadRehearsalAdapter, apptypes.PayloadRehearsalConfig) error
+	}{
+		{
+			name:  "completed-only scrub query",
+			state: "completed",
+			invoke: func(ctx context.Context, adapter *infra.PayloadRehearsalAdapter, config apptypes.PayloadRehearsalConfig) error {
+				_, err := adapter.Scrub(ctx, config)
+				if err != nil {
+					return xerrors.Errorf("Scrub: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			name:  "unconditional rollback query",
+			state: "failed",
+			invoke: func(ctx context.Context, adapter *infra.PayloadRehearsalAdapter, config apptypes.PayloadRehearsalConfig) error {
+				_, err := adapter.Rollback(ctx, config)
+				if err != nil {
+					return xerrors.Errorf("Rollback: %w", err)
+				}
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			dir, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			live, target, backup := filepath.Join(dir, "live.db"), filepath.Join(dir, "target.db"), filepath.Join(dir, "backup.db")
+			migrations, err := sqliteschema.Migrations()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = infra.NewStoreManagementDatasource(infra.NewDatabase(live, migrations)).Initialize(ctx); err != nil {
+				t.Fatal(err)
+			}
+			db, err := sql.Open("sqlite", live)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = db.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at) VALUES('event-1','prompt','test','session-1','body','2026-08-01T00:00:00Z')`); err != nil {
+				t.Fatal(err)
+			}
+			if err = db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			copyTestFile(t, live, target)
+			adapter := newRehearsalAdapter(t, migrations, live)
+			config := rehearsalTestConfig(target, live, backup)
+			result, err := adapter.Run(ctx, config, apptypes.PayloadRehearsalRunCommand{Mode: apptypes.PayloadRehearsalStart})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			db, err = sql.Open("sqlite", target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = db.Exec(`UPDATE payload_rehearsal_runs SET started_at='2026-01-01T00:00:00.5Z',updated_at='2026-01-01T00:00:00.5Z' WHERE run_id=?`, result.RunID); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = db.Exec(`INSERT INTO payload_rehearsal_runs(run_id,target_fingerprint,config_hash,state,event_high_water,audit_high_water,started_at,updated_at,rollback_digest,target_device,target_inode) VALUES('lexical-winner','wrong-fingerprint','','` + tt.state + `','','','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z','wrong-digest','wrong-device','wrong-inode')`); err != nil {
+				t.Fatal(err)
+			}
+			if err = db.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			gotErr := ""
+			if err = tt.invoke(ctx, adapter, config); err != nil {
+				gotErr = err.Error()
+			}
+			if diff := cmp.Diff("", gotErr); diff != "" {
+				t.Fatalf("latest run was not selected by normalized timestamp (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -15,7 +15,7 @@ WITH
           ))
       AND (? = '' OR ts_norm(s.started_at) >= ts_norm(?))
       AND (? = '' OR ts_norm(s.started_at) < ts_norm(?))
-    ORDER BY s.started_at DESC
+    ORDER BY ts_norm(s.started_at) DESC, s.session_id DESC
     LIMIT ? OFFSET ?
   ),
   event_agg AS (
@@ -78,4 +78,4 @@ LEFT JOIN event_agg agg ON agg.session_id = s.session_id
 LEFT JOIN latest_events latest ON latest.session_id = s.session_id
 LEFT JOIN events latest_body ON latest_body.id = latest.latest_event_id
 LEFT JOIN command_audits latest_audit ON latest_audit.event_id = latest.latest_event_id
-ORDER BY s.started_at DESC
+ORDER BY ts_norm(s.started_at) DESC, s.session_id DESC


### PR DESCRIPTION
`started_at` is written as RFC3339Nano, which is variable width, and `'.'` (0x2E) sorts below `'Z'` (0x5A). A lexical `ORDER BY` therefore puts the *later* timestamp last — the #1185 hazard, still reachable in four places.

| site | consequence |
|---|---|
| `sql/list_sessions.sql:18` (inner CTE, paged) | `list sessions --limit 1` returns the older session and drops the newer one from the page |
| `sql/list_sessions.sql:78` (outer ordering) | the returned page is ordered wrongly even when it contains the right rows |
| `payload_rehearsal.go:685` | "latest completed run" selects the wrong run to scrub against |
| `payload_rehearsal.go:917` | "latest run" selects the wrong run to roll back against |

Lines 16-17 of the same statement already routed the `from`/`to` filters through `ts_norm()`, so the inconsistency sat inside one query.

Each site gains an id tie-break (`session_id` / `run_id`) so the order is total, matching the convention in `search_projection_session_query.go`.

No persisted `started_at_norm` column: `sessions` has none (unlike `events`, migration 031), and adding one is a schema change that should be measured before it is chosen. A function call in `ORDER BY` is the accepted cost here.

## Verification

Red-before-green, verified independently of the implementer by reverting each site in turn:

- revert **both** `list_sessions.sql` sites → `limit 1` returns `sess-a` where `sess-b` (`…00:00:00.5Z`) is genuinely later:
  ```
  session IDs mismatch (-want +got):
  - "sess-b"
  + "sess-a"
  ```
- revert **only** the outer `ORDER BY` → the `limit 2` case fails alone, with the page returned in inverted order. So the two sites are covered independently rather than by one test that happens to pass through both.

`go build ./...`, `go test ./infrastructure/sqlite/`, `go tool golangci-lint run` (0 issues) all clean on the final tree.

Implementation: gpt-5.6-luna. Review and verification: Claude Opus 5.

Closes #1729
