### PR TITLE
Diagnose leftover Grok user-level Traceary hooks

### DIFF
--- a/docs/integrations/grok-plugin.ja.md
+++ b/docs/integrations/grok-plugin.ja.md
@@ -131,7 +131,7 @@ traceary doctor --client grok --project-dir . --json
 `grok-mcp`、`grok-skills` が `pass` になります。`grok-event-coverage` は直近 DB
 証拠を評価し、セッションが3件未満なら誤 pass せず「まだ判定しない」と報告します。
 
-## プロジェクト hook と trust
+## プロジェクト / user hook 経路
 
 hook、MCP、skill をまとめて配線できるため、ネイティブ plugin を推奨します。
 hook だけを導入することもできます。
@@ -144,11 +144,26 @@ traceary hooks install --client grok --project-dir .
 traceary hooks install --client grok --global
 ```
 
+Grok はすべての source の hook をマージします。**有効な経路は 1 つだけ**にしてください。
+
+- MCP と skill も使う場合は native plugin `traceary-grok` を優先する
+- plugin を使わないときだけ project または user の hook-only 経路を使う
+- plugin 導入後に user ファイルを残さない。plugin hooks を project / user route に
+  コピーして代替しない。経路が重複すると同じイベントを二重に記録する可能性があり、
+  古い user ファイルの stale timeout が優先されることもある
+
+`traceary doctor --client grok` は次を報告します。
+
+- `grok-hooks` — native plugin の hook coverage
+- `grok-hooks-user` — 任意の user-level ファイル `~/.grok/hooks/traceary.json`
+  （存在すれば `pass`、なければ `skip`）
+- `grok-hooks-routes` — native / project / user のうち 2 つ以上が有効なとき警告し、
+  user route が関与する場合はヒントに `~/.grok/hooks/traceary.json` を示す
+
 Grok は project hook を独立した trust 境界として扱います。project route を使う場合は
 ファイル内容を確認し、そのプロジェクトで Grok の `/hooks-trust` を実行してください。
 project hook が存在する一方で host が project を未信頼と報告した場合、
-`grok-hook-trust` が警告します。plugin hook を project route にコピーして代替しないで
-ください。経路が重複すると同じイベントを二重に記録する可能性があります。
+`grok-hook-trust` が警告します。
 
 ## 更新と削除
 
@@ -203,6 +218,8 @@ pass であることを確認してください。
 | `grok-plugin-resolution` が警告 | Grok が native 以外の path class、同名の legacy package、または local-repository identity を解決しています。local-repository identity の場合は `grok plugin list --json` を確認し、その checkout で `scripts/install-grok-plugin.sh --migrate-local-repo-identity` を実行してください。それ以外は通常の installer を実行し、`traceary-grok` が有効 route になったことを確認してください。doctor が読むのは inventory metadata だけです。 |
 | `grok-hook-trust` が警告 | project hook を確認して `/hooks-trust` を実行するか、未使用の project route を削除する |
 | `grok-hooks` が警告 | 導入済み hook file が不足しているか、7 event の厳密な契約からずれている。plugin を再導入する |
+| `grok-hooks-user` が失敗 | `~/.grok/hooks/traceary.json` が存在するが読み取れない、または有効な JSON ではない。修正または削除する |
+| `grok-hooks-routes` が警告 | native plugin / project / user-level の経路が 2 つ以上有効。1 つだけ残し、plugin 導入済みなら `traceary-grok` を優先して `~/.grok/hooks/traceary.json` を削除する |
 | `grok-mcp` / `grok-skills` が警告 | 導入済みパッケージの内容が不足している。plugin を再導入する |
 | `grok-event-coverage` が警告 | 直近の `agent=grok` event と待機中の hook/transcript queue を確認する。導入状態が正常でも実行時配送まで保証しない |
 

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -136,7 +136,7 @@ A healthy installation reports `pass` for `grok-cli`, `grok-plugin`,
 than three recent sessions it reports that coverage is not judged yet rather
 than claiming a false pass.
 
-## Project hook route and trust
+## Project and user hook routes
 
 The native plugin is the recommended route because it wires hooks, MCP, and
 skills together. Traceary can also install hooks only:
@@ -149,11 +149,29 @@ traceary hooks install --client grok --project-dir .
 traceary hooks install --client grok --global
 ```
 
