### PR TITLE
Raise Grok and Kimi hook timeouts from 5s to 10s

### DIFF
--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -552,7 +552,7 @@ func checkKimi(root, version string) error {
 	for i, want := range expectedHooks {
 		hook := manifest.Hooks[i]
 		expectedCommand := "traceary hook kimi " + want.action
-		if hook.Event != want.event || hook.Matcher != want.matcher || hook.Command != expectedCommand || hook.Timeout != 5 {
+		if hook.Event != want.event || hook.Matcher != want.matcher || hook.Command != expectedCommand || hook.Timeout != 10 {
 			return xerrors.Errorf("kimi plugin hook rule %d (%s) drifted from the verified Kimi contract", i, want.event)
 		}
 	}
@@ -599,7 +599,7 @@ func checkGrokHooks(path string, hooks hookFile) error {
 		}
 		command := entries[0].Hooks[0]
 		expectedCommand := `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "` + want.action + `"`
-		if command.Name != want.name || command.Type != "command" || command.Command != expectedCommand || command.Timeout != 5 {
+		if command.Name != want.name || command.Type != "command" || command.Command != expectedCommand || command.Timeout != 10 {
 			return xerrors.Errorf("%s %s command drifted from the verified Grok contract", path, want.event)
 		}
 	}

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -261,7 +261,7 @@ func grokHookFixture() hookFile {
 		{"PostCompact", "traceary-compact-post", "post-compact"},
 	} {
 		hooks[spec.event] = []hookEntry{{Hooks: []hookCommand{{
-			Name: spec.name, Type: "command", Timeout: 5,
+			Name: spec.name, Type: "command", Timeout: 10,
 			Command: `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "` + spec.action + `"`,
 		}}}}
 	}

--- a/infrastructure/filesystem/grok_hooks_handler.go
+++ b/infrastructure/filesystem/grok_hooks_handler.go
@@ -16,10 +16,15 @@ func NewGrokHooksHandler() *GrokHooksHandler { return &GrokHooksHandler{} }
 // Name returns the canonical client identifier.
 func (h *GrokHooksHandler) Name() string { return "grok" }
 
+// grokHookTimeoutSeconds is the per-hook timeout written into
+// `.grok/hooks/traceary.json`. Grok's default is 5s; 10s matches the packaged
+// plugin, Gemini, Antigravity, and Kimi host budgets.
+const grokHookTimeoutSeconds = 10
+
 // Build returns the native Grok hook plan for the core events verified against
 // Grok Build 0.2.99. Contract events without live payload evidence are omitted.
 func (h *GrokHooksHandler) Build(tracearyBin string) model.Hooks {
-	const timeoutSeconds = 5
+	timeoutSeconds := grokHookTimeoutSeconds
 	actionByEvent := []struct {
 		event  string
 		action string

--- a/infrastructure/filesystem/grok_hooks_handler_test.go
+++ b/infrastructure/filesystem/grok_hooks_handler_test.go
@@ -27,6 +27,10 @@ func TestGrokHooksHandler_BuildsVerifiedCoreHooks(t *testing.T) {
 		if len(entries) != 1 || len(entries[0].Commands()) != 1 {
 			t.Fatalf("Build().Entries(%q) = %v, want one command", event, entries)
 		}
+		timeout, ok := entries[0].Commands()[0].Timeout().Value()
+		if !ok || timeout != 10 {
+			t.Fatalf("Build().Entries(%q) timeout = %d, present=%v, want 10", event, timeout, ok)
+		}
 	}
 
 	projectDir := t.TempDir()

--- a/infrastructure/filesystem/kimi_hooks_handler.go
+++ b/infrastructure/filesystem/kimi_hooks_handler.go
@@ -11,9 +11,9 @@ import (
 
 // kimiHookTimeoutSeconds is the per-hook timeout written into the generated
 // Kimi Code [[hooks]] rules. Kimi's default is 30s; Traceary's runtime
-// entrypoints are fail-soft and quick, so 5s keeps a slow disk from stalling
-// the host loop while leaving ample headroom (matching the Grok contract).
-const kimiHookTimeoutSeconds = 5
+// entrypoints are fail-soft and quick, so 10s matches the packaged Grok,
+// Gemini, and Antigravity host budgets and the hook-spool drain assumption.
+const kimiHookTimeoutSeconds = 10
 
 // KimiHooksHandler is the client-specific boundary for Kimi Code hooks.
 //

--- a/infrastructure/filesystem/kimi_hooks_handler_test.go
+++ b/infrastructure/filesystem/kimi_hooks_handler_test.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,7 +69,7 @@ func TestKimiHooksHandler_RendersTOMLHookRules(t *testing.T) {
 			t.Errorf("rendered document missing runtime command for action %q", action)
 		}
 	}
-	if !strings.Contains(text, "timeout = 5") {
+	if !strings.Contains(text, fmt.Sprintf("timeout = %d", kimiHookTimeoutSeconds)) {
 		t.Error("rendered document missing per-hook timeout")
 	}
 }
@@ -140,8 +141,8 @@ func TestKimiHooksHandler_RenderedTOMLParses(t *testing.T) {
 		if !strings.Contains(hook.Command, "'/tmp/traceary bin/traceary' 'hook' 'kimi' '") {
 			t.Errorf("parsed command %q lost the quoted traceary bin path", hook.Command)
 		}
-		if hook.Timeout != 5 {
-			t.Errorf("parsed timeout = %d, want 5", hook.Timeout)
+		if hook.Timeout != kimiHookTimeoutSeconds {
+			t.Errorf("parsed timeout = %d, want %d", hook.Timeout, kimiHookTimeoutSeconds)
 		}
 		if hook.Matcher == "Agent" {
 			agentMatcherRules++

--- a/integrations/grok-plugin/hooks/hooks.json
+++ b/integrations/grok-plugin/hooks/hooks.json
@@ -1,12 +1,12 @@
 {
   "description": "Native Traceary lifecycle hooks for Grok Build.",
   "hooks": {
-    "SessionStart": [{"hooks": [{"name": "traceary-session-start", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"session-start\"", "timeout": 5}]}],
-    "UserPromptSubmit": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"user-prompt-submit\"", "timeout": 5}]}],
-    "PreToolUse": [{"hooks": [{"name": "traceary-tool-pre", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"pre-tool-use\"", "timeout": 5}]}],
-    "PostToolUse": [{"hooks": [{"name": "traceary-audit", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"post-tool-use\"", "timeout": 5}]}],
-    "Stop": [{"hooks": [{"name": "traceary-stop", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"stop\"", "timeout": 5}]}],
-    "PreCompact": [{"hooks": [{"name": "traceary-compact-pre", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"pre-compact\"", "timeout": 5}]}],
-    "PostCompact": [{"hooks": [{"name": "traceary-compact-post", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"post-compact\"", "timeout": 5}]}]
+    "SessionStart": [{"hooks": [{"name": "traceary-session-start", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"session-start\"", "timeout": 10}]}],
+    "UserPromptSubmit": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"user-prompt-submit\"", "timeout": 10}]}],
+    "PreToolUse": [{"hooks": [{"name": "traceary-tool-pre", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"pre-tool-use\"", "timeout": 10}]}],
+    "PostToolUse": [{"hooks": [{"name": "traceary-audit", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"post-tool-use\"", "timeout": 10}]}],
+    "Stop": [{"hooks": [{"name": "traceary-stop", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"stop\"", "timeout": 10}]}],
+    "PreCompact": [{"hooks": [{"name": "traceary-compact-pre", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"pre-compact\"", "timeout": 10}]}],
+    "PostCompact": [{"hooks": [{"name": "traceary-compact-post", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"post-compact\"", "timeout": 10}]}]
   }
 }

