### PR TITLE
docs: state --index-family-bytes as a target, not a ceiling

### DIFF
--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -10,8 +10,12 @@ import (
 // family — documents, trigram index, session tier and literal fingerprints —
 // measured as active b-tree allocation, not source text.
 //
-// 1464 MiB is what the 4 GiB store gate (#1620) leaves once every other Wave 3
-// removal is applied; it is derived, not chosen.
+// It is a *target*, not a cap. Only the recent tier can be evicted, so only it
+// is enforced: the corpus-proportional tiers (session summaries and keywords,
+// literal fingerprints) are measured and subtracted from this figure as a
+// reserve, and the remainder becomes the recent tier's source-text ceiling. The
+// family total is re-measured when a generation completes and recorded through
+// index_family_within_budget — reported, not guaranteed in advance.
 //
 // What it buys is a *variable* window, not a fixed one. Trigram measures 2.16x
 // the source text, so this is roughly 0.66 GiB of indexable text. Measured
@@ -42,10 +46,12 @@ type SearchProjectionBudget struct {
 	// physical database, page, journal, or WAL growth bound.
 	WriteBytes int64
 	RecentAge  time.Duration
-	// IndexFamilyBytes is the operator-facing ceiling on physical bytes of
+	// IndexFamilyBytes is the operator-facing budget for physical bytes of
 	// the bounded search index family (active b-tree allocation via dbstat),
-	// not source text. Eviction compares against the derived source ceiling,
-	// never against this figure directly.
+	// not source text. It is a target rather than a cap: eviction compares
+	// against the source ceiling derived from it after the non-recent reserve
+	// is subtracted, never against this figure directly, and the family total
+	// is reported at completion rather than enforced.
 	IndexFamilyBytes int64
 }
 

--- a/presentation/cli/store_search_projection.go
+++ b/presentation/cli/store_search_projection.go
@@ -97,9 +97,11 @@ func (c *RootCLI) newStoreSearchProjectionRunCommand(name string, start bool) *c
 	cmd.Flags().DurationVar(&timeAge, "recent-age", 30*24*time.Hour, "recent projection age")
 	// Index-family budget: physical bytes of documents, trigram index, session
 	// tier and literal fingerprints (active b-tree allocation), not source text.
-	// 1464 MiB is what the 4 GiB store gate leaves; trigram ~2.16x yields a
-	// variable recent window (~1.5–2 weeks at the median rate).
-	cmd.Flags().Int64Var(&recent, "index-family-bytes", apptypes.DefaultSearchProjectionIndexFamilyBytes, "physical byte ceiling for the bounded search index family (not source text)")
+	// It is a target, not a cap. The corpus-proportional tiers are subtracted
+	// from it as a reserve and the remainder becomes the recent tier's evictable
+	// ceiling; only that remainder is enforced. The family total is re-measured
+	// at completion and reported through index_family_within_budget.
+	cmd.Flags().Int64Var(&recent, "index-family-bytes", apptypes.DefaultSearchProjectionIndexFamilyBytes, "physical byte budget for the bounded search index family, in index bytes rather than source text; enforced by evicting the recent tier and reported at completion")
 	if !start {
 		cmd.Flags().BoolVar(&untilComplete, "until-complete", false, "resume bounded batches until complete or a command bound is reached")
 		cmd.Flags().IntVar(&maxBatches, "max-batches", 100, "maximum durable batches in one command")


### PR DESCRIPTION
## Resolution: the rename is rejected; the over-promise it pointed at is real and is fixed

#1810 asked to rename `--index-family-bytes` (and `IndexFamilyBytes`, `DefaultSearchProjectionIndexFamilyBytes`, `index_family_byte_limit`, `index_family_within_budget`, and the migration-055 columns) to something recent-tier-specific — `--recent-index-bytes` was the suggestion — on the premise that #1796 narrowed the ceiling to the evictable recent tier only, so the flag would bound "a little over a third" of what its name claims.

**That premise did not survive #1796's implementation** (PR #1817). #1796 interleaved eviction with the source walk; it did not change the derivation. The value is still a whole-family budget:

- `deriveSearchProjectionCapacity` measures recent, generation-scoped non-recent and shared non-recent pages, and subtracts the non-recent reserve from this figure before deriving the recent tier's source ceiling: `SourceCeiling = (budget − NonRecentBytes) / amplification` (`infrastructure/sqlite/search_projection_rebuild.go:1271-1288`).
- At completion the **whole** family is re-measured and compared against this same figure to set `index_family_within_budget` to `1` / `0` / `-1` (`:1467-1498`).
- Nothing anywhere uses it as a recent-tier-only ceiling. Eviction reads the persisted `recent_source_ceiling_bytes`, which is the derived remainder, never the flag (`:570-600`).

So the accurate description is a whole-family target converted into a derived ceiling on the one tier that can actually be evicted. `--recent-index-bytes` would state a contract the code does not have, and would sit confusingly next to the retired `recent_byte_limit` column (a *source text* ceiling, kept only for rollback) and the unrelated `--recent-age`.

Reviewed with gpt-5.6-sol, which reached the same conclusion independently and proposed `--index-family-budget-bytes` as an alternative. Rejected as churn: `--index-family-bytes` is already a neutral, accurate noun — the family, in bytes — and adding `-budget-` to the operator-facing flag conveys what the help text should say anyway. v0.34's direction is to reduce surface, not to rename it.

## What is actually fixed

The word **"ceiling"**. Nothing caps the family. One tier is enforced by eviction; the corpus-proportional tiers are measured and reserved but never bounded; the total is reported after the fact. The flag help, the default constant's doc and the `SearchProjectionBudget` field comment now say that:

```
-"physical byte ceiling for the bounded search index family (not source text)"
+"physical byte budget for the bounded search index family, in index bytes rather
+ than source text; enforced by evicting the recent tier and reported at completion"
```

Also drops the "1464 MiB is what the 4 GiB store gate leaves once every other Wave 3 removal is applied" derivation of the default, which no longer describes how the figure is set. The same sentence was removed from `docs/search-projection-rebuild.md` in #1817.

No behaviour change, no schema change, no `ConfigHash` change. `go build ./...`, `go test ./presentation/cli/ ./application/types/` and `go tool golangci-lint run` (0 issues) clean.

Closes #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
