### PR TITLE
fix: make the hygiene scan duration tests deterministic

### DIFF
--- a/application/usecase/memory_hygiene.go
+++ b/application/usecase/memory_hygiene.go
@@ -20,6 +20,14 @@ type memoryHygieneUsecase struct {
 	memory              memoryHygieneWriter
 	memoryQuery         queryservice.MemoryQueryService
 	extraRedactPatterns []string
+	nowFunc             func() time.Time
+}
+
+func (u *memoryHygieneUsecase) now() time.Time {
+	if u.nowFunc == nil {
+		return time.Now()
+	}
+	return u.nowFunc()
 }
 
 // defaultStalenessThreshold controls the expiry-suggestion window when
@@ -101,7 +109,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 		Consistency:       consistency,
 		ConsistencyReason: consistencyReason,
 	}
-	startedAt := time.Now()
+	startedAt := u.now()
 	finishPartial := func(reason apptypes.MemoryHygieneStopReason) (apptypes.MemoryHygieneScanResult, error) {
 		return finishPartialMemoryHygieneResult(
 			result,
@@ -113,7 +121,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 			consistencyReason,
 			digest,
 			now,
-			startedAt,
+			u.now().Sub(startedAt),
 			initialPhase,
 			initialKeyset,
 			initialRevision,
@@ -123,7 +131,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 	defer cancel()
 
 	for {
-		if time.Since(startedAt) >= budget.MaxDuration() {
+		if u.now().Sub(startedAt) >= budget.MaxDuration() {
 			if _, hasRevision := revision.Value(); hasRevision {
 				return finishPartial(apptypes.MemoryHygieneStopReasonTimeLimit)
 			}
@@ -173,7 +181,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 				result.Consistency = consistency
 				result.ConsistencyReason = consistencyReason
 				revisionChangedWhileRetrying = true
-				if errors.Is(scanCtx.Err(), context.DeadlineExceeded) || time.Since(startedAt) >= budget.MaxDuration() {
+				if errors.Is(scanCtx.Err(), context.DeadlineExceeded) || u.now().Sub(startedAt) >= budget.MaxDuration() {
 					return finishPartial(apptypes.MemoryHygieneStopReasonRevisionChanged)
 				}
 				continue
@@ -194,7 +202,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 		result.Usage.Comparisons += page.Comparisons
 
 		for _, unit := range page.Units {
-			if time.Since(startedAt) >= budget.MaxDuration() {
+			if u.now().Sub(startedAt) >= budget.MaxDuration() {
 				return finishPartial(apptypes.MemoryHygieneStopReasonTimeLimit)
 			}
 			matches := u.matchesForScanUnit(phase, unit, now, staleness, similarity)
@@ -229,7 +237,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 				result.StopReason = apptypes.MemoryHygieneStopReasonComplete
 				result.Consistency = consistency
 				result.ConsistencyReason = consistencyReason
-				result.Usage.Elapsed = time.Since(startedAt)
+				result.Usage.Elapsed = u.now().Sub(startedAt)
 				result.Usage.ElapsedMillis = result.Usage.Elapsed.Milliseconds()
 				return result, nil
 			}
@@ -509,7 +517,7 @@ func finishPartialMemoryHygieneResult(
 	consistencyReason apptypes.MemoryHygieneConsistencyReason,
 	digest string,
 	now time.Time,
-	startedAt time.Time,
+	elapsed time.Duration,
 	initialPhase apptypes.MemoryHygieneScanPhase,
 	initialKeyset apptypes.MemoryHygieneScanKeyset,
 	initialRevision domtypes.Optional[int64],
@@ -543,7 +551,7 @@ func finishPartialMemoryHygieneResult(
 	result.Consistency = consistency
 	result.ConsistencyReason = consistencyReason
 	result.NextCursor = cursor
-	result.Usage.Elapsed = time.Since(startedAt)
+	result.Usage.Elapsed = elapsed
 	result.Usage.ElapsedMillis = result.Usage.Elapsed.Milliseconds()
 	return result, nil
 }

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -616,15 +616,17 @@ func TestMemoryHygieneScan_RevisionChurnReturnsPartialOnlyAfterDurationExhausts(
 
 	scope := workspaceScope(t, "github.com/example/repo")
 	now := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	clock := &memoryHygieneTestClock{now: now}
 	query := &stubMemoryQueryService{
 		scanRevision: 1,
+		scanClock:    clock,
 		summaries: []apptypes.MemorySummary{
 			candidateSummary(t, "mem-a", scope, "git status", domtypes.MemorySourceExtracted, now),
 			candidateSummary(t, "mem-b", scope, "go test ./...", domtypes.MemorySourceExtracted, now),
 			candidateSummary(t, "mem-c", scope, "gh pr checks", domtypes.MemorySourceExtracted, now),
 		},
 	}
-	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil, usecase.MemoryUsecaseDependencies{NowFunc: clock.Now})
 	first, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
 		Now:    now,
 		Budget: memoryHygieneTestBudget(t, 2, 1<<20, 100),
@@ -647,7 +649,7 @@ func TestMemoryHygieneScan_RevisionChurnReturnsPartialOnlyAfterDurationExhausts(
 		t.Fatalf("MemoryHygieneScanBudgetFrom() error = %v", err)
 	}
 	query.advanceScanRevision = true
-	query.scanDelay = 5 * time.Millisecond
+	query.scanAdvance = shortBudget.MaxDuration()
 	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
 		Cursor: first.NextCursor,
 		Budget: shortBudget,
@@ -771,12 +773,13 @@ func TestMemoryHygieneScan_TimeLimitWithoutCursorProgressReturnsTypedError(t *te
 
 	scope := workspaceScope(t, "github.com/example/repo")
 	query := &stubMemoryQueryService{
-		scanDelay: 5 * time.Millisecond,
+		scanClock:   &memoryHygieneTestClock{now: time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)},
+		scanAdvance: time.Millisecond,
 		summaries: []apptypes.MemorySummary{
 			acceptedSummaryAt(t, "mem-a", scope, "git status", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
 		},
 	}
-	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil, usecase.MemoryUsecaseDependencies{NowFunc: query.scanClock.Now})
 	budget, err := apptypes.MemoryHygieneScanBudgetFrom(apptypes.MemoryHygieneScanBudgetParams{
 		MaxRows:        2,
 		MaxScanBytes:   1 << 20,

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -23,6 +23,7 @@ type memoryUsecase struct {
 	eventQuery          queryservice.EventQueryService
 	codexSource         application.CodexMemorySource
 	extraRedactPatterns []string
+	nowFunc             func() time.Time
 }
 
 // MemoryUsecaseDependencies carries the optional dependency set needed by
@@ -34,6 +35,7 @@ type MemoryUsecaseDependencies struct {
 	SessionQuery queryservice.SessionQueryService
 	EventQuery   queryservice.EventQueryService
 	CodexSource  application.CodexMemorySource
+	NowFunc      func() time.Time
 }
 
 // NewMemoryUsecase creates a consolidated MemoryUsecase facade.
@@ -47,12 +49,16 @@ func NewMemoryUsecase(
 		memoryRepo:          memoryRepo,
 		memoryQuery:         memoryQuery,
 		extraRedactPatterns: slices.Clone(extraRedactPatterns),
+		nowFunc:             time.Now,
 	}
 	if len(optionalDeps) > 0 {
 		deps := optionalDeps[0]
 		usecase.sessionQuery = deps.SessionQuery
 		usecase.eventQuery = deps.EventQuery
 		usecase.codexSource = deps.CodexSource
+		if deps.NowFunc != nil {
+			usecase.nowFunc = deps.NowFunc
+		}
 	}
 	return usecase
 }
@@ -702,6 +708,7 @@ func (u *memoryUsecase) Scan(ctx context.Context, criteria apptypes.MemoryHygien
 		memory:              u,
 		memoryQuery:         u.memoryQuery,
 		extraRedactPatterns: u.extraRedactPatterns,
+		nowFunc:             u.nowFunc,
 	}).Scan(ctx, criteria)
 }
 
@@ -710,6 +717,7 @@ func (u *memoryUsecase) Apply(ctx context.Context, criteria apptypes.MemoryHygie
 		memory:              u,
 		memoryQuery:         u.memoryQuery,
 		extraRedactPatterns: u.extraRedactPatterns,
+		nowFunc:             u.nowFunc,
 	}).Apply(ctx, criteria)
 }
 

--- a/application/usecase/memory_usecase_import_test.go
+++ b/application/usecase/memory_usecase_import_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,11 +35,29 @@ type stubMemoryQueryService struct {
 	scanPageCriteria      []apptypes.MemoryHygieneScanPageCriteria
 	scanRevision          int64
 	advanceScanRevision   bool
-	scanDelay             time.Duration
+	scanAdvance           time.Duration
+	scanClock             *memoryHygieneTestClock
 	revalidationCalls     []apptypes.MemoryHygieneRevalidationCriteria
 	revalidationResults   map[string]apptypes.MemoryHygieneRevalidationSourceResult
 	revalidationErrors    map[string]error
 	revalidationRevisions []int64
+}
+
+type memoryHygieneTestClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *memoryHygieneTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *memoryHygieneTestClock) Advance(delta time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(delta)
 }
 
 func (s *stubMemoryQueryService) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
@@ -96,8 +115,8 @@ func (s *stubMemoryQueryService) ScanMemoryHygienePage(
 ) (apptypes.MemoryHygieneScanSourcePage, error) {
 	s.scanPageCalls++
 	s.scanPageCriteria = append(s.scanPageCriteria, criteria)
-	if s.scanDelay > 0 {
-		time.Sleep(s.scanDelay)
+	if s.scanAdvance > 0 && s.scanClock != nil {
+		s.scanClock.Advance(s.scanAdvance)
 	}
 	if s.advanceScanRevision {
 		s.scanRevision++


### PR DESCRIPTION
## What

`TestMemoryHygieneScan_RevisionChurnReturnsPartialOnlyAfterDurationExhausts` failed intermittently on CI — on PR #1800, whose diff does not touch memory hygiene:

```
memory hygiene continuation cannot progress:
time_limit budget stopped before advancing the cursor
```

It raced two independent wall-clock deadlines: a budget of `MaxDuration: time.Millisecond` against a stub that slept `5 * time.Millisecond`. The scan checks elapsed time at the top of every iteration, *before* fetching the first page (`memory_hygiene.go:131`). On a loaded runner more than 1 ms can pass between `startedAt` and that check, so the scan stopped with `time_limit` before the cursor moved — and a partial result that made no progress is a typed error. Re-running the same commit passed; locally it passes 20/20. That is the signature of a scheduling race, not a logic bug.

The behaviour under test — a revision change wins over an exhausted duration — is real and worth holding. The wall clock is the wrong instrument for holding it: 1 ms is below the scheduling noise floor of the machines this runs on.

## How

Not by widening the margins. 10 ms against 100 ms would lower the failure rate without removing the race, and it would come back the first time CI got slower.

The elapsed-time reads in the hygiene scan now go through an injected clock. `MemoryUsecaseDependencies` — already a variadic optional struct — gains `NowFunc func() time.Time`, defaulting to `time.Now`, so **no existing call site changes**. The two tests inject a mutex-guarded fake clock that the scan stub advances by a known amount at a known point, instead of sleeping and hoping the scheduler cooperates. Production behaviour is unchanged: `nowFunc` is `time.Now` everywhere outside these tests.

Two details worth recording:

- `finishPartialMemoryHygieneResult` used to take `startedAt` and call `time.Since` itself, which is a second, hidden reading of the clock. It now takes the already-computed `elapsed`, so there is exactly one place elapsed time is measured.
- `context.WithTimeout(ctx, budget.MaxDuration())` deliberately still runs on the real clock, and the tests do not depend on it firing. Faking a context deadline would have meant faking the runtime, and the assertions do not need it: the fake clock reaches the budget on the first stub call, so the branch under test is chosen before the real deadline is relevant either way.

## Verification

Determinism is the whole point, so it was measured rather than asserted:

| run | result |
|---|---|
| `go test -race -count=200` on the two tests | ok |
| 8 concurrent `go test -race -count=30 -run TestMemoryHygieneScan` on this machine | 8/8 ok |

`go build ./...`, `go test -count=1 ./...` and `go tool golangci-lint run` (0 issues) clean.

No CHANGELOG entry: no operator-visible behaviour changes.

Closes #1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