--- a/integrations/kimi-plugin/kimi.plugin.json
+++ b/integrations/kimi-plugin/kimi.plugin.json
@@ -30,53 +30,53 @@
     {
       "event": "SessionStart",
       "command": "traceary hook kimi session-start",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "SessionEnd",
       "command": "traceary hook kimi session-end",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "UserPromptSubmit",
       "command": "traceary hook kimi user-prompt-submit",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "PreToolUse",
       "matcher": "Agent",
       "command": "traceary hook kimi pre-tool-use",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "PostToolUse",
       "command": "traceary hook kimi post-tool-use",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "PostToolUseFailure",
       "command": "traceary hook kimi post-tool-use-failure",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "Stop",
       "command": "traceary hook kimi stop",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "SubagentStop",
       "command": "traceary hook kimi subagent-stop",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "PreCompact",
       "command": "traceary hook kimi pre-compact",
-      "timeout": 5
+      "timeout": 10
     },
     {
       "event": "PostCompact",
       "command": "traceary hook kimi post-compact",
-      "timeout": 5
+      "timeout": 10
     }
   ]
 }

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -220,7 +220,7 @@ func grokHookFileHasVerifiedCoverage(path string) bool {
 		}
 		got := routes[0].Hooks[0]
 		wantCommand := `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "` + contract.action + `"`