+Grok merges hooks from every source. Keep **exactly one** route active:
+
+- Prefer the native plugin `traceary-grok` when you also want MCP and skills.
+- Use the project or user hook-only route only when you intentionally skip the
+  plugin.
+- Do not leave a leftover user file after installing the plugin, and do not
+  copy plugin hooks into the project or user route as a fallback. Duplicate
+  routes can record the same event twice (including an older user file with a
+  stale timeout).
+
+`traceary doctor --client grok` reports:
+
+- `grok-hooks` — native plugin hook coverage
+- `grok-hooks-user` — optional user-level file at `~/.grok/hooks/traceary.json`
+  (`pass` when present, `skip` when absent)
+- `grok-hooks-routes` — warns when more than one of native / project / user is
+  active, and names `~/.grok/hooks/traceary.json` in the hint when the user
+  route is involved
+
 Grok treats project hooks as a separate trust boundary. When the project route
 is intentional, inspect the file and use Grok's `/hooks-trust` flow in that
 project. `grok-hook-trust` warns when a project hook file exists but the host
-reports the project as untrusted. Do not copy plugin hooks into the project
-route as a fallback; duplicate routes can record the same event twice.
+reports the project as untrusted.
 
 ## Update or remove
 
@@ -214,6 +232,8 @@ removed separately if they were installed.
 | `grok-plugin-resolution` warns | Grok resolved a non-native path class, a same-name legacy package, or a local-repository identity. For a local-repository identity, review `grok plugin list --json` and run `scripts/install-grok-plugin.sh --migrate-local-repo-identity` from that checkout; otherwise run the normal installer and confirm `traceary-grok` is the enabled route. Doctor reads only inventory metadata. |
 | `grok-hook-trust` warns | Review the project hook file and use `/hooks-trust`, or remove the unused project route |
 | `grok-hooks` warns | The installed hook file is missing or has drifted from the exact seven-event contract; reinstall the plugin |
