### PR TITLE
v0.34.0-57: recover stale WAL sidecars instead of deadlocking store compact

### DIFF
--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -31,6 +31,11 @@ func (u *storeCompactionUsecase) Plan(ctx context.Context, source string) (domai
 	if filepath.Clean(source) != u.expectedStore {
 		return domain.CompactionRun{}, fmt.Errorf("compaction store binding mismatch")
 	}
+	release, err := u.lease.AcquireExclusive(ctx, u.expectedStore)
+	if err != nil {
+		return domain.CompactionRun{}, err
+	}
+	defer release()
 	idBytes := make([]byte, 16)
 	if _, err := rand.Read(idBytes); err != nil {
 		return domain.CompactionRun{}, fmt.Errorf("create compaction run id: %w", err)

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -39,8 +39,10 @@ advisory lockを保持します。`apply`、`resume`、`rollback` はjournalや�
 排他を継続します。取得はcontext cancellationに従い、プロセス終了時はOSが
 lockを解放します。lock file自体は意図的に残します。既存databaseと親directoryの
 symlinkは同じlease namespaceへ解決し、安全にfenceできないhardlink databaseは
-拒否します。非対応platformまたは
-probe失敗時は `false` としてfail closedします。旧版や非協調processは引き続き
+拒否します。`plan`の実行前にはlease取得が必須なので、非対応platformでは
+planがlease取得時点で失敗します。したがって永続化されたrunの
+`lease_capability`は常に`true`です。このfieldは後続のcapability probeではなく、
+planがlease前提を満たしたことを記録します。旧版や非協調processは引き続き
 事前停止が必要です。
 filesystem安全性は協調モデルです。参加するlive openerはすべて隣接leaseを使い、
 破壊的境界ではsource、candidate、rollbackのhardlinkを拒否します。権限を持つ

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -17,6 +17,14 @@ source store size の 1.1 倍の空き容量を要求します。成功後も so
 大きさの元 database rollback copy が残ります。運用者向けの詳細は
 [`store compact` のディスク容量](../operations/store-compact-disk-cost.ja.md) を参照してください。
 
+`plan`はpreflight全体でstoreのexclusive leaseを保持します。regularかつ0 byteの
+`-wal`または`-shm`だけをstale artifactとして削除し、directoryをsyncしてから、
+storeをopenする前に再検査します。non-zeroのWAL/SHM、サイズにかかわらずすべての
+`-journal`、symlink、FIFO、その他のnon-regular pathは削除しません。sidecarが残って
+いる場合は、すべてのTraceary process（projection/status reader、旧版、非協調版を
+含む）を停止して同じcommandをretryしてください。sidecarを手動削除してはいけません。
+non-zeroまたはnon-regularのsidecarにはliveなSQLite stateが含まれる可能性があります。
+
 レガシー検索インデックスの検査はsource digestより前に走るため、数GiBのstore
 全体をハッシュした後ではなく数秒で失敗します。先にcompactすると死んだindexを
 新しいファイルへコピーして固定化してしまうので、`traceary store search-retire`

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -17,13 +17,16 @@ source store size の 1.1 倍の空き容量を要求します。成功後も so
 大きさの元 database rollback copy が残ります。運用者向けの詳細は
 [`store compact` のディスク容量](../operations/store-compact-disk-cost.ja.md) を参照してください。
 
-`plan`はpreflight全体でstoreのexclusive leaseを保持します。regularかつ0 byteの
-`-wal`または`-shm`だけをstale artifactとして削除し、directoryをsyncしてから、
-storeをopenする前に再検査します。non-zeroのWAL/SHM、サイズにかかわらずすべての
-`-journal`、symlink、FIFO、その他のnon-regular pathは削除しません。sidecarが残って
-いる場合は、すべてのTraceary process（projection/status reader、旧版、非協調版を
-含む）を停止して同じcommandをretryしてください。sidecarを手動削除してはいけません。
-non-zeroまたはnon-regularのsidecarにはliveなSQLite stateが含まれる可能性があります。
+`plan`はpreflight全体でstoreのexclusive leaseを保持します。`-journal`がなく、
+non-zeroの`-wal`もない場合は、存在するregularな`-wal`と`-shm`を、`-shm`が
+non-zeroでも両方stale artifactとして削除します。directoryをsyncしてから、storeを
+openする前に再検査します。shm fileはdatabase contentを含まず、fsyncもされません。
+empty WALではすべてのcontentをmain database fileから取得します。non-zeroのWAL、
+サイズにかかわらずすべての`-journal`、symlink、FIFO、その他のnon-regular pathは
+削除しません。sidecarが残っている場合は、すべてのTraceary process（projection/status
+reader、旧版、非協調版を含む）を停止して同じcommandをretryしてください。sidecarを
+手動削除してはいけません。non-zero WALまたはnon-regular sidecarにはliveなSQLite
+stateが含まれる可能性があります。
 
 レガシー検索インデックスの検査はsource digestより前に走るため、数GiBのstore
 全体をハッシュした後ではなく数秒で失敗します。先にcompactすると死んだindexを

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -17,7 +17,7 @@ source store size の 1.1 倍の空き容量を要求します。成功後も so
 大きさの元 database rollback copy が残ります。運用者向けの詳細は
 [`store compact` のディスク容量](../operations/store-compact-disk-cost.ja.md) を参照してください。
 
-`plan`はpreflight全体でstoreのexclusive leaseを保持します。`-journal`がなく、
+`store compact`の`plan`はpreflight全体でstoreのexclusive leaseを保持します。`-journal`がなく、
 non-zeroの`-wal`もない場合は、存在するregularな`-wal`と`-shm`を、`-shm`が
 non-zeroでも両方stale artifactとして削除します。directoryをsyncしてから、storeを
 openする前に再検査します。shm fileはdatabase contentを含まず、fsyncもされません。
@@ -28,12 +28,16 @@ reader、旧版、非協調版を含む）を停止して同じcommandをretry�
 手動削除してはいけません。non-zero WALまたはnon-regular sidecarにはliveなSQLite
 stateが含まれる可能性があります。
 
-`apply`と`resume`も同じcleanupを実行します。`plan`が返ったあとにreaderがsidecarを
+`store compact apply`と`store compact resume`も同じcleanupを実行します。`plan`が返ったあとにreaderがsidecarを
 作りうるためです。cleanupはexclusive leaseを取得できたときだけ走り、liveな協調接続は
 すべて同じleaseのshared formを保持しているため、いずれかがstoreを開いている間に
 sidecarが削除されることはありません（lease取得側が待ちます）。exchange直前の最終検査は
 strictのままです。その時点ではcleanupが済んでいるため、そこでsidecarが現れることは
 run中にopenerが現れたことを意味し、runは中止されます。
+
+このsidecar recoveryは`store compact`に限られます。`store payload-rehearsal`が使う
+prepared-upgrade pathはpreflight全体でexclusive leaseを保持しないため、sidecarを
+recoveryせずに拒否します。
 
 レガシー検索インデックスの検査はsource digestより前に走るため、数GiBのstore
 全体をハッシュした後ではなく数秒で失敗します。先にcompactすると死んだindexを

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -28,6 +28,13 @@ reader、旧版、非協調版を含む）を停止して同じcommandをretry�
 手動削除してはいけません。non-zero WALまたはnon-regular sidecarにはliveなSQLite
 stateが含まれる可能性があります。
 
+`apply`と`resume`も同じcleanupを実行します。`plan`が返ったあとにreaderがsidecarを
+作りうるためです。cleanupはexclusive leaseを取得できたときだけ走り、liveな協調接続は
+すべて同じleaseのshared formを保持しているため、いずれかがstoreを開いている間に
+sidecarが削除されることはありません（lease取得側が待ちます）。exchange直前の最終検査は
+strictのままです。その時点ではcleanupが済んでいるため、そこでsidecarが現れることは
+run中にopenerが現れたことを意味し、runは中止されます。
+
 レガシー検索インデックスの検査はsource digestより前に走るため、数GiBのstore
 全体をハッシュした後ではなく数秒で失敗します。先にcompactすると死んだindexを
 新しいファイルへコピーして固定化してしまうので、`traceary store search-retire`

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -24,14 +24,16 @@ the candidate size is unknown until `VACUUM INTO` finishes, and the original
 source-size rollback copy remains after success. See [store compact disk
 cost](../operations/store-compact-disk-cost.md) for the operator guidance.
 
-`plan` holds the exclusive store lease for its entire preflight. If it finds a
-regular, zero-byte `-wal` or `-shm`, it removes the stale artifact, syncs the
-directory, and checks again before opening the store. It never removes a
-non-zero WAL/SHM, any `-journal`, symlink, FIFO, or other non-regular path. If
-one remains, stop all other Traceary processes (including projection/status
-readers and older or non-cooperating versions) and retry the same command; do
-not remove the sidecar manually. A non-zero or non-regular sidecar may contain
-live SQLite state.
+`plan` holds the exclusive store lease for its entire preflight. If it finds no
+`-journal` and no non-zero `-wal`, it removes both regular `-wal` and `-shm`
+sidecars when present, even when the `-shm` is non-zero, syncs the directory,
+and checks again before opening the store. The shm file contains no database
+content and is never fsynced; an empty WAL means all content comes from the
+main database file. It never removes a non-zero WAL, any `-journal`, symlink,
+FIFO, or other non-regular path. If one remains, stop all other Traceary
+processes (including projection/status readers and older or non-cooperating
+versions) and retry the same command; do not remove the sidecar manually. A
+non-zero WAL or non-regular sidecar may contain live SQLite state.
 
 The legacy search index check runs before the source digest, so it fails in
 seconds rather than after hashing a multi-GiB store. Compacting first would

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -24,7 +24,8 @@ the candidate size is unknown until `VACUUM INTO` finishes, and the original
 source-size rollback copy remains after success. See [store compact disk
 cost](../operations/store-compact-disk-cost.md) for the operator guidance.
 
-`plan` holds the exclusive store lease for its entire preflight. If it finds no
+For `store compact`, `plan` holds the exclusive store lease for its entire
+preflight. If it finds no
 `-journal` and no non-zero `-wal`, it removes both regular `-wal` and `-shm`
 sidecars when present, even when the `-shm` is non-zero, syncs the directory,
 and checks again before opening the store. The shm file contains no database
@@ -35,13 +36,17 @@ processes (including projection/status readers and older or non-cooperating
 versions) and retry the same command; do not remove the sidecar manually. A
 non-zero WAL or non-regular sidecar may contain live SQLite state.
 
-`apply` and `resume` repeat that cleanup, because a reader can create a sidecar
+`store compact apply` and `store compact resume` repeat that cleanup, because a reader can create a sidecar
 after `plan` returns. Cleanup can only run once the exclusive lease is held, and
 every live cooperating connection holds the shared form of the same lease, so a
 sidecar is never removed while any of them has the store open — the lease
 acquisition waits instead. The final pre-exchange check stays strict: by then
 cleanup has already happened, so a sidecar appearing there means an opener
 arrived mid-run and the run aborts.
+
+This sidecar recovery is specific to `store compact`. The prepared-upgrade
+path used by `store payload-rehearsal` does not hold the exclusive lease across
+its preflight, so it refuses any SQLite sidecar rather than recovering it.
 
 The legacy search index check runs before the source digest, so it fails in
 seconds rather than after hashing a multi-GiB store. Compacting first would

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -47,8 +47,11 @@ including across the database inode exchange. Acquisition honors cancellation
 and process termination releases the OS lock. The lock file remains on disk by
 design. Existing database and parent-directory symlinks resolve to the same
 lease namespace; hard-linked database files are rejected because aliases cannot
-be fenced safely. Unsupported platforms and failed capability probes report `false` and
-fail closed. Operators must still stop older or non-cooperating processes.
+be fenced safely. Lease acquisition is required before `plan` can run, so
+unsupported platforms fail at acquisition instead of producing a plan. A
+persisted run therefore always has `lease_capability: true`; this field records
+the completed plan's lease precondition rather than a later capability probe.
+Operators must still stop older or non-cooperating processes.
 The filesystem safety model is cooperative: every participating live opener
 uses the adjacent lease, and every destructive boundary rejects hard-linked
 source, candidate, or rollback files. Privileged or non-cooperating processes

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -24,6 +24,15 @@ the candidate size is unknown until `VACUUM INTO` finishes, and the original
 source-size rollback copy remains after success. See [store compact disk
 cost](../operations/store-compact-disk-cost.md) for the operator guidance.
 
+`plan` holds the exclusive store lease for its entire preflight. If it finds a
+regular, zero-byte `-wal` or `-shm`, it removes the stale artifact, syncs the
+directory, and checks again before opening the store. It never removes a
+non-zero WAL/SHM, any `-journal`, symlink, FIFO, or other non-regular path. If
+one remains, stop all other Traceary processes (including projection/status
+readers and older or non-cooperating versions) and retry the same command; do
+not remove the sidecar manually. A non-zero or non-regular sidecar may contain
+live SQLite state.
+
 The legacy search index check runs before the source digest, so it fails in
 seconds rather than after hashing a multi-GiB store. Compacting first would
 copy the dead index into the new file and bake it in, so run

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -35,6 +35,14 @@ processes (including projection/status readers and older or non-cooperating
 versions) and retry the same command; do not remove the sidecar manually. A
 non-zero WAL or non-regular sidecar may contain live SQLite state.
 
+`apply` and `resume` repeat that cleanup, because a reader can create a sidecar
+after `plan` returns. Cleanup can only run once the exclusive lease is held, and
+every live cooperating connection holds the shared form of the same lease, so a
+sidecar is never removed while any of them has the store open — the lease
+acquisition waits instead. The final pre-exchange check stays strict: by then
+cleanup has already happened, so a sidecar appearing there means an opener
+arrived mid-run and the run aborts.
+
 The legacy search index check runs before the source digest, so it fails in
 seconds rather than after hashing a multi-GiB store. Compacting first would
 copy the dead index into the new file and bake it in, so run

--- a/infrastructure/sqlite/compaction_files.go
+++ b/infrastructure/sqlite/compaction_files.go
@@ -470,12 +470,19 @@ func (PreparedStoreUpgradeFiles) Recheck(ctx context.Context, run domain.Compact
 	if current.Device != run.Resources.FilesystemDevice || !atomicExchangeSupported() {
 		return errors.New("planned filesystem capability drift")
 	}
-	return rejectSQLiteSidecars(run.SourcePath)
+	// Apply and resume call Recheck while holding the exclusive store lease.
+	// Clean up the same stale zero-byte sidecars that Plan handles; a reader
+	// can create them after Plan returns but before apply/resume starts.
+	return cleanupStaleSQLiteSidecars(ctx, run.SourcePath)
 }
 
 // RecheckForPublish performs only constant-count identity/link/sidecar checks.
 // It deliberately does not hash, open SQLite, inspect free space, or copy data
 // while the adjacent exclusive lease is held.
+//
+// Unlike Recheck, this check remains strict: cleanup has already happened
+// under the lease, so a sidecar appearing here means a live opener appeared
+// mid-run and the run must abort.
 func (PreparedStoreUpgradeFiles) RecheckForPublish(ctx context.Context, run domain.PreparedStoreUpgradeRun) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/infrastructure/sqlite/compaction_files.go
+++ b/infrastructure/sqlite/compaction_files.go
@@ -355,12 +355,18 @@ func writeJournalRecord(w io.Writer, run domain.CompactionRun) error {
 }
 
 // PreparedStoreUpgradeFiles implements fenced, same-directory replacement.
-type PreparedStoreUpgradeFiles struct{ recoveryHook func(string) error }
+type PreparedStoreUpgradeFiles struct {
+	// CallerHoldsExclusiveLease declares that the caller holds the exclusive
+	// store lease for the entire call. This is the precondition that licenses
+	// recovery of stale SQLite sidecars.
+	CallerHoldsExclusiveLease bool
+	recoveryHook              func(string) error
+}
 
 // StoreReplacementFiles preserves the legacy compaction composition surface.
 type StoreReplacementFiles = PreparedStoreUpgradeFiles
 
-func (PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.CompactionRun) (domain.CompactionRun, error) {
+func (f PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.CompactionRun) (domain.CompactionRun, error) {
 	if err := ctx.Err(); err != nil {
 		return run, err
 	}
@@ -375,7 +381,7 @@ func (PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.Compaction
 	if err := validateStoreLinkIdentity(run.SourcePath); err != nil {
 		return run, err
 	}
-	if err := cleanupStaleSQLiteSidecars(ctx, run.SourcePath); err != nil {
+	if err := f.checkSQLiteSidecars(ctx, run.SourcePath); err != nil {
 		return run, err
 	}
 	// Once the cleanup returns, the store has no WAL/SHM at all -- stale ones
@@ -416,8 +422,16 @@ func (PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.Compaction
 	}
 	run.SourceDigest = digest
 	exchangeCapability := probeReplacementCapabilities(filepath.Dir(run.SourcePath)) == nil
-	// Plan is invoked by the use case while its exclusive store lease is held.
-	run.Resources = domain.CompactionResourcePlan{RequiredBytes: required, DestinationBytes: uint64(id.Size), TemporaryBytes: temporary, SafetyMarginBytes: margin, AvailableBytes: available, FilesystemDevice: id.Device, LeaseCapability: true, ExchangeCapability: exchangeCapability}
+	var leaseCapability bool
+	if f.CallerHoldsExclusiveLease {
+		// Do not probe here: flock locks attach to the open file description, so
+		// a fresh descriptor conflicts with the caller's held exclusive lease
+		// and retries until ctx is done.
+		leaseCapability = true
+	} else {
+		leaseCapability = probeStoreLeaseCapability(ctx, run.SourcePath) == nil
+	}
+	run.Resources = domain.CompactionResourcePlan{RequiredBytes: required, DestinationBytes: uint64(id.Size), TemporaryBytes: temporary, SafetyMarginBytes: margin, AvailableBytes: available, FilesystemDevice: id.Device, LeaseCapability: leaseCapability, ExchangeCapability: exchangeCapability}
 	if !run.Resources.ExchangeCapability {
 		return run, errors.New("atomic exchange capability unavailable")
 	}
@@ -440,7 +454,7 @@ func insufficientCompactionSpaceError(required, available uint64, sourceSize int
 		required-available, required, available, sourceSize)
 }
 
-func (PreparedStoreUpgradeFiles) Recheck(ctx context.Context, run domain.CompactionRun) error {
+func (f PreparedStoreUpgradeFiles) Recheck(ctx context.Context, run domain.CompactionRun) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -474,7 +488,14 @@ func (PreparedStoreUpgradeFiles) Recheck(ctx context.Context, run domain.Compact
 	// Apply and resume call Recheck while holding the exclusive store lease.
 	// Clean up the same stale zero-byte sidecars that Plan handles; a reader
 	// can create them after Plan returns but before apply/resume starts.
-	return cleanupStaleSQLiteSidecars(ctx, run.SourcePath)
+	return f.checkSQLiteSidecars(ctx, run.SourcePath)
+}
+
+func (f PreparedStoreUpgradeFiles) checkSQLiteSidecars(ctx context.Context, storePath string) error {
+	if f.CallerHoldsExclusiveLease {
+		return cleanupStaleSQLiteSidecars(ctx, storePath)
+	}
+	return rejectSQLiteSidecars(storePath)
 }
 
 // RecheckForPublish performs only constant-count identity/link/sidecar checks.

--- a/infrastructure/sqlite/compaction_files.go
+++ b/infrastructure/sqlite/compaction_files.go
@@ -378,8 +378,9 @@ func (PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.Compaction
 	if err := cleanupStaleSQLiteSidecars(ctx, run.SourcePath); err != nil {
 		return run, err
 	}
-	// After the sidecar rejection the store has no live WAL/SHM, so it is safe
-	// to open. This runs before the digest deliberately: hashing a 24 GiB
+	// Once the cleanup returns, the store has no WAL/SHM at all -- stale ones
+	// were removed and a live one would have been refused -- so it is safe to
+	// open. This runs before the digest deliberately: hashing a 24 GiB
 	// source only to copy 16 GiB of dead index into the candidate is the exact
 	// waste the check exists to prevent.
 	//

--- a/infrastructure/sqlite/compaction_files.go
+++ b/infrastructure/sqlite/compaction_files.go
@@ -372,10 +372,10 @@ func (PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.Compaction
 			return run, fmt.Errorf("compaction output already exists: %s", path)
 		}
 	}
-	if err := rejectSQLiteSidecars(run.SourcePath); err != nil {
+	if err := validateStoreLinkIdentity(run.SourcePath); err != nil {
 		return run, err
 	}
-	if err := validateStoreLinkIdentity(run.SourcePath); err != nil {
+	if err := cleanupStaleSQLiteSidecars(ctx, run.SourcePath); err != nil {
 		return run, err
 	}
 	// After the sidecar rejection the store has no live WAL/SHM, so it is safe
@@ -415,8 +415,8 @@ func (PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.Compaction
 	}
 	run.SourceDigest = digest
 	exchangeCapability := probeReplacementCapabilities(filepath.Dir(run.SourcePath)) == nil
-	leaseCapability := probeStoreLeaseCapability(ctx, run.SourcePath) == nil
-	run.Resources = domain.CompactionResourcePlan{RequiredBytes: required, DestinationBytes: uint64(id.Size), TemporaryBytes: temporary, SafetyMarginBytes: margin, AvailableBytes: available, FilesystemDevice: id.Device, LeaseCapability: leaseCapability, ExchangeCapability: exchangeCapability}
+	// Plan is invoked by the use case while its exclusive store lease is held.
+	run.Resources = domain.CompactionResourcePlan{RequiredBytes: required, DestinationBytes: uint64(id.Size), TemporaryBytes: temporary, SafetyMarginBytes: margin, AvailableBytes: available, FilesystemDevice: id.Device, LeaseCapability: true, ExchangeCapability: exchangeCapability}
 	if !run.Resources.ExchangeCapability {
 		return run, errors.New("atomic exchange capability unavailable")
 	}
@@ -939,8 +939,9 @@ func inspectRegularFile(path string) (domain.StoreFileIdentity, error) {
 
 func rejectSQLiteSidecars(path string) error {
 	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
-		if _, err := os.Lstat(path + suffix); err == nil {
-			return fmt.Errorf("SQLite sidecar exists: %s", path+suffix)
+		sidecarPath := path + suffix
+		if info, err := os.Lstat(sidecarPath); err == nil {
+			return sqliteSidecarRefusal(sidecarPath, info)
 		} else if !os.IsNotExist(err) {
 			return err
 		}

--- a/infrastructure/sqlite/compaction_files_test.go
+++ b/infrastructure/sqlite/compaction_files_test.go
@@ -227,6 +227,34 @@ func TestStoreReplacementFilesRejectsSymlinkAndSidecar(t *testing.T) {
 	}
 }
 
+func TestStoreReplacementFilesRecheckCleansSidecarCreatedAfterPlan(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "store.db")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run, err := (StoreReplacementFiles{}).Plan(context.Background(), domain.CompactionRun{
+		SourcePath:    source,
+		CandidatePath: filepath.Join(dir, "candidate"),
+		RollbackPath:  filepath.Join(dir, "rollback"),
+	})
+	if err != nil {
+		if errors.Is(err, ErrPreparedUpgradeUnsupported) {
+			t.Skipf("compaction replacement unsupported: %v", err)
+		}
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source+"-wal", nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (StoreReplacementFiles{}).Recheck(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(source + "-wal"); !os.IsNotExist(err) {
+		t.Fatalf("sidecar created after plan was not removed: %v", err)
+	}
+}
+
 func TestAtomicExchangePreservesBothInodes(t *testing.T) {
 	dir := t.TempDir()
 	left, right := filepath.Join(dir, "left"), filepath.Join(dir, "right")

--- a/infrastructure/sqlite/compaction_files_test.go
+++ b/infrastructure/sqlite/compaction_files_test.go
@@ -212,18 +212,24 @@ func TestStoreReplacementFilesRejectsSymlinkAndSidecar(t *testing.T) {
 		t.Fatal(err)
 	}
 	run := domain.CompactionRun{SourcePath: link, CandidatePath: filepath.Join(dir, "candidate"), RollbackPath: filepath.Join(dir, "rollback")}
-	if _, err := (StoreReplacementFiles{}).Plan(context.Background(), run); err == nil {
+	if _, err := (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).Plan(context.Background(), run); err == nil {
 		t.Fatal("Plan accepted symlink")
 	}
 	if err := os.WriteFile(source+"-wal", nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(source+"-shm", make([]byte, 32*1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	run.SourcePath = source
-	if _, err := (StoreReplacementFiles{}).Plan(context.Background(), run); err != nil && strings.Contains(err.Error(), "sidecar") {
+	if _, err := (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).Plan(context.Background(), run); err != nil && strings.Contains(err.Error(), "sidecar") {
 		t.Fatalf("Plan rejected stale zero-byte WAL: %v", err)
 	}
 	if _, err := os.Lstat(source + "-wal"); !os.IsNotExist(err) {
 		t.Fatalf("stale WAL was not removed: %v", err)
+	}
+	if _, err := os.Lstat(source + "-shm"); !os.IsNotExist(err) {
+		t.Fatalf("stale SHM was not removed: %v", err)
 	}
 }
 
@@ -233,7 +239,7 @@ func TestStoreReplacementFilesRecheckCleansSidecarCreatedAfterPlan(t *testing.T)
 	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	run, err := (StoreReplacementFiles{}).Plan(context.Background(), domain.CompactionRun{
+	run, err := (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).Plan(context.Background(), domain.CompactionRun{
 		SourcePath:    source,
 		CandidatePath: filepath.Join(dir, "candidate"),
 		RollbackPath:  filepath.Join(dir, "rollback"),
@@ -247,11 +253,82 @@ func TestStoreReplacementFilesRecheckCleansSidecarCreatedAfterPlan(t *testing.T)
 	if err := os.WriteFile(source+"-wal", nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := (StoreReplacementFiles{}).Recheck(context.Background(), run); err != nil {
+	if err := os.WriteFile(source+"-shm", make([]byte, 32*1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).Recheck(context.Background(), run); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Lstat(source + "-wal"); !os.IsNotExist(err) {
 		t.Fatalf("sidecar created after plan was not removed: %v", err)
+	}
+	if _, err := os.Lstat(source + "-shm"); !os.IsNotExist(err) {
+		t.Fatalf("SHM created after plan was not removed: %v", err)
+	}
+}
+
+func TestPreparedStoreUpgradeFilesZeroValueRefusesSidecars(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "store.db")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wal := source + "-wal"
+	shm := source + "-shm"
+	if err := os.WriteFile(wal, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shm, make([]byte, 32*1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := (PreparedStoreUpgradeFiles{}).Plan(context.Background(), domain.CompactionRun{
+		SourcePath: source, CandidatePath: filepath.Join(dir, "candidate"), RollbackPath: filepath.Join(dir, "rollback"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "sidecar") {
+		t.Fatalf("zero-value Plan error = %v, want sidecar refusal", err)
+	}
+	for _, path := range []string{wal, shm} {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Fatalf("refused sidecar %s was changed: %v", path, statErr)
+		}
+		if path == shm && info.Size() != 32*1024 {
+			t.Fatalf("refused SHM size = %d, want %d", info.Size(), 32*1024)
+		}
+	}
+}
+
+func TestPreparedStoreUpgradeFilesZeroValueRecheckRefusesSidecars(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "store.db")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	files := PreparedStoreUpgradeFiles{}
+	run, err := files.Plan(context.Background(), domain.CompactionRun{
+		SourcePath: source, CandidatePath: filepath.Join(dir, "candidate"), RollbackPath: filepath.Join(dir, "rollback"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !run.Resources.LeaseCapability {
+		t.Fatal("zero-value Plan did not report the available lease capability")
+	}
+	wal := source + "-wal"
+	shm := source + "-shm"
+	if err := os.WriteFile(wal, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shm, make([]byte, 32*1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Recheck(context.Background(), run); err == nil || !strings.Contains(err.Error(), "sidecar") {
+		t.Fatalf("zero-value Recheck error = %v, want sidecar refusal", err)
+	}
+	for _, path := range []string{wal, shm} {
+		if _, statErr := os.Stat(path); statErr != nil {
+			t.Fatalf("refused sidecar %s was changed: %v", path, statErr)
+		}
 	}
 }
 
@@ -282,7 +359,7 @@ func TestStoreReplacementFilesRejectsCandidateReplacementAfterVerification(t *te
 	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	run, err := (StoreReplacementFiles{}).Plan(context.Background(), domain.CompactionRun{SourcePath: source, CandidatePath: candidate, RollbackPath: rollback})
+	run, err := (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).Plan(context.Background(), domain.CompactionRun{SourcePath: source, CandidatePath: candidate, RollbackPath: rollback})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +370,7 @@ func TestStoreReplacementFilesRejectsCandidateReplacementAfterVerification(t *te
 	if err != nil {
 		t.Fatal(err)
 	}
-	run, err = (StoreReplacementFiles{}).FenceCandidate(context.Background(), run)
+	run, err = (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).FenceCandidate(context.Background(), run)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +381,7 @@ func TestStoreReplacementFilesRejectsCandidateReplacementAfterVerification(t *te
 		t.Fatal(err)
 	}
 	run.Phase = domain.CompactionSwapIntent
-	if err := (StoreReplacementFiles{}).Exchange(context.Background(), run); err == nil {
+	if err := (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).Exchange(context.Background(), run); err == nil {
 		t.Fatal("Exchange accepted replaced candidate")
 	}
 	got, _ := os.ReadFile(source)
@@ -327,7 +404,7 @@ func TestStoreReplacementFilesObserveRejectsFencedCandidateReadyConflict(t *test
 	candidateID, _ := inspectRegularFile(candidate)
 	run := domain.CompactionRun{SourcePath: source, CandidatePath: candidate, RollbackPath: filepath.Join(dir, "rollback"), SourceIdentity: sourceID, Candidate: candidateID}
 	run.Candidate.Inode++
-	if _, err := (StoreReplacementFiles{}).Observe(context.Background(), run); err == nil {
+	if _, err := (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).Observe(context.Background(), run); err == nil {
 		t.Fatal("Observe accepted candidate identity conflict")
 	}
 }
@@ -486,7 +563,7 @@ func TestCompactionDestructiveBoundariesRejectHardLinkedArtifacts(t *testing.T) 
 			if err := os.Link(linked, linked+".alias"); err != nil {
 				t.Fatal(err)
 			}
-			files := StoreReplacementFiles{}
+			files := StoreReplacementFiles{CallerHoldsExclusiveLease: true}
 			var err error
 			switch actionPath {
 			case "fence":

--- a/infrastructure/sqlite/compaction_files_test.go
+++ b/infrastructure/sqlite/compaction_files_test.go
@@ -219,8 +219,11 @@ func TestStoreReplacementFilesRejectsSymlinkAndSidecar(t *testing.T) {
 		t.Fatal(err)
 	}
 	run.SourcePath = source
-	if _, err := (StoreReplacementFiles{}).Plan(context.Background(), run); err == nil {
-		t.Fatal("Plan accepted WAL sidecar")
+	if _, err := (StoreReplacementFiles{}).Plan(context.Background(), run); err != nil && strings.Contains(err.Error(), "sidecar") {
+		t.Fatalf("Plan rejected stale zero-byte WAL: %v", err)
+	}
+	if _, err := os.Lstat(source + "-wal"); !os.IsNotExist(err) {
+		t.Fatalf("stale WAL was not removed: %v", err)
 	}
 }
 

--- a/infrastructure/sqlite/compaction_large_shape_test.go
+++ b/infrastructure/sqlite/compaction_large_shape_test.go
@@ -44,7 +44,7 @@ func TestCompactionE2E_21Point4GiBShape(t *testing.T) {
 		t.Fatal(err)
 	}
 	planningJournal := &CompactionFileJournal{Dir: filepath.Join(dir, "planning-journal")}
-	planner := usecase.NewStoreCompactionUsecase(source, planningJournal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	planner := usecase.NewStoreCompactionUsecase(source, planningJournal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err := planner.Plan(context.Background(), source)
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func TestCompactionE2E_21Point4GiBShape(t *testing.T) {
 	if err := journal.Create(context.Background(), run); err != nil {
 		t.Fatal(err)
 	}
-	service := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	service := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err = service.Apply(context.Background(), run.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/infrastructure/sqlite/compaction_sidecars.go
+++ b/infrastructure/sqlite/compaction_sidecars.go
@@ -11,11 +11,13 @@ type sqliteSidecar struct {
 	path string
 }
 
-// cleanupStaleSQLiteSidecars runs only behind the compaction lease. Every
-// cooperating physical SQLite connection holds the shared form of that lease,
-// so a reader or writer cannot keep a sidecar live while this cleanup runs.
-// Non-cooperating SQLite clients remain outside this advisory-lock boundary,
-// just as they are for the existing replacement protocol.
+// cleanupStaleSQLiteSidecars requires the caller to declare that it holds the
+// exclusive store lease for the entire call. That declaration licenses
+// recovery because every cooperating physical SQLite connection holds the
+// shared form of that lease, so a reader or writer cannot keep a sidecar live
+// while this cleanup runs. Non-cooperating SQLite clients remain outside that
+// advisory-lock boundary, just as they are for the existing replacement
+// protocol.
 func cleanupStaleSQLiteSidecars(ctx context.Context, storePath string) error {
 	var stale []sqliteSidecar
 	for _, suffix := range []string{"-wal", "-shm", "-journal"} {

--- a/infrastructure/sqlite/compaction_sidecars.go
+++ b/infrastructure/sqlite/compaction_sidecars.go
@@ -1,0 +1,72 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type sqliteSidecar struct {
+	path string
+}
+
+// cleanupStaleSQLiteSidecars runs only behind the compaction lease. Every
+// cooperating physical SQLite connection holds the shared form of that lease,
+// so a reader or writer cannot keep a sidecar live while this cleanup runs.
+// Non-cooperating SQLite clients remain outside this advisory-lock boundary,
+// just as they are for the existing replacement protocol.
+func cleanupStaleSQLiteSidecars(ctx context.Context, storePath string) error {
+	var stale []sqliteSidecar
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("sidecar cleanup canceled: %w", err)
+		}
+		path := storePath + suffix
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("stat SQLite sidecar %s: %w", path, err)
+		}
+		if suffix == "-journal" || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() != 0 {
+			return sqliteSidecarRefusal(path, info)
+		}
+		stale = append(stale, sqliteSidecar{path: path})
+	}
+	for _, sidecar := range stale {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("sidecar cleanup canceled: %w", err)
+		}
+		if err := os.Remove(sidecar.path); err != nil {
+			return fmt.Errorf("remove stale SQLite sidecar %s: %w", sidecar.path, err)
+		}
+	}
+	if len(stale) > 0 {
+		if err := syncDirectory(filepath.Dir(storePath)); err != nil {
+			return fmt.Errorf("sync SQLite sidecar cleanup directory: %w", err)
+		}
+	}
+	return rejectSQLiteSidecars(storePath)
+}
+
+func sqliteSidecarRefusal(path string, info os.FileInfo) error {
+	return fmt.Errorf("SQLite sidecar %s is %s with size %d bytes; stop other Traceary processes and retry", path, sqliteSidecarType(info), info.Size())
+}
+
+func sqliteSidecarType(info os.FileInfo) string {
+	mode := info.Mode()
+	switch {
+	case mode.IsRegular():
+		return "a regular file"
+	case mode&os.ModeSymlink != 0:
+		return "a symlink"
+	case mode&os.ModeNamedPipe != 0:
+		return "a FIFO"
+	case mode.IsDir():
+		return "a directory"
+	default:
+		return fmt.Sprintf("a %s", mode.Type().String())
+	}
+}

--- a/infrastructure/sqlite/compaction_sidecars.go
+++ b/infrastructure/sqlite/compaction_sidecars.go
@@ -30,10 +30,18 @@ func cleanupStaleSQLiteSidecars(ctx context.Context, storePath string) error {
 		if err != nil {
 			return fmt.Errorf("stat SQLite sidecar %s: %w", path, err)
 		}
-		if suffix == "-journal" || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() != 0 {
+		if suffix == "-journal" || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
 			return sqliteSidecarRefusal(path, info)
 		}
-		stale = append(stale, sqliteSidecar{path: path})
+		if suffix == "-wal" && info.Size() != 0 {
+			return sqliteSidecarRefusal(path, info)
+		}
+		// The shm file contains no database content and is never fsynced. When
+		// the WAL's mxFrame is zero, the WAL is empty and all content comes from
+		// the main database file, so a regular shm is stale regardless of size.
+		if suffix == "-wal" || suffix == "-shm" {
+			stale = append(stale, sqliteSidecar{path: path})
+		}
 	}
 	for _, sidecar := range stale {
 		if err := ctx.Err(); err != nil {

--- a/infrastructure/sqlite/compaction_sidecars_test.go
+++ b/infrastructure/sqlite/compaction_sidecars_test.go
@@ -13,19 +13,18 @@ import (
 func TestCleanupStaleSQLiteSidecars(t *testing.T) {
 	tests := []struct {
 		name       string
-		suffix     string
-		content    []byte
-		makePath   func(string) error
+		sidecars   []sidecarFixture
 		wantRemove bool
 		wantType   string
 	}{
-		{name: "zero byte WAL", suffix: "-wal", wantRemove: true},
-		{name: "zero byte SHM", suffix: "-shm", wantRemove: true},
-		{name: "non-zero WAL", suffix: "-wal", content: []byte("live"), wantType: "regular file"},
-		{name: "zero byte journal", suffix: "-journal", wantType: "regular file"},
-		{name: "non-zero journal", suffix: "-journal", content: []byte("live"), wantType: "regular file"},
-		{name: "symlink WAL", suffix: "-wal", makePath: func(path string) error { return os.Symlink("target", path) }, wantType: "symlink"},
-		{name: "FIFO SHM", suffix: "-shm", makePath: func(path string) error { return syscall.Mkfifo(path, 0o600) }, wantType: "FIFO"},
+		{name: "zero byte WAL", sidecars: []sidecarFixture{{suffix: "-wal"}}, wantRemove: true},
+		{name: "SHM alone", sidecars: []sidecarFixture{{suffix: "-shm"}}, wantRemove: true},
+		{name: "zero byte WAL beside 32 KB SHM", sidecars: []sidecarFixture{{suffix: "-wal"}, {suffix: "-shm", content: make([]byte, 32*1024)}}, wantRemove: true},
+		{name: "non-zero WAL", sidecars: []sidecarFixture{{suffix: "-wal", content: []byte("live")}}, wantType: "regular file"},
+		{name: "zero byte journal", sidecars: []sidecarFixture{{suffix: "-journal"}}, wantType: "regular file"},
+		{name: "non-zero journal", sidecars: []sidecarFixture{{suffix: "-journal", content: []byte("live")}}, wantType: "regular file"},
+		{name: "symlink WAL", sidecars: []sidecarFixture{{suffix: "-wal", makePath: func(path string) error { return os.Symlink("target", path) }}}, wantType: "symlink"},
+		{name: "FIFO SHM", sidecars: []sidecarFixture{{suffix: "-shm", makePath: func(path string) error { return syscall.Mkfifo(path, 0o600) }}}, wantType: "FIFO"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -34,33 +33,43 @@ func TestCleanupStaleSQLiteSidecars(t *testing.T) {
 			if err := os.WriteFile(store, []byte("store"), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			sidecar := store + tt.suffix
-			var err error
-			if tt.makePath != nil {
-				err = tt.makePath(sidecar)
-			} else {
-				err = os.WriteFile(sidecar, tt.content, 0o600)
-			}
-			if err != nil {
-				t.Skipf("sidecar fixture unavailable: %v", err)
+			for _, fixture := range tt.sidecars {
+				sidecar := store + fixture.suffix
+				var err error
+				if fixture.makePath != nil {
+					err = fixture.makePath(sidecar)
+				} else {
+					err = os.WriteFile(sidecar, fixture.content, 0o600)
+				}
+				if err != nil {
+					t.Skipf("sidecar fixture unavailable: %v", err)
+				}
 			}
 
-			err = cleanupStaleSQLiteSidecars(context.Background(), store)
+			err := cleanupStaleSQLiteSidecars(context.Background(), store)
 			if tt.wantRemove {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if _, statErr := os.Lstat(sidecar); !errors.Is(statErr, os.ErrNotExist) {
-					t.Fatalf("sidecar remains: %v", statErr)
+				for _, fixture := range tt.sidecars {
+					if _, statErr := os.Lstat(store + fixture.suffix); !errors.Is(statErr, os.ErrNotExist) {
+						t.Fatalf("sidecar remains: %v", statErr)
+					}
 				}
 				return
 			}
 			if err == nil || !strings.Contains(err.Error(), tt.wantType) || !strings.Contains(err.Error(), "stop other Traceary processes and retry") {
 				t.Fatalf("error = %v, want type %q and recovery instruction", err, tt.wantType)
 			}
-			if _, statErr := os.Lstat(sidecar); statErr != nil {
+			if _, statErr := os.Lstat(store + tt.sidecars[0].suffix); statErr != nil {
 				t.Fatalf("refused sidecar was changed: %v", statErr)
 			}
 		})
 	}
+}
+
+type sidecarFixture struct {
+	suffix   string
+	content  []byte
+	makePath func(string) error
 }

--- a/infrastructure/sqlite/compaction_sidecars_test.go
+++ b/infrastructure/sqlite/compaction_sidecars_test.go
@@ -1,0 +1,66 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestCleanupStaleSQLiteSidecars(t *testing.T) {
+	tests := []struct {
+		name       string
+		suffix     string
+		content    []byte
+		makePath   func(string) error
+		wantRemove bool
+		wantType   string
+	}{
+		{name: "zero byte WAL", suffix: "-wal", wantRemove: true},
+		{name: "zero byte SHM", suffix: "-shm", wantRemove: true},
+		{name: "non-zero WAL", suffix: "-wal", content: []byte("live"), wantType: "regular file"},
+		{name: "zero byte journal", suffix: "-journal", wantType: "regular file"},
+		{name: "non-zero journal", suffix: "-journal", content: []byte("live"), wantType: "regular file"},
+		{name: "symlink WAL", suffix: "-wal", makePath: func(path string) error { return os.Symlink("target", path) }, wantType: "symlink"},
+		{name: "FIFO SHM", suffix: "-shm", makePath: func(path string) error { return syscall.Mkfifo(path, 0o600) }, wantType: "FIFO"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store := filepath.Join(dir, "store.db")
+			if err := os.WriteFile(store, []byte("store"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			sidecar := store + tt.suffix
+			var err error
+			if tt.makePath != nil {
+				err = tt.makePath(sidecar)
+			} else {
+				err = os.WriteFile(sidecar, tt.content, 0o600)
+			}
+			if err != nil {
+				t.Skipf("sidecar fixture unavailable: %v", err)
+			}
+
+			err = cleanupStaleSQLiteSidecars(context.Background(), store)
+			if tt.wantRemove {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, statErr := os.Lstat(sidecar); !errors.Is(statErr, os.ErrNotExist) {
+					t.Fatalf("sidecar remains: %v", statErr)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantType) || !strings.Contains(err.Error(), "stop other Traceary processes and retry") {
+				t.Fatalf("error = %v, want type %q and recovery instruction", err, tt.wantType)
+			}
+			if _, statErr := os.Lstat(sidecar); statErr != nil {
+				t.Fatalf("refused sidecar was changed: %v", statErr)
+			}
+		})
+	}
+}

--- a/infrastructure/sqlite/compaction_sqlite_test.go
+++ b/infrastructure/sqlite/compaction_sqlite_test.go
@@ -119,7 +119,7 @@ func TestStoreCompactionSmallAllocatedShapeE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 	planningJournal := &CompactionFileJournal{Dir: filepath.Join(dir, "planning-journal")}
-	planner := usecase.NewStoreCompactionUsecase(source, planningJournal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	planner := usecase.NewStoreCompactionUsecase(source, planningJournal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err := planner.Plan(ctx, source)
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +134,7 @@ func TestStoreCompactionSmallAllocatedShapeE2E(t *testing.T) {
 	if err := journal.Create(ctx, run); err != nil {
 		t.Fatal(err)
 	}
-	service := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	service := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err = service.Apply(ctx, run.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -192,7 +192,7 @@ func TestStoreCompactionResumeReplacesRunOwnedNearCapacityPartialCandidate(t *te
 		t.Fatal(err)
 	}
 	plannerJournal := &CompactionFileJournal{Dir: filepath.Join(dir, "planner")}
-	planner := usecase.NewStoreCompactionUsecase(source, plannerJournal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	planner := usecase.NewStoreCompactionUsecase(source, plannerJournal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err := planner.Plan(ctx, source)
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +209,7 @@ func TestStoreCompactionResumeReplacesRunOwnedNearCapacityPartialCandidate(t *te
 	if err := journal.Append(ctx, run); err != nil {
 		t.Fatal(err)
 	}
-	files := StoreReplacementFiles{}
+	files := StoreReplacementFiles{CallerHoldsExclusiveLease: true}
 	prepared, err := files.PrepareCandidate(ctx, run)
 	if err != nil {
 		t.Fatal(err)
@@ -240,7 +240,7 @@ func TestStoreCompactionResumeReplacesRunOwnedNearCapacityPartialCandidate(t *te
 		t.Fatal(err)
 	}
 	t.Logf("source=%d partial=%d", len(data), partialSize)
-	fresh := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	fresh := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	got, err := fresh.Resume(ctx, run.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -270,7 +270,7 @@ func TestStoreCompactionResumePreservesUnknownValidCandidate(t *testing.T) {
 	_, _ = db.Exec(`CREATE TABLE expected(v TEXT); INSERT INTO expected VALUES('source')`)
 	_ = db.Close()
 	plannerJournal := &CompactionFileJournal{Dir: filepath.Join(dir, "planner")}
-	planner := usecase.NewStoreCompactionUsecase(source, plannerJournal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	planner := usecase.NewStoreCompactionUsecase(source, plannerJournal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err := planner.Plan(ctx, source)
 	if err != nil {
 		t.Fatal(err)
@@ -291,7 +291,7 @@ func TestStoreCompactionResumePreservesUnknownValidCandidate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fresh := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	fresh := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	if _, err := fresh.Resume(ctx, run.ID); err == nil {
 		t.Fatal("Resume accepted unknown valid candidate")
 	}
@@ -319,7 +319,7 @@ func TestStoreCompactionResumeDoesNotAdoptCrashGapEmptyCandidate(t *testing.T) {
 	_, _ = db.Exec(`CREATE TABLE expected(v TEXT)`)
 	_ = db.Close()
 	planning := &CompactionFileJournal{Dir: filepath.Join(dir, "planning")}
-	planner := usecase.NewStoreCompactionUsecase(source, planning, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	planner := usecase.NewStoreCompactionUsecase(source, planning, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err := planner.Plan(ctx, source)
 	if err != nil {
 		t.Fatal(err)
@@ -333,7 +333,7 @@ func TestStoreCompactionResumeDoesNotAdoptCrashGapEmptyCandidate(t *testing.T) {
 	if err := journal.Append(ctx, run); err != nil {
 		t.Fatal(err)
 	}
-	files := StoreReplacementFiles{}
+	files := StoreReplacementFiles{CallerHoldsExclusiveLease: true}
 	identity, err := files.PrepareCandidate(ctx, run)
 	if err != nil {
 		t.Fatal(err)
@@ -383,7 +383,7 @@ func TestStoreCompactionResumeRejectsReplacedPreparedCandidateInode(t *testing.T
 	if err := os.Rename(replacementPath, run.CandidatePath); err != nil {
 		t.Fatal(err)
 	}
-	fresh := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	fresh := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	if _, err := fresh.Resume(ctx, run.ID); err == nil {
 		t.Fatal("Resume accepted a replacement inode")
 	}
@@ -420,7 +420,7 @@ func TestStoreCompactionResumeRebuildsValidIncompletePreparedCandidate(t *testin
 	if !observed.SameInode(run.PreparedCandidateIdentity) {
 		t.Fatal("SQLite replaced the prepared inode")
 	}
-	fresh := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	fresh := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	got, err := fresh.Resume(ctx, run.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -438,7 +438,7 @@ func TestStoreCompactionApplyRejectsSameContentReplacementAfterVerification(t *t
 	_, _ = db.Exec(`CREATE TABLE expected(v TEXT); INSERT INTO expected VALUES('source')`)
 	_ = db.Close()
 	journal := &CompactionFileJournal{Dir: filepath.Join(dir, "journal")}
-	planner := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	planner := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err := planner.Plan(ctx, source)
 	if err != nil {
 		t.Fatal(err)
@@ -450,7 +450,7 @@ func TestStoreCompactionApplyRejectsSameContentReplacementAfterVerification(t *t
 		t.Fatal(err)
 	}
 	builder := replacingAfterVerifyBuilder{SQLiteCompactionBuilder: SQLiteCompactionBuilder{}}
-	service := usecase.NewStoreCompactionUsecase(source, journal, builder, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	service := usecase.NewStoreCompactionUsecase(source, journal, builder, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	if _, err := service.Apply(ctx, run.ID); err == nil {
 		t.Fatal("Apply accepted a same-content replacement inode")
 	}
@@ -504,7 +504,7 @@ func TestStoreCompactionExclusiveBoundaryRejectsLateHardLinkBeforeObservation(t 
 			}
 			run := domain.CompactionRun{ID: "0123456789abcdef0123456789abcdef", SourcePath: source, CandidatePath: candidate, RollbackPath: rollback, Phase: tc.phase}
 			journal := &observationTrackingJournal{run: run}
-			service := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+			service := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 			hardlink := filepath.Join(realDir, "late-hardlink.db")
 			if err := os.Link(filepath.Join(realDir, "store.db"), hardlink); err != nil {
 				t.Fatal(err)
@@ -584,7 +584,7 @@ func (b replacingAfterVerifyBuilder) VerifyPair(ctx context.Context, source, can
 func prepareCompactionCandidateForResumeTest(ctx context.Context, t *testing.T, source, dir string) (domain.CompactionRun, *CompactionFileJournal) {
 	t.Helper()
 	planning := &CompactionFileJournal{Dir: filepath.Join(dir, "planning")}
-	planner := usecase.NewStoreCompactionUsecase(source, planning, SQLiteCompactionBuilder{}, StoreReplacementFiles{}, StoreLeaseCoordinator{})
+	planner := usecase.NewStoreCompactionUsecase(source, planning, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
 	run, err := planner.Plan(ctx, source)
 	if err != nil {
 		t.Fatal(err)
@@ -598,7 +598,7 @@ func prepareCompactionCandidateForResumeTest(ctx context.Context, t *testing.T, 
 	if err := journal.Append(ctx, run); err != nil {
 		t.Fatal(err)
 	}
-	identity, err := (StoreReplacementFiles{}).PrepareCandidate(ctx, run)
+	identity, err := (StoreReplacementFiles{CallerHoldsExclusiveLease: true}).PrepareCandidate(ctx, run)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/infrastructure/sqlite/legacy_search_retire_compaction_test.go
+++ b/infrastructure/sqlite/legacy_search_retire_compaction_test.go
@@ -26,7 +26,7 @@ func TestCompactionRefusesAStoreThatStillCarriesTheLegacySearchFamily(t *testing
 		source,
 		&CompactionFileJournal{Dir: filepath.Join(dir, "planning-journal")},
 		SQLiteCompactionBuilder{},
-		StoreReplacementFiles{},
+		StoreReplacementFiles{CallerHoldsExclusiveLease: true},
 		StoreLeaseCoordinator{},
 	)
 	_, err := planner.Plan(ctx, source)

--- a/infrastructure/sqlite/store_lease.go
+++ b/infrastructure/sqlite/store_lease.go
@@ -56,6 +56,18 @@ func (StoreLeaseCoordinator) AcquireExclusive(ctx context.Context, path string) 
 	return func() { once.Do(func() { _ = lease.Close() }) }, nil
 }
 
+func probeStoreLeaseCapability(ctx context.Context, path string) error {
+	lockPath, err := canonicalLeasePath(path)
+	if err != nil {
+		return err
+	}
+	lease, err := acquireAdvisoryLease(ctx, lockPath, true)
+	if err != nil {
+		return err
+	}
+	return lease.Close()
+}
+
 // openCoordinatedDB makes the shared OS lease lifetime identical to each
 // physical driver.Conn lifetime. The stable adjacent lock file survives the
 // database inode exchange performed by compaction.

--- a/infrastructure/sqlite/store_lease.go
+++ b/infrastructure/sqlite/store_lease.go
@@ -56,18 +56,6 @@ func (StoreLeaseCoordinator) AcquireExclusive(ctx context.Context, path string) 
 	return func() { once.Do(func() { _ = lease.Close() }) }, nil
 }
 
-func probeStoreLeaseCapability(ctx context.Context, path string) error {
-	lockPath, err := canonicalLeasePath(path)
-	if err != nil {
-		return err
-	}
-	lease, err := acquireAdvisoryLease(ctx, lockPath, true)
-	if err != nil {
-		return err
-	}
-	return lease.Close()
-}
-
 // openCoordinatedDB makes the shared OS lease lifetime identical to each
 // physical driver.Conn lifetime. The stable adjacent lock file survives the
 // database inode exchange performed by compaction.

--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func run() error {
 		cli.WithLegacySearchRetire(usecase.NewLegacySearchRetireUsecase(db)),
 		cli.WithStoreCompactionFactory(func(path string) application.StoreCompactionUsecase {
 			journal := &sqlite.CompactionFileJournal{Dir: filepath.Join(filepath.Dir(path), ".traceary-compaction")}
-			return usecase.NewStoreCompactionUsecase(path, journal, sqlite.SQLiteCompactionBuilder{}, sqlite.StoreReplacementFiles{}, sqlite.StoreLeaseCoordinator{})
+			return usecase.NewStoreCompactionUsecase(path, journal, sqlite.SQLiteCompactionBuilder{}, sqlite.StoreReplacementFiles{CallerHoldsExclusiveLease: true}, sqlite.StoreLeaseCoordinator{})
 		}),
 		cli.WithPayloadRehearsal(payloadRehearsalUsecase),
 		cli.WithPayloadBackfill(payloadBackfillUsecase),


### PR DESCRIPTION
Closes #1845.

`store compact` deadlocked its own documented operator sequence. After `plan`, running `store search-projection status` left a zero-byte `-wal` and a 32 KB `-shm` behind, and every subsequent compaction command refused on their mere existence — identically, forever. The only escape was an undocumented, unrelated mutation: any writing command cleared the sidecars. This is a v0.34.0 release blocker, found while cutting the RC.

## What changed

`plan` now takes the exclusive store lease for its whole preflight, as `apply` and `resume` already did. While it is held, a stale WAL artifact is recovered rather than refused:

- `-journal` present in any form -> refuse, unchanged.
- Any sidecar that is not a regular file (symlink, FIFO, directory) -> refuse, unchanged.
- `-wal` present and non-zero -> refuse, unchanged. This is the case that may hold committed frames.
- Otherwise remove both `-wal` and `-shm`, whatever the `-shm`'s size is, sync the directory, and re-run the strict check.

`Recheck` — the apply/resume preflight — does the same, because the sidecar in the reproduction appears *after* `plan` returns. `RecheckForPublish` deliberately stays strict: cleanup has already happened under the lease, so a sidecar appearing there means an opener arrived mid-run and the run must abort. Candidate-path guards stay strict too; a sidecar beside a file we built ourselves is a surprise, not an artifact.

The refusal message now names the sidecar's type and size and tells the operator what to do, instead of `SQLite sidecar exists: <path>`.

### Recovery is gated on the lease, not assumed

`PreparedStoreUpgradeFiles` is shared by two use cases, and only `storeCompactionUsecase` holds the exclusive lease across `Plan`/`Recheck`. `preparedStoreUpgradeUsecase` — the `store payload-rehearsal` path — acquires it only at the publish steps. So the adapter now carries an explicit `CallerHoldsExclusiveLease`, set only where the compaction use case is wired. With it, sidecars are recovered; without it, they are refused exactly as before this PR. `lease_capability` is derived from the same field rather than hardcoded, so the `!LeaseCapability` guard stays meaningful for the unleased caller and for a run persisted by an older binary.

### Why the `-shm` size is not a criterion

The first attempt required both sidecars to be zero-byte and could therefore never fire on the reproduction it was written for: a cleanly-closed reader always leaves a 32,768-byte `-shm`. Per the [SQLite WAL format specification](https://www.sqlite.org/walformat.html), the shm "does not contain any database content and is not required to recover the database following a crash", is "never fsync()-ed to disk", and is normally truncated by the first client to connect to a quiescent database; and when the WAL's `mxFrame` is zero "all content should be obtained directly from the database file". The `-wal` carries the recoverable state, so its length is the evidence and the `-shm`'s is not.

### Why this cannot race a live opener

Cleanup runs only once the exclusive lease is held, and every live cooperating connection holds the shared form of the same lease, so the acquisition waits rather than deleting anything. Non-cooperating SQLite clients remain outside this advisory-lock boundary — the same boundary the replacement protocol already depends on, so no new assumption.

## Verification

Measured on binaries built from this branch, not asserted.

**The reported reproduction, no manual intervention:**

```
after log                        clean
after search-retire              clean
after compact plan               clean
after search-projection status   -wal 0 bytes, -shm 32,768 bytes
apply RUN_ID                     phase: committed
PRAGMA integrity_check           ok
```

with the logical digest (events / sessions / command_audits counts and total body length) unchanged. Also run through `resume` instead of `apply`.

**Refusals still hold** (each measured, each a separate scratch store):

| case | result |
|---|---|
| `-wal` of 819,912 bytes, live writer connected | refused, size reported |
| zero-byte `-journal` | refused |
| `-wal` symlinked to `/etc/hosts` | refused, type reported |
| zero-byte `-wal` + 32 KB `-shm` on the unleased rehearsal path | refused, both files untouched |

`store payload-rehearsal preview` and `run` still succeed on a clean copy.

**Lease exclusion, measured:**

- With another process holding the **exclusive** lease, `plan` waited 3.61 s and then succeeded.
- With another process holding the **shared** lease for 8 s, `plan` blocked 7.15 s — its full remaining lifetime — and removed the `-wal` only after it released. It did not delete a sidecar out from under the holder.

`go build ./...`, `go test ./...`, `go tool golangci-lint run`, `go run ./cmd/repo-tooling docs verify-i18n` all pass.

## Review

Implementation by gpt-5.6-luna over four rounds; review and the final verification by Claude Opus 5. Round 1 cleaned up in `plan` only, so the reproduction still failed at `apply` — caught by running it. Round 2 added `Recheck` but kept the zero-byte rule for `-shm`, which cannot fire on the real reproduction — caught by luna and corrected against the SQLite specification. Round 4 fixed a HIGH from the gpt-5.6-sol review: the cleanup was reachable from the unleased prepared-upgrade path, where its safety argument does not hold. gpt-5.6-sol also reviewed the blocker-vs-defer call and the shape of the fix before any code was written.