-		if got.Name != contract.name || got.Type != "command" || got.Command != wantCommand || got.Timeout != 5 {
+		if got.Name != contract.name || got.Type != "command" || got.Command != wantCommand || got.Timeout != 10 {
 			return false
 		}
 	}

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -210,7 +210,7 @@ func writeGrokDoctorHookFixture(t *testing.T, path string, complete bool) {
 			"name":    contract.name,
 			"type":    "command",
 			"command": `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "` + contract.action + `"`,
-			"timeout": 5,
+			"timeout": 10,
 		}}}}
 	}
 	data, err := json.Marshal(map[string]any{"hooks": hooks})

--- a/presentation/cli/doctor_kimi.go
+++ b/presentation/cli/doctor_kimi.go
@@ -144,7 +144,7 @@ func kimiManifestHasVerifiedHooks(manifest kimiPluginManifest) bool {
 	}
 	for _, hook := range manifest.Hooks {
 		key := rule{hook.Event, hook.Matcher, hook.Command}
-		if _, ok := counts[key]; !ok || hook.Timeout != 5 {
+		if _, ok := counts[key]; !ok || hook.Timeout != 10 {
 			return false
 		}
 		counts[key]--

--- a/presentation/cli/doctor_kimi_internal_test.go
+++ b/presentation/cli/doctor_kimi_internal_test.go
@@ -92,16 +92,16 @@ func TestProbeKimiDoctorStateReadsManagedPluginAndRecord(t *testing.T) {
   "version": "0.28.0",
   "mcpServers": {"traceary": {"command": "traceary", "args": ["mcp-server"]}},
   "hooks": [
-    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 5},
-    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 5},
-    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 5},
-    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 5},
-    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 5},
-    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 5},
-    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 5},
-    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 5},
-    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 5},
-    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 5}
+    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 10},
+    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 10},
+    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 10},
+    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 10},
+    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 10},
+    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 10},
+    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 10},
+    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 10},
+    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 10},
+    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 10}
   ]
 }`
 	if err := os.WriteFile(filepath.Join(manifestDir, "kimi.plugin.json"), []byte(manifest), 0o600); err != nil {
@@ -181,30 +181,30 @@ func TestKimiMCPJSONRegistersRejectsInvalidDeclarations(t *testing.T) {
 
 func TestKimiManifestHasVerifiedHooksIsOrderIndependent(t *testing.T) {
 	base := `[
-    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 5},
-    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 5},
-    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 5},
-    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 5},
-    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 5},
-    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 5},
-    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 5},
-    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 5},
-    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 5},
-    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 5}
+    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 10},
+    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 10},
+    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 10},
+    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 10},
+    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 10},
+    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 10},
+    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 10},
+    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 10},
+    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 10},
+    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 10}
   ]`
 
 	t.Run("shuffled order still satisfies the contract", func(t *testing.T) {
 		shuffled := `[
-    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 5},
-    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 5},
-    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 5},
-    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 5},
-    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 5},
-    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 5},
-    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 5},
-    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 5},
-    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 5},
-    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 5}
+    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 10},
+    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 10},
+    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 10},
+    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 10},
+    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 10},
+    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 10},
+    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 10},
+    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 10},
+    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 10},
+    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 10}
   ]`
 		var manifest kimiPluginManifest
 		if err := json.Unmarshal([]byte(`{"hooks":`+shuffled+`}`), &manifest); err != nil {
@@ -218,7 +218,7 @@ func TestKimiManifestHasVerifiedHooksIsOrderIndependent(t *testing.T) {
 	t.Run("extra hook rule is rejected", func(t *testing.T) {
 		var manifest kimiPluginManifest
 		extra := base[:len(base)-2] + `,