+| `grok-hooks-user` fails | `~/.grok/hooks/traceary.json` exists but is unreadable or not valid JSON; fix or remove it |
+| `grok-hooks-routes` warns | More than one of native plugin, project, and user-level routes is active. Retain exactly one; prefer `traceary-grok` and remove `~/.grok/hooks/traceary.json` if the plugin is installed |
 | `grok-mcp` / `grok-skills` warns | The installed package inventory is incomplete; reinstall it |
 | `grok-event-coverage` warns | Inspect recent `agent=grok` events and pending hook/transcript queues; a healthy install alone does not prove runtime delivery |
 

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -55,9 +55,16 @@ type grokDoctorState struct {
 	// UserHooksInvalid is true when the user-level file exists but is unreadable
 	// or not valid JSON. Diagnosis only; doctor does not rewrite the file.
 	UserHooksInvalid bool
-	NativeHooks      bool
-	MCPServers       int
-	Skills           int
+	// NativeHooksPresent is true when inspect reports a traceary-grok hook with
+	// a native path class. Grok still merges that route even when coverage is
+	// incomplete/stale, so duplicate-route detection must use presence rather
+	// than verified coverage.
+	NativeHooksPresent bool
+	// NativeHooks is true only when the native route also passes the exact
+	// seven-event verified coverage contract. Used by grok-hooks only.
+	NativeHooks bool
+	MCPServers  int
+	Skills      int
 }
 
 type grokPluginListEntry struct {
@@ -162,8 +169,11 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		if hook.Source.PluginName == legacyTracearyPluginName {
 			state.LegacyPluginDetected = true
 		}
-		if hook.Source.PluginName == grokTracearyPluginName && pathClass == grokPluginPathClassNative && grokHookFileHasVerifiedCoverage(hook.Target) {
-			state.NativeHooks = true
+		if hook.Source.PluginName == grokTracearyPluginName && pathClass == grokPluginPathClassNative {
+			state.NativeHooksPresent = true
+			if grokHookFileHasVerifiedCoverage(hook.Target) {
+				state.NativeHooks = true
+			}
 		}
 	}
 	return state, nil
@@ -420,10 +430,12 @@ func buildGrokUserHooksCheck(state grokDoctorState) doctorCheck {
 // buildGrokHookRoutesSummary warns when more than one Grok hook route is active.
 // Grok merges every source, so user-level leftovers next to the native plugin
 // (or project route) can fire duplicate handlers — the same class of problem as
-// Antigravity multi-route setups. Diagnosis only; no files are removed.
+// Antigravity multi-route setups. Native route presence (not verified coverage)
+// counts, because a stale/partial plugin file is still executed by Grok.
+// Diagnosis only; no files are removed.
 func buildGrokHookRoutesSummary(state grokDoctorState) doctorCheck {
 	active := make([]string, 0, 3)
-	if state.NativeHooks {
+	if state.NativeHooksPresent {
 		active = append(active, "native plugin")
 	}
 	if state.ProjectHooks {

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -46,9 +46,18 @@ type grokDoctorState struct {
 	LocalRepoConflict    bool
 	ProjectTrusted       bool
 	ProjectHooks         bool
-	NativeHooks          bool
-	MCPServers           int
-	Skills               int
+	// UserHooks is true when the user-level Traceary Grok hook file exists as a
+	// regular file (primary), or inspect reports source.type=user for a Traceary
+	// Grok hook target. Grok merges all hook sources, so this route can fire
+	// alongside the native plugin.
+	UserHooks     bool
+	UserHooksPath string
+	// UserHooksInvalid is true when the user-level file exists but is unreadable
+	// or not valid JSON. Diagnosis only; doctor does not rewrite the file.
+	UserHooksInvalid bool
+	NativeHooks      bool
+	MCPServers       int
+	Skills           int
 }
 
 type grokPluginListEntry struct {
@@ -122,6 +131,10 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 	if info, statErr := os.Stat(filepath.Join(projectDir, ".grok", "hooks", "traceary.json")); statErr == nil && info.Mode().IsRegular() {
 		state.ProjectHooks = true
 	}
+	if userPath, resolved, pathErr := resolveHooksGlobalPath("grok"); pathErr == nil && resolved {
+		state.UserHooksPath = userPath
+		probeGrokUserHooksFile(&state, userPath)
+	}
 	for _, plugin := range document.Plugins {
 		if plugin.Name != grokTracearyPluginName {
 			continue
@@ -131,8 +144,16 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		state.Skills = plugin.Provides.Skills
 	}
 	for _, hook := range document.Hooks {
-		if hook.Source.Type == "project" {
+		switch hook.Source.Type {
+		case "project":
 			state.ProjectHooks = true
+		case "user":
+			if grokIsTracearyUserHookTarget(hook.Target, state.UserHooksPath) {
+				state.UserHooks = true
+				if state.UserHooksPath == "" && strings.TrimSpace(hook.Target) != "" {
+					state.UserHooksPath = hook.Target
+				}
+			}
 		}
 		pathClass := grokPluginPathClass(hook.Target)
 		if hook.Source.PluginName == grokTracearyPluginName || (hook.Source.PluginName == legacyTracearyPluginName && state.ResolvedPathClass == "") {
@@ -146,6 +167,34 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		}
 	}
 	return state, nil
+}
+
+// probeGrokUserHooksFile records whether the resolved user-level Traceary Grok
+// hook file exists and whether it is readable JSON. Diagnosis only.
+func probeGrokUserHooksFile(state *grokDoctorState, userPath string) {
+	info, err := os.Stat(userPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return
+	}
+	state.UserHooks = true
+	data, readErr := os.ReadFile(userPath) // #nosec G304 -- resolved user hook path
+	if readErr != nil || !json.Valid(data) {
+		state.UserHooksInvalid = true
+	}
+}
+
+// grokIsTracearyUserHookTarget reports whether an inspect hook target looks like
+// the user-level Traceary Grok hook file (not an unrelated user hook).
+func grokIsTracearyUserHookTarget(target, knownUserPath string) bool {
+	normalized := filepath.ToSlash(strings.TrimSpace(target))
+	if normalized == "" {
+		return false
+	}
+	if knownUserPath != "" && filepath.Clean(target) == filepath.Clean(knownUserPath) {
+		return true
+	}
+	return strings.HasSuffix(normalized, "/.grok/hooks/traceary.json") ||
+		strings.HasSuffix(normalized, "/.grok/hooks/traceary.json/")
 }
 
 // grokIsLocalRepositoryIdentity distinguishes Grok's repository-level local
@@ -287,6 +336,7 @@ func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doct
 		hookStatus, hookMessage = doctorStatusWarn, Localize("native Grok hook coverage is missing or incomplete", "native Grok hook coverage が不足しています")
 	}
 	checks = append(checks, doctorCheck{Name: "grok-hooks", Status: hookStatus, Message: hookMessage, Hint: Localize("update or reinstall the native Traceary Grok plugin", "native Traceary Grok plugin を更新または再インストールしてください")})
+	checks = append(checks, buildGrokUserHooksCheck(state), buildGrokHookRoutesSummary(state))
 	mcpStatus := doctorStatusPass
 	mcpMessage := Localize("native Grok plugin exposes one Traceary MCP server", "native Grok plugin は Traceary MCP server を1件公開しています")
 	if state.MCPServers != 1 {
@@ -302,4 +352,120 @@ func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doct
 	}
 	checks = append(checks, doctorCheck{Name: "grok-skills", Status: skillStatus, Message: skillMessage, Hint: Localize("update or reinstall the native Traceary Grok plugin", "native Traceary Grok plugin を更新または再インストールしてください")})
 	return checks
+}
+
+// grokUserHooksDisplayPath prefers a home-relative tilde form so doctor output
+// does not leak host-private temporary path prefixes while still naming the
+// canonical user route (~/.grok/hooks/traceary.json).
+func grokUserHooksDisplayPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return "~/.grok/hooks/traceary.json"
+	}
+	home, err := userHomeDirFunc()
+	if err == nil && strings.TrimSpace(home) != "" {
+		home = filepath.Clean(home)
+		cleaned := filepath.Clean(path)
+		if cleaned == home || strings.HasPrefix(cleaned, home+string(os.PathSeparator)) {
+			rel, relErr := filepath.Rel(home, cleaned)
+			if relErr == nil {
+				return "~/" + filepath.ToSlash(rel)
+			}
+		}
+	}
+	return path
+}
+
+// buildGrokUserHooksCheck reports the optional user-level hook route. Absent is
+// SKIP (optional when the native plugin is used); present is PASS; invalid is
+// FAIL because Grok cannot load a malformed hooks document from that path.
+func buildGrokUserHooksCheck(state grokDoctorState) doctorCheck {
+	displayPath := grokUserHooksDisplayPath(state.UserHooksPath)
+	if !state.UserHooks {
+		return doctorCheck{
+			Name:   "grok-hooks-user",
+			Status: doctorStatusSkip,
+			Message: localizef(
+				"no user-level Grok Traceary hooks at %s (optional when the native plugin or project route is active)",
+				"user-level の Grok Traceary hooks (%s) はありません（native plugin または project route が有効なら任意です）",
+				displayPath,
+			),
+		}
+	}
+	if state.UserHooksInvalid {
+		return doctorCheck{
+			Name:   "grok-hooks-user",
+			Status: doctorStatusFail,
+			Message: localizef(
+				"invalid user-level Grok Traceary hooks at %s (unreadable or not valid JSON). Fix or remove the file; doctor does not rewrite it",
+				"user-level の Grok Traceary hooks (%s) が不正です（読み取れないか有効な JSON ではありません）。修正または削除してください。doctor はファイルを書き換えません",
+				displayPath,
+			),
+			Hint: Localize(
+				"remove or fix ~/.grok/hooks/traceary.json; prefer the native plugin traceary-grok",
+				"~/.grok/hooks/traceary.json を削除または修正してください。native plugin traceary-grok を優先してください",
+			),
+		}
+	}
+	return doctorCheck{
+		Name:   "grok-hooks-user",
+		Status: doctorStatusPass,
+		Message: localizef(
+			"user-level Grok Traceary hooks are present at %s",
+			"user-level の Grok Traceary hooks が存在します: %s",
+			displayPath,
+		),
+	}
+}
+
+// buildGrokHookRoutesSummary warns when more than one Grok hook route is active.
+// Grok merges every source, so user-level leftovers next to the native plugin
+// (or project route) can fire duplicate handlers — the same class of problem as
+// Antigravity multi-route setups. Diagnosis only; no files are removed.
+func buildGrokHookRoutesSummary(state grokDoctorState) doctorCheck {
+	active := make([]string, 0, 3)
+	if state.NativeHooks {
+		active = append(active, "native plugin")
+	}
+	if state.ProjectHooks {
+		active = append(active, "project")
+	}
+	if state.UserHooks {
+		active = append(active, "user-level")
+	}
+	displayPath := grokUserHooksDisplayPath(state.UserHooksPath)
+	if len(active) > 1 {
+		return doctorCheck{
+			Name:   "grok-hooks-routes",
+			Status: doctorStatusWarn,
+			Message: localizef(
+				"multiple Grok hook routes are active and can register duplicate lifecycle handlers: %s. Retain exactly one route",
+				"複数の Grok hook 経路が有効で lifecycle handler が重複登録される可能性があります: %s。経路を 1 つだけ残してください",
+				strings.Join(active, ", "),
+			),
+			Hint: localizef(
+				"Retain exactly one Grok hook route. Prefer the native plugin traceary-grok; remove %s if the plugin is installed. Do not copy plugin hooks into the user or project route",
+				"Grok hook 経路は 1 つだけ残してください。native plugin traceary-grok を優先し、plugin を導入済みなら %s を削除してください。plugin hooks を user または project route にコピーしないでください",
+				displayPath,
+			),
+		}
+	}
+	if len(active) == 1 {
+		return doctorCheck{
+			Name:   "grok-hooks-routes",
+			Status: doctorStatusPass,
+			Message: localizef(
+				"Grok hooks are active via a single route: %s",
+				"Grok hooks は単一の経路で有効です: %s",
+				active[0],
+			),
+		}
+	}
+	return doctorCheck{
+		Name:   "grok-hooks-routes",
+		Status: doctorStatusSkip,
+		Message: Localize(
+			"no Grok hook route is active yet (see grok-hooks / grok-hooks-user)",
+			"有効な Grok hook 経路はまだありません（grok-hooks / grok-hooks-user を参照）",
+		),
+	}
 }

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -399,3 +399,232 @@ func TestGrokIsLocalRepositoryIdentity(t *testing.T) {
 		})
 	}
 }
