### PR TITLE
fix: bound payload rehearsal failure cleanup

### DIFF
--- a/application/usecase/payload_rehearsal.go
+++ b/application/usecase/payload_rehearsal.go
@@ -96,7 +96,9 @@ func (u *payloadRehearsalUsecase) run(ctx context.Context, c types.PayloadRehear
 		return result, xerrors.Errorf("prepare payload rehearsal: %w", err)
 	}
 	if result, err = liveResult(result); err != nil {
-		_, _ = u.workflow.Pause(context.WithoutCancel(ctx), handle)
+		pauseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+		_, _ = u.workflow.Pause(pauseCtx, handle)
+		cancel()
 		_ = u.workflow.Close(handle)
 		return result, err
 	}
@@ -119,7 +121,9 @@ func (u *payloadRehearsalUsecase) run(ctx context.Context, c types.PayloadRehear
 				return result, xerrors.Errorf("advance payload rehearsal: %w", err)
 			}
 			if result, err = liveResult(result); err != nil {
-				_, _ = u.workflow.Pause(context.WithoutCancel(ctx), handle)
+				pauseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+				_, _ = u.workflow.Pause(pauseCtx, handle)
+				cancel()
 				return result, err
 			}
 			if c.StopAfterBatches > 0 && result.BatchCount-initialBatches >= c.StopAfterBatches && (!done || fieldIndex != len(fields)-1) {
@@ -165,7 +169,9 @@ func (u *payloadRehearsalUsecase) Scrub(ctx context.Context, c types.PayloadRehe
 		return types.PayloadRehearsalMetrics{}, xerrors.Errorf("prepare payload rehearsal scrub: %w", err)
 	}
 	if result, err = liveResult(result); err != nil {
-		_ = u.scrubber.ReleaseScrub(context.WithoutCancel(ctx), handle)
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+		_ = u.scrubber.ReleaseScrub(releaseCtx, handle)
+		cancel()
 		_ = u.scrubber.CloseScrub(handle)
 		return result, err
 	}

--- a/application/usecase/payload_rehearsal_test.go
+++ b/application/usecase/payload_rehearsal_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/duck8823/traceary/application"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"golang.org/x/xerrors"
 )
 
 type rehearsalBackendFake struct {
@@ -24,6 +27,9 @@ type rehearsalBackendFake struct {
 	advancesRemaining    int
 	cancelAfterAdvance   func()
 	pauseContextErr      error
+	pauseBlocks          bool
+	releaseBlocks        bool
+	cleanupStarted       chan struct{}
 }
 type fakeRunHandle struct{}
 type fakeScrubHandle struct{}
@@ -77,6 +83,11 @@ func TestPayloadRehearsalStopsAfterCommittedBatchBoundary(t *testing.T) {
 	}
 }
 func (f *rehearsalBackendFake) Pause(ctx context.Context, _ application.PayloadRehearsalRunHandle) (apptypes.PayloadRehearsalMetrics, error) {
+	if f.pauseBlocks {
+		close(f.cleanupStarted)
+		<-ctx.Done()
+		return f.run, xerrors.Errorf("pause cleanup context: %w", ctx.Err())
+	}
 	f.pauseContextErr = ctx.Err()
 	f.run.State = "paused"
 	return f.run, nil
@@ -123,7 +134,12 @@ func (f *rehearsalBackendFake) CompleteScrub(context.Context, application.Payloa
 	f.scrub.ActivationReadiness.ScrubPassed = true
 	return f.scrub, nil
 }
-func (*rehearsalBackendFake) ReleaseScrub(context.Context, application.PayloadRehearsalScrubHandle) error {
+func (f *rehearsalBackendFake) ReleaseScrub(ctx context.Context, _ application.PayloadRehearsalScrubHandle) error {
+	if f.releaseBlocks {
+		close(f.cleanupStarted)
+		<-ctx.Done()
+		return xerrors.Errorf("release cleanup context: %w", ctx.Err())
+	}
 	return nil
 }
 func (*rehearsalBackendFake) CloseScrub(application.PayloadRehearsalScrubHandle) error { return nil }
@@ -170,6 +186,84 @@ func TestPayloadRehearsalUsecaseRejectsUnboundedBatchBeforeBackend(t *testing.T)
 	}
 	if len(f.calls) != 0 {
 		t.Fatalf("backend calls = %v", f.calls)
+	}
+}
+
+func TestPayloadRehearsalBoundsFailureCleanup(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		setup      func(*rehearsalBackendFake)
+		act        func(*rehearsalBackendFake) (apptypes.PayloadRehearsalMetrics, error)
+		wantResult apptypes.PayloadRehearsalMetrics
+	}{
+		{
+			name: "run prepare live result failure",
+			setup: func(f *rehearsalBackendFake) {
+				f.run.LiveIdentityOnly = false
+				f.pauseBlocks = true
+			},
+			act: func(f *rehearsalBackendFake) (apptypes.PayloadRehearsalMetrics, error) {
+				return usecase.NewPayloadRehearsalUsecase(f, f, f, f).Run(context.Background(), validRehearsalConfig())
+			},
+			wantResult: apptypes.PayloadRehearsalMetrics{State: "running", LiveIdentityOnly: false},
+		},
+		{
+			name: "run advance live result failure",
+			setup: func(f *rehearsalBackendFake) {
+				f.driftRunAdvance = true
+				f.pauseBlocks = true
+			},
+			act: func(f *rehearsalBackendFake) (apptypes.PayloadRehearsalMetrics, error) {
+				return usecase.NewPayloadRehearsalUsecase(f, f, f, f).Resume(context.Background(), validRehearsalConfig())
+			},
+			wantResult: apptypes.PayloadRehearsalMetrics{State: "running", LiveIdentityOnly: false},
+		},
+		{
+			name: "scrub prepare live result failure",
+			setup: func(f *rehearsalBackendFake) {
+				f.scrub.LiveIdentityOnly = false
+				f.releaseBlocks = true
+			},
+			act: func(f *rehearsalBackendFake) (apptypes.PayloadRehearsalMetrics, error) {
+				return usecase.NewPayloadRehearsalUsecase(f, f, f, f).Scrub(context.Background(), validRehearsalConfig())
+			},
+			wantResult: apptypes.PayloadRehearsalMetrics{State: "scrubbing", LiveIdentityOnly: false},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &rehearsalBackendFake{
+				preview:        apptypes.PayloadRehearsalMetrics{State: "planned", DryRunZeroWrite: true, LiveIdentityOnly: true, FreeBytes: 100, EstimatedHeadroom: 50},
+				run:            apptypes.PayloadRehearsalMetrics{State: "running", LiveIdentityOnly: true},
+				scrub:          apptypes.PayloadRehearsalMetrics{State: "scrubbing", LiveIdentityOnly: true},
+				cleanupStarted: make(chan struct{}),
+			}
+			tc.setup(f)
+			done := make(chan struct{})
+			var got apptypes.PayloadRehearsalMetrics
+			var err error
+			go func() {
+				got, err = tc.act(f)
+				close(done)
+			}()
+			select {
+			case <-f.cleanupStarted:
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("cleanup call was not reached")
+			}
+			select {
+			case <-done:
+			case <-time.After(1500 * time.Millisecond):
+				t.Fatal("cleanup call did not return within the one-second bound")
+			}
+			want := tc.wantResult
+			want.ActivationReadiness = application.EvaluatePayloadActivationReadiness(want)
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("result mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(usecase.ErrUnsafePayloadRehearsalTransition, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("error mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #1791

`application/usecase/payload_rehearsal.go` calls `Pause` / `ReleaseScrub` six times on terminal paths. Three were bounded to one second; three passed `context.WithoutCancel(ctx)` directly.

`context.WithoutCancel` strips the caller's deadline along with its cancellation, so those three waited on nothing. Both calls reach the store, and acquiring the store lease waits only on the context — so a concurrent lease holder made those sites hang with no ceiling. Lines 99 and 168 sit on the failure path of a `liveResult` check, which runs exactly when something is already wrong.

Losing a checkpoint is recoverable. Hanging is not. `infrastructure/sqlite/payload_backfill.go` already records that reasoning for the equivalent write, and the three bounded sites in this same function already implement it.

## Change

All three now use the idiom the bounded sites already use — `context.WithTimeout(context.WithoutCancel(ctx), time.Second)` with `cancel` called. The file has one spelling instead of two. No timeout value changed, no error handling changed, nothing outside this file and its tests touched.

## Tests

`TestPayloadRehearsalBoundsFailureCleanup`, table-driven over the three paths: `run` via the prepare-then-`liveResult`-failure route, `run` via the advance route, and `Scrub`. Each stub blocks until its context is done, so the test distinguishes "returned because the bound fired" from "returned immediately".

Verified they pin the defect rather than passing either way — with `application/usecase/payload_rehearsal.go` restored from `origin/main`:

```
--- FAIL: TestPayloadRehearsalBoundsFailureCleanup (4.51s)
    --- FAIL: .../run_prepare_live_result_failure (1.50s)
        payload_rehearsal_test.go:256: cleanup call did not return within the one-second bound
    --- FAIL: .../run_advance_live_result_failure (1.50s)
    --- FAIL: .../scrub_prepare_live_result_failure (1.50s)
```

All three pass on this branch.

## Documentation

Checked whether any release note claimed these paths were already bounded. The CHANGELOG's "migration, scrub, rollback, WAL reservations are bounded" refers to resource limits in the processing body, not failure cleanup, and no document claims all six cleanup sites are bounded. The release note was not overclaiming.

`go build ./...`, `go test ./...`, `go tool golangci-lint run` (0 issues), `docs verify-i18n`, `docs verify-commands` all green.

Co-authored-by: gpt-5.6-luna <noreply@openai.com>