-    {"event": "Notification", "command": "traceary hook kimi notification", "timeout": 5}
+    {"event": "Notification", "command": "traceary hook kimi notification", "timeout": 10}
   ]`
 		if err := json.Unmarshal([]byte(`{"hooks":`+extra+`}`), &manifest); err != nil {
 			t.Fatalf("decode manifest with extra rule: %v", err)

--- a/presentation/cli/hook_kimi_transcript.go
+++ b/presentation/cli/hook_kimi_transcript.go
@@ -228,7 +228,7 @@ const kimiTranscriptTurnsStateDir = "kimi-transcript-turns"
 
 // kimiTranscriptTurnLockTimeout bounds how long a Stop firing waits to
 // acquire the per-session turn-marker lock. The Kimi Stop hook's host timeout
-// is 5s (integrations/kimi-plugin/kimi.plugin.json) and the critical section
+// is 10s (integrations/kimi-plugin/kimi.plugin.json) and the critical section
 // runs a DB migration check plus an event insert against a store that can be
 // tens of GB, so this budget leaves several seconds of headroom inside the
 // host deadline for that work to finish even after a fully contended wait.
@@ -329,7 +329,7 @@ func kimiTranscriptTurnStatePath(sessionID string) (string, error) {
 // flock (unlike the prior mkdir-based lock) is released by the kernel when
 // the holding process dies for any reason, including SIGKILL — so a host
 // kill mid-critical-section (a real risk here: the section runs a DB
-// migration check plus an insert against a multi-GB store, inside a 5s host
+// migration check plus an insert against a multi-GB store, inside a 10s host
 // hook timeout) cannot leave a stale lock behind. No PID check, TTL, or
 // cleanup is needed. Acquisition is bounded by kimiTranscriptTurnLockTimeout
 // so a firing never spins past its host budget; exhausting that budget

--- a/presentation/cli/hooks_test.go
+++ b/presentation/cli/hooks_test.go
@@ -215,7 +215,7 @@ func TestRootCLI_HooksPrintCommand(t *testing.T) {
 				if diff := cmp.Diff(want, entries[0].Hooks[0].Command); diff != "" {
 					t.Fatalf("Grok %s command mismatch (-want +got):\n%s", event, diff)
 				}
-				if diff := cmp.Diff(5, entries[0].Hooks[0].Timeout); diff != "" {
+				if diff := cmp.Diff(10, entries[0].Hooks[0].Timeout); diff != "" {
 					t.Fatalf("Grok %s timeout mismatch (-want +got):\n%s", event, diff)
 				}
 			}


### PR DESCRIPTION
Closes #1882

## Summary

Grok and Kimi packaged hook budgets were 5 seconds. Gemini is 10000ms and Antigravity is 10 seconds. `hook_spool.go` already comments that packaged host budgets are 10 seconds.

This PR only raises the packaged timeouts and the doctor / repo-tooling / filesystem pins that hard-coded `5`.

## Not in this PR

- #1881 — opportunistic spool drain still runs inside the host budget
- #1876 — no retry cap / dead-letter

## Test plan

- [x] `go test ./...`
- [x] `go tool golangci-lint run`
- [ ] Reinstall Grok/Kimi plugins from this checkout and start a new session to observe `hook_execution` elapsed_ms