+
+func TestProbeGrokDoctorStateUserHookRoutes(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+
+	tests := []struct {
+		name              string
+		writeUserHooks    bool
+		invalidUserHooks  bool
+		nativePlugin      bool
+		inspectUserHooks  bool
+		wantUserHooks     bool
+		wantRoutesStatus  string
+		wantRoutesSubstr  []string
+		wantUserStatus    string
+		wantUserSubstr    []string
+	}{
+		{
+			name:             "user file absent with native plugin has no duplicate warning",
+			nativePlugin:     true,
+			wantUserHooks:    false,
+			wantRoutesStatus: doctorStatusPass,
+			wantRoutesSubstr: []string{"single route", "native plugin"},
+			wantUserStatus:   doctorStatusSkip,
+			wantUserSubstr:   []string{"no user-level", "~/.grok/hooks/traceary.json"},
+		},
+		{
+			name:             "user file and native plugin warn for duplicate routes",
+			writeUserHooks:   true,
+			nativePlugin:     true,
+			inspectUserHooks: true,
+			wantUserHooks:    true,
+			wantRoutesStatus: doctorStatusWarn,
+			wantRoutesSubstr: []string{"exactly one", "user-level", "native plugin", "~/.grok/hooks/traceary.json"},
+			wantUserStatus:   doctorStatusPass,
+			wantUserSubstr:   []string{"user-level", "~/.grok/hooks/traceary.json"},
+		},
+		{
+			name:             "user file present without plugin reports user route",
+			writeUserHooks:   true,
+			wantUserHooks:    true,
+			wantRoutesStatus: doctorStatusPass,
+			wantRoutesSubstr: []string{"single route", "user-level"},
+			wantUserStatus:   doctorStatusPass,
+			wantUserSubstr:   []string{"user-level", "~/.grok/hooks/traceary.json"},
+		},
+		{
+			name:             "invalid user file fails the user route check",
+			writeUserHooks:   true,
+			invalidUserHooks: true,
+			wantUserHooks:    true,
+			wantRoutesStatus: doctorStatusPass,
+			wantRoutesSubstr: []string{"single route", "user-level"},
+			wantUserStatus:   doctorStatusFail,
+			wantUserSubstr:   []string{"invalid", "~/.grok/hooks/traceary.json"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			originalLookPath, originalOutput, originalHome := grokDoctorLookPath, grokDoctorOutput, userHomeDirFunc
+			t.Cleanup(func() {
+				grokDoctorLookPath, grokDoctorOutput, userHomeDirFunc = originalLookPath, originalOutput, originalHome
+			})
+
+			home := t.TempDir()
+			userHomeDirFunc = func() (string, error) { return home, nil }
+			grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+
+			projectDir := t.TempDir()
+			userHookPath := filepath.Join(home, ".grok", "hooks", "traceary.json")
+			if tc.writeUserHooks {
+				if tc.invalidUserHooks {
+					if err := os.MkdirAll(filepath.Dir(userHookPath), 0o700); err != nil {
+						t.Fatalf("MkdirAll() error = %v", err)
+					}
+					if err := os.WriteFile(userHookPath, []byte(`not-json`), 0o600); err != nil {
+						t.Fatalf("WriteFile() error = %v", err)
+					}
+				} else {
+					writeGrokDoctorHookFixture(t, userHookPath, true)
+				}
+			}
+
+			var pluginHook string
+			if tc.nativePlugin {
+				pluginHook = filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-traceary-grok", "hooks", "hooks.json")
+				writeGrokDoctorHookFixture(t, pluginHook, true)
+			}
+
+			grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+				switch strings.Join(args, " ") {
+				case "--version":
+					return []byte("grok 0.2.111\n"), nil
+				case "plugin list --json":
+					if tc.nativePlugin {
+						return []byte(`[{"name":"traceary-grok","version":"0.34.0","path":` + strconv.Quote(filepath.Dir(filepath.Dir(pluginHook))) + `}]`), nil
+					}
+					return []byte(`[]`), nil
+				case "--cwd " + projectDir + " inspect --json":
+					hooks := []string{}
+					if tc.nativePlugin {
+						hooks = append(hooks, `{"target":`+strconv.Quote(pluginHook)+`,"source":{"type":"plugin","plugin_name":"traceary-grok"}}`)
+					}
+					if tc.inspectUserHooks || tc.writeUserHooks {
+						// Corroborate the user file route when present; doctor also stats the file.
+						hooks = append(hooks, `{"target":`+strconv.Quote(userHookPath)+`,"source":{"type":"user"}}`)
+					}
+					plugins := `[]`
+					if tc.nativePlugin {
+						plugins = `[{"name":"traceary-grok","enabled":true,"provides":{"skills":3,"mcpServers":1}}]`
+					}
+					return []byte(`{"projectTrusted":true,"plugins":` + plugins + `,"hooks":[` + strings.Join(hooks, ",") + `]}`), nil
+				default:
+					t.Fatalf("unexpected Grok arguments: %v", args)
+					return nil, nil
+				}
+			}
+
+			state, err := probeGrokDoctorState(context.Background(), projectDir)
+			if err != nil {
+				t.Fatalf("probeGrokDoctorState() error = %v", err)
+			}
+			if state.UserHooks != tc.wantUserHooks {
+				t.Fatalf("UserHooks = %v, want %v (state=%+v)", state.UserHooks, tc.wantUserHooks, state)
+			}
+			if tc.wantUserHooks {
+				if state.UserHooksPath != userHookPath {
+					t.Fatalf("UserHooksPath = %q, want %q", state.UserHooksPath, userHookPath)
+				}
+				if state.UserHooksInvalid != tc.invalidUserHooks {
+					t.Fatalf("UserHooksInvalid = %v, want %v", state.UserHooksInvalid, tc.invalidUserHooks)
+				}
+			}
+			if state.NativeHooks != tc.nativePlugin {
+				t.Fatalf("NativeHooks = %v, want %v", state.NativeHooks, tc.nativePlugin)
+			}
+
+			checks := buildGrokDoctorChecks(state, "0.34.0")
+			byName := map[string]doctorCheck{}
+			for _, check := range checks {
+				byName[check.Name] = check
+				if strings.Contains(check.Message+check.Hint, "/private/") {
+					t.Fatalf("check exposed private path: %+v", check)
+				}
+			}
+
+			userCheck, ok := byName["grok-hooks-user"]
+			if !ok {
+				t.Fatalf("checks = %+v, want grok-hooks-user", checks)
+			}
+			if userCheck.Status != tc.wantUserStatus {
+				t.Fatalf("grok-hooks-user = %+v, want status %s", userCheck, tc.wantUserStatus)
+			}
+			for _, sub := range tc.wantUserSubstr {
+				if !strings.Contains(userCheck.Message+userCheck.Hint, sub) {
+					t.Fatalf("grok-hooks-user = %+v, want substring %q", userCheck, sub)
+				}
+			}
+
+			routesCheck, ok := byName["grok-hooks-routes"]
+			if !ok {
+				t.Fatalf("checks = %+v, want grok-hooks-routes", checks)
+			}
+			if routesCheck.Status != tc.wantRoutesStatus {
+				t.Fatalf("grok-hooks-routes = %+v, want status %s", routesCheck, tc.wantRoutesStatus)
+			}
+			for _, sub := range tc.wantRoutesSubstr {
+				if !strings.Contains(routesCheck.Message+routesCheck.Hint, sub) {
+					t.Fatalf("grok-hooks-routes = %+v, want substring %q", routesCheck, sub)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildGrokHookRoutesSummary(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	tests := []struct {
+		name       string
+		state      grokDoctorState
+		status     string
+		messageSub string
+		hintSub    string
+	}{
+		{
+			name:       "native only passes",
+			state:      grokDoctorState{NativeHooks: true},
+			status:     doctorStatusPass,
+			messageSub: "native plugin",
+		},
+		{
+			name:       "user plus native warns with path",
+			state:      grokDoctorState{NativeHooks: true, UserHooks: true, UserHooksPath: "/tmp/home/.grok/hooks/traceary.json"},
+			status:     doctorStatusWarn,
+			messageSub: "exactly one",
+			hintSub:    "traceary.json",
+		},
+		{
+			name:       "user plus project warns",
+			state:      grokDoctorState{ProjectHooks: true, UserHooks: true, UserHooksPath: "/tmp/home/.grok/hooks/traceary.json"},
+			status:     doctorStatusWarn,
+			messageSub: "user-level",
+			hintSub:    "exactly one",
+		},
+		{
+			name:       "no routes skips",
+			state:      grokDoctorState{},
+			status:     doctorStatusSkip,
+			messageSub: "no Grok hook route",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			check := buildGrokHookRoutesSummary(tc.state)
+			if check.Name != "grok-hooks-routes" || check.Status != tc.status {
+				t.Fatalf("check = %+v, want status %s", check, tc.status)
+			}
+			if !strings.Contains(check.Message+check.Hint, tc.messageSub) {
+				t.Fatalf("check = %+v, want message substring %q", check, tc.messageSub)
+			}
+			if tc.hintSub != "" && !strings.Contains(check.Message+check.Hint, tc.hintSub) {
+				t.Fatalf("check = %+v, want hint substring %q", check, tc.hintSub)
+			}
+			if strings.Contains(check.Message+check.Hint, "/private/") {
+				t.Fatalf("check exposed private path: %+v", check)
+			}
+		})
+	}
+}

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -532,8 +532,8 @@ func TestProbeGrokDoctorStateUserHookRoutes(t *testing.T) {
 					t.Fatalf("UserHooksInvalid = %v, want %v", state.UserHooksInvalid, tc.invalidUserHooks)
 				}
 			}
-			if state.NativeHooks != tc.nativePlugin {
-				t.Fatalf("NativeHooks = %v, want %v", state.NativeHooks, tc.nativePlugin)
+			if state.NativeHooks != tc.nativePlugin || state.NativeHooksPresent != tc.nativePlugin {
+				t.Fatalf("NativeHooks/Present = %v/%v, want both %v", state.NativeHooks, state.NativeHooksPresent, tc.nativePlugin)
 			}
 
 			checks := buildGrokDoctorChecks(state, "0.34.0")
@@ -574,6 +574,71 @@ func TestProbeGrokDoctorStateUserHookRoutes(t *testing.T) {
 	}
 }
 
+func TestProbeGrokDoctorStateWarnsDuplicateWhenNativeCoverageIncomplete(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	originalLookPath, originalOutput, originalHome := grokDoctorLookPath, grokDoctorOutput, userHomeDirFunc
+	t.Cleanup(func() {
+		grokDoctorLookPath, grokDoctorOutput, userHomeDirFunc = originalLookPath, originalOutput, originalHome
+	})
+
+	home := t.TempDir()
+	userHomeDirFunc = func() (string, error) { return home, nil }
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+
+	projectDir := t.TempDir()
+	userHookPath := filepath.Join(home, ".grok", "hooks", "traceary.json")
+	writeGrokDoctorHookFixture(t, userHookPath, true)
+
+	// Incomplete native fixture: Grok still merges it, but coverage fails.
+	pluginHook := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-traceary-grok", "hooks", "hooks.json")
+	writeGrokDoctorHookFixture(t, pluginHook, false)
+
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 0.2.111\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary-grok","version":"0.34.0","path":` + strconv.Quote(filepath.Dir(filepath.Dir(pluginHook))) + `}]`), nil
+		case "--cwd " + projectDir + " inspect --json":
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":3,"mcpServers":1}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary-grok"}},{"target":` + strconv.Quote(userHookPath) + `,"source":{"type":"user"}}]}`), nil
+		default:
+			t.Fatalf("unexpected Grok arguments: %v", args)
+			return nil, nil
+		}
+	}
+
+	state, err := probeGrokDoctorState(context.Background(), projectDir)
+	if err != nil {
+		t.Fatalf("probeGrokDoctorState() error = %v", err)
+	}
+	if !state.UserHooks || !state.NativeHooksPresent || state.NativeHooks {
+		t.Fatalf("state = %+v, want user + present incomplete native route", state)
+	}
+
+	checks := buildGrokDoctorChecks(state, "0.34.0")
+	byName := map[string]doctorCheck{}
+	for _, check := range checks {
+		byName[check.Name] = check
+		if strings.Contains(check.Message+check.Hint, "/private/") {
+			t.Fatalf("check exposed private path: %+v", check)
+		}
+	}
+
+	hooksCheck, ok := byName["grok-hooks"]
+	if !ok || hooksCheck.Status != doctorStatusWarn || !strings.Contains(hooksCheck.Message, "incomplete") {
+		t.Fatalf("grok-hooks = %+v, want incomplete coverage warning", hooksCheck)
+	}
+	routesCheck, ok := byName["grok-hooks-routes"]
+	if !ok || routesCheck.Status != doctorStatusWarn {
+		t.Fatalf("grok-hooks-routes = %+v, want duplicate-route warning", routesCheck)
+	}
+	for _, sub := range []string{"exactly one", "user-level", "native plugin", "~/.grok/hooks/traceary.json"} {
+		if !strings.Contains(routesCheck.Message+routesCheck.Hint, sub) {
+			t.Fatalf("grok-hooks-routes = %+v, want substring %q", routesCheck, sub)
+		}
+	}
+}
+
 func TestBuildGrokHookRoutesSummary(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
 	tests := []struct {
@@ -585,13 +650,20 @@ func TestBuildGrokHookRoutesSummary(t *testing.T) {
 	}{
 		{
 			name:       "native only passes",
-			state:      grokDoctorState{NativeHooks: true},
+			state:      grokDoctorState{NativeHooksPresent: true, NativeHooks: true},
 			status:     doctorStatusPass,
 			messageSub: "native plugin",
 		},
 		{
 			name:       "user plus native warns with path",
-			state:      grokDoctorState{NativeHooks: true, UserHooks: true, UserHooksPath: "/tmp/home/.grok/hooks/traceary.json"},
+			state:      grokDoctorState{NativeHooksPresent: true, NativeHooks: true, UserHooks: true, UserHooksPath: "/tmp/home/.grok/hooks/traceary.json"},
+			status:     doctorStatusWarn,
+			messageSub: "exactly one",
+			hintSub:    "traceary.json",
+		},
+		{
+			name:       "user plus incomplete native still warns",
+			state:      grokDoctorState{NativeHooksPresent: true, NativeHooks: false, UserHooks: true, UserHooksPath: "/tmp/home/.grok/hooks/traceary.json"},
 			status:     doctorStatusWarn,
 			messageSub: "exactly one",
 			hintSub:    "traceary.json",


### PR DESCRIPTION
## Summary

- `traceary doctor --client grok` now stats `~/.grok/hooks/traceary.json` (via `resolveHooksGlobalPath("grok")`) and reports it as `grok-hooks-user`
- `grok-hooks-routes` warns when user-level coexists with native plugin and/or project hooks (Grok merges all sources), naming the user file and asking operators to keep exactly one route
- Docs document the user route as the same class of duplicate as the project route; diagnosis only (no rewrite/delete)

## Test plan

- [x] `go test ./presentation/cli` (pass)
- [x] `go tool golangci-lint run ./presentation/cli/...` (0 issues)
- [x] Unit coverage: user absent + native (no duplicate warn); user + native (WARN with path + "exactly one"); user only (user route reported); invalid user JSON fails user check

Closes #1884