### PR TITLE
Cap hook spool retries and dead-letter poison records

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -296,10 +296,11 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		report.Mode = doctorModeMetadataOnlyLargeStore
 		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(snapshot, resolvedDBPath))
 		// This is an intentional, successful bounded outcome. Do not initialize
-		// SQLite, list events, scan hook spools, or inspect client state here:
+		// SQLite, list events, open spool payloads, or inspect client state here:
 		// those operations can block behind a live writer and some inspect event
-		// bodies/payloads. The result is useful precisely because it is based on
-		// filesystem metadata only and cannot mutate or expose store content.
+		// bodies/payloads. Hook spool is still reported via directory entry
+		// counts and byte sizes only (pending / stale inflight / dead-letter).
+		report.Checks = append(report.Checks, inspectHookSpoolFilesystemMetadata())
 		return report, nil
 	}
 

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -571,6 +571,80 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 	}
 }
 
+func TestRootCLI_DoctorLargeStoreReportsHookSpoolMetadataWithoutPayloadReads(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	setTracearyPathToCurrentExecutable(t)
+
+	// Isolate the hook spool so doctor metadata counts come only from this fixture.
+	stateDir := t.TempDir()
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+	deadDir := filepath.Join(spoolDir, "dead")
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	const secretPayload = "SECRET_LARGE_STORE_SPOOL_PAYLOAD"
+	pendingPath := filepath.Join(spoolDir, "20260101T000000.000000000Z-claude-pending.json")
+	if err := os.WriteFile(pendingPath, []byte(`{"schema_version":1,"command":"prompt","client":"claude","payload":"`+secretPayload+`","created_at":"2026-01-01T00:00:00Z"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile pending: %v", err)
+	}
+	deadPath := filepath.Join(deadDir, "dead-one.json")
+	if err := os.WriteFile(deadPath, []byte(`{"schema_version":1,"attempt_count":3,"payload":"`+secretPayload+`"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile dead: %v", err)
+	}
+
+	largeStore := filepath.Join(t.TempDir(), "large-metadata-only.db")
+	file, err := os.OpenFile(largeStore, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	if err := file.Truncate(2 << 30); err != nil {
+		_ = file.Close()
+		t.Fatalf("Truncate() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	store := &storeManagementUsecaseStub{}
+	events := &eventUsecaseStub{}
+	capacity := &panicCapacityInspector{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(store),
+		cli.WithEvent(events),
+		cli.WithCapacityInspector(capacity),
+	).Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", largeStore, "--json", "--warnings-ok"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	report := decodeDoctorReport(t, stdout.Bytes())
+	if report.Mode != "metadata_only_large_store" {
+		t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
+	}
+	if store.initCalled {
+		t.Fatal("large-store doctor initialized SQLite, want metadata-only outcome")
+	}
+	if events.listCalls != 0 {
+		t.Fatalf("large-store doctor listed %d events, want no event/payload reads", events.listCalls)
+	}
+
+	spool := statusByName(report, "hook-spool")
+	if spool.Status != "warn" {
+		t.Fatalf("hook-spool status = %q, want warn (message=%q)", spool.Status, spool.Message)
+	}
+	if !strings.Contains(spool.Message, "pending=1") || !strings.Contains(spool.Message, "dead=1") {
+		t.Fatalf("hook-spool message = %q, want pending and dead metadata counts", spool.Message)
+	}
+	if strings.Contains(spool.Message, secretPayload) || strings.Contains(spool.Hint, secretPayload) {
+		t.Fatalf("large-store doctor leaked spool payload body: %#v", spool)
+	}
+}
+
 func TestRootCLI_DoctorCommand_ClaudeHookCancellationDiagnostics(t *testing.T) {
 	t.Run("passes when no pending marker exists", func(t *testing.T) {
 		homeDir := t.TempDir()

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -533,6 +533,9 @@ func loadHookSpoolReplayBatch(
 	return records, unreadable, nil
 }
 
+// writeHookSpoolRecordAtomic replaces path with the encoded record via
+// same-directory tmp + rename so a crash leaves either the previous or the
+// new content at path, never two distinct replayable files for one update.
 func writeHookSpoolRecordAtomic(path string, record hookSpoolRecord) error {
 	encoded, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
@@ -554,22 +557,28 @@ func writeHookSpoolRecordAtomic(path string, record hookSpoolRecord) error {
 // unreadable load, then either renames the record to the retry tail or moves
 // it to spool/dead/ when shouldDeadLetter reports true. lastError is stored
 // for operator inspection and must never be treated as a payload body by doctor.
+//
+// Transition safety: update the JSON in place (tmp + rename over the original),
+// then rename that single file to zz-retry-* or spool/dead/*. Never write a
+// second replayable path and delete the original — a crash between those steps
+// would leave two copies of the same event.
+//
+// Unreadable paths (including external symlinks) must not be opened with a
+// link-following API. They are renamed into spool/dead/ without copying content
+// so the next drain cannot replay an external target payload.
 func requeueHookSpoolRecord(path string, lastError string) error {
 	if strings.TrimSpace(path) == "" {
 		return xerrors.New("hook spool path is required")
 	}
 	data, err := readHookSpoolFile(path)
 	if err != nil {
-		// Fall back to a plain read so rename-only recovery still works when
-		// the nofollow open fails for an unreadable path.
-		data, err = os.ReadFile(path)
-		if err != nil {
-			return xerrors.Errorf("failed to read hook spool record for requeue: %w", err)
-		}
+		// Do not fall back to os.ReadFile: that would follow symlinks and could
+		// copy an external target into a new regular retry JSON.
+		return renameHookSpoolRecordToDead(path)
 	}
 	record, ok := parseHookSpoolRecordForRequeue(data)
 	if !ok {
-		// Preserve raw bytes so operators can inspect the poison file later.
+		// Preserve raw bytes from the nofollow regular-file read only.
 		record = hookSpoolRecord{
 			SchemaVersion: hookSpoolSchemaVersion,
 			Payload:       string(data),
@@ -582,27 +591,15 @@ func requeueHookSpoolRecord(path string, lastError string) error {
 	}
 	record.Path = ""
 
-	if shouldDeadLetter(record.AttemptCount) {
-		return deadLetterHookSpoolRecord(path, record)
-	}
-
-	random := make([]byte, 8)
-	if _, err := rand.Read(random); err != nil {
-		return xerrors.Errorf("failed to generate hook spool retry ID: %w", err)
-	}
-	name := fmt.Sprintf(
-		"zz-retry-%s-%s.json",
-		time.Now().UTC().Format("20060102T150405.000000000Z"),
-		hex.EncodeToString(random),
-	)
-	newPath := filepath.Join(filepath.Dir(path), name)
-	if err := writeHookSpoolRecordAtomic(newPath, record); err != nil {
+	// 1) Atomically update the single original path in place.
+	if err := writeHookSpoolRecordAtomic(path, record); err != nil {
 		return err
 	}
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return xerrors.Errorf("failed to remove original hook spool record after requeue: %w", err)
+	// 2) Rename that one file to the retry tail or dead-letter directory.
+	if shouldDeadLetter(record.AttemptCount) {
+		return renameHookSpoolRecordToDead(path)
 	}
-	return nil
+	return renameHookSpoolRecordToRetryTail(path)
 }
 
 func parseHookSpoolRecordForRequeue(data []byte) (hookSpoolRecord, bool) {
@@ -613,7 +610,24 @@ func parseHookSpoolRecordForRequeue(data []byte) (hookSpoolRecord, bool) {
 	return record, true
 }
 
-func deadLetterHookSpoolRecord(path string, record hookSpoolRecord) error {
+func renameHookSpoolRecordToRetryTail(path string) error {
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		return xerrors.Errorf("failed to generate hook spool retry ID: %w", err)
+	}
+	name := fmt.Sprintf(
+		"zz-retry-%s-%s.json",
+		time.Now().UTC().Format("20060102T150405.000000000Z"),
+		hex.EncodeToString(random),
+	)
+	newPath := filepath.Join(filepath.Dir(path), name)
+	if err := os.Rename(path, newPath); err != nil {
+		return xerrors.Errorf("failed to move hook spool record to retry tail: %w", err)
+	}
+	return nil
+}
+
+func renameHookSpoolRecordToDead(path string) error {
 	deadDir, err := hookSpoolDeadDir()
 	if err != nil {
 		return err
@@ -631,11 +645,8 @@ func deadLetterHookSpoolRecord(path string, record hookSpoolRecord) error {
 		hex.EncodeToString(random),
 	)
 	newPath := filepath.Join(deadDir, name)
-	if err := writeHookSpoolRecordAtomic(newPath, record); err != nil {
-		return err
-	}
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return xerrors.Errorf("failed to remove original hook spool record after dead-letter: %w", err)
+	if err := os.Rename(path, newPath); err != nil {
+		return xerrors.Errorf("failed to move hook spool record to dead-letter: %w", err)
 	}
 	return nil
 }

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -23,10 +23,16 @@ const (
 	// hookSpoolReplayBatchLimit caps opportunistic drain work per hook
 	// invocation so replay cannot exhaust the host timeout budget.
 	hookSpoolReplayBatchLimit = 5
+	// hookSpoolRetryLimit is the maximum number of delivery attempts for a
+	// replayable spool record (first delivery + 2 retries). After this many
+	// failed attempts the record is retained under spool/dead/ and excluded
+	// from opportunistic drain so poison records cannot consume the batch.
+	hookSpoolRetryLimit = 3
 	// Packaged host hook budgets are 10 seconds. An in-flight record older than
 	// one minute belongs to a process that did not finish its normal
 	// success/failure transition and is safe to make replayable.
 	hookSpoolInflightStaleAge = time.Minute
+	hookSpoolDeadDirName      = "dead"
 )
 
 type hookInvocationSpec struct {
@@ -44,7 +50,19 @@ type hookSpoolRecord struct {
 	DBPath        string    `json:"db_path,omitempty"`
 	Payload       string    `json:"payload"`
 	CreatedAt     time.Time `json:"created_at"`
-	Path          string    `json:"-"`
+	// AttemptCount tracks failed replay/requeue attempts. Missing field = 0
+	// (never classified as a failed replay). schema_version stays 1.
+	AttemptCount int `json:"attempt_count,omitempty"`
+	// LastError is the most recent replay/requeue failure message. Doctor must
+	// never print payload bodies; this field is for operator inspection only.
+	LastError string    `json:"last_error,omitempty"`
+	Path      string    `json:"-"`
+}
+
+// shouldDeadLetter reports whether a spool record with the given attempt count
+// has exhausted hookSpoolRetryLimit and must leave the replayable queue.
+func shouldDeadLetter(attempt int) bool {
+	return attempt >= hookSpoolRetryLimit
 }
 
 // explicitHookPayloadReader tells readHookPayload that the bytes came from a
@@ -122,8 +140,9 @@ type hookSpoolDrainResult struct {
 
 // drainHookSpoolRecords replays up to limit pending spool records in filename
 // queue order. A record is removed only after replay returns nil. A failed
-// record is atomically moved to the retry tail so it cannot starve unattempted
-// records. Returns counts of successful replays and retained failures.
+// record increments attempt_count and is either moved to the retry tail or,
+// after hookSpoolRetryLimit attempts, retained under spool/dead/. Returns
+// counts of successful replays and retained failures.
 func (c *RootCLI) drainHookSpoolRecords(ctx context.Context, limit int) (replayed, failed int) {
 	result := c.drainHookSpoolRecordsDetailed(ctx, limit)
 	// Preserve the legacy aggregate used by opportunistic debug logging while
@@ -149,7 +168,7 @@ func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) 
 		if ctx.Err() != nil {
 			break
 		}
-		if err := requeueHookSpoolRecord(path); err != nil {
+		if err := requeueHookSpoolRecord(path, "unreadable hook spool record"); err != nil {
 			slog.Debug("unreadable hook spool requeue failed", "path", path, "error", err)
 		}
 	}
@@ -164,7 +183,13 @@ func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) 
 		if err := c.replayHookSpoolRecord(ctx, record); err != nil {
 			result.Failed++
 			slog.Debug("hook spool replay failed", "path", record.Path, "command", record.Command, "client", record.Client, "error", err)
-			if requeueErr := requeueHookSpoolRecord(record.Path); requeueErr != nil {
+			// Observed unreplayable classes that still hit this path and
+			// eventually dead-letter after the retry cap (validators stay
+			// strict; do not relax them):
+			//  1. "invalid Kimi usage record metadata" — unreplayable input
+			//  2. "conflicting duplicate Claude assistant usage" — unreplayable
+			//     against current identity rules (not last-write-wins)
+			if requeueErr := requeueHookSpoolRecord(record.Path, err.Error()); requeueErr != nil {
 				slog.Debug("failed hook spool requeue failed", "path", record.Path, "error", requeueErr)
 			}
 			continue
@@ -172,7 +197,7 @@ func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) 
 		if err := os.Remove(record.Path); err != nil && !os.IsNotExist(err) {
 			result.Failed++
 			slog.Debug("hook spool clear failed after replay", "path", record.Path, "error", err)
-			if requeueErr := requeueHookSpoolRecord(record.Path); requeueErr != nil {
+			if requeueErr := requeueHookSpoolRecord(record.Path, err.Error()); requeueErr != nil {
 				slog.Debug("committed hook spool requeue failed", "path", record.Path, "error", requeueErr)
 			}
 			continue
@@ -400,6 +425,14 @@ func hookSpoolDir() (string, error) {
 	return filepath.Join(stateDir, "spool"), nil
 }
 
+func hookSpoolDeadDir() (string, error) {
+	dir, err := hookSpoolDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, hookSpoolDeadDirName), nil
+}
+
 func listHookSpoolRecordPaths() ([]string, error) {
 	dir, err := hookSpoolDir()
 	if err != nil {
@@ -414,11 +447,14 @@ func listHookSpoolRecordPaths() ([]string, error) {
 	}
 	paths := make([]string, 0, len(entries))
 	for _, entry := range entries {
+		// Skip spool/dead/** and any other subdirectory; only top-level
+		// replayable *.json files are candidates for drain.
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 			continue
 		}
 		paths = append(paths, filepath.Join(dir, entry.Name()))
 	}
+	sort.Strings(paths)
 	return paths, nil
 }
 
@@ -486,16 +522,70 @@ func loadHookSpoolReplayBatch(
 			unreadable = append(unreadable, path)
 			continue
 		}
+		// Records already at the retry cap must not consume drain budget.
+		// They should already live under spool/dead/; this is a crash-safety filter.
+		if shouldDeadLetter(record.AttemptCount) {
+			continue
+		}
 		record.Path = path
 		records = append(records, record)
 	}
 	return records, unreadable, nil
 }
 
-func requeueHookSpoolRecord(path string) error {
+func writeHookSpoolRecordAtomic(path string, record hookSpoolRecord) error {
+	encoded, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return xerrors.Errorf("failed to encode hook spool record: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, encoded, 0o600); err != nil {
+		return xerrors.Errorf("failed to write hook spool record: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return xerrors.Errorf("failed to publish hook spool record: %w", err)
+	}
+	return nil
+}
+
+// requeueHookSpoolRecord increments attempt_count after a failed replay or
+// unreadable load, then either renames the record to the retry tail or moves
+// it to spool/dead/ when shouldDeadLetter reports true. lastError is stored
+// for operator inspection and must never be treated as a payload body by doctor.
+func requeueHookSpoolRecord(path string, lastError string) error {
 	if strings.TrimSpace(path) == "" {
 		return xerrors.New("hook spool path is required")
 	}
+	data, err := readHookSpoolFile(path)
+	if err != nil {
+		// Fall back to a plain read so rename-only recovery still works when
+		// the nofollow open fails for an unreadable path.
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return xerrors.Errorf("failed to read hook spool record for requeue: %w", err)
+		}
+	}
+	record, ok := parseHookSpoolRecordForRequeue(data)
+	if !ok {
+		// Preserve raw bytes so operators can inspect the poison file later.
+		record = hookSpoolRecord{
+			SchemaVersion: hookSpoolSchemaVersion,
+			Payload:       string(data),
+			CreatedAt:     time.Now().UTC(),
+		}
+	}
+	record.AttemptCount++
+	if trimmed := strings.TrimSpace(lastError); trimmed != "" {
+		record.LastError = trimmed
+	}
+	record.Path = ""
+
+	if shouldDeadLetter(record.AttemptCount) {
+		return deadLetterHookSpoolRecord(path, record)
+	}
+
 	random := make([]byte, 8)
 	if _, err := rand.Read(random); err != nil {
 		return xerrors.Errorf("failed to generate hook spool retry ID: %w", err)
@@ -505,10 +595,176 @@ func requeueHookSpoolRecord(path string) error {
 		time.Now().UTC().Format("20060102T150405.000000000Z"),
 		hex.EncodeToString(random),
 	)
-	if err := os.Rename(path, filepath.Join(filepath.Dir(path), name)); err != nil {
-		return xerrors.Errorf("failed to move hook spool record to retry tail: %w", err)
+	newPath := filepath.Join(filepath.Dir(path), name)
+	if err := writeHookSpoolRecordAtomic(newPath, record); err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to remove original hook spool record after requeue: %w", err)
 	}
 	return nil
+}
+
+func parseHookSpoolRecordForRequeue(data []byte) (hookSpoolRecord, bool) {
+	var record hookSpoolRecord
+	if err := json.Unmarshal(data, &record); err != nil || record.SchemaVersion != hookSpoolSchemaVersion {
+		return hookSpoolRecord{}, false
+	}
+	return record, true
+}
+
+func deadLetterHookSpoolRecord(path string, record hookSpoolRecord) error {
+	deadDir, err := hookSpoolDeadDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		return xerrors.Errorf("failed to create hook spool dead-letter directory: %w", err)
+	}
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		return xerrors.Errorf("failed to generate hook spool dead-letter ID: %w", err)
+	}
+	name := fmt.Sprintf(
+		"dead-%s-%s.json",
+		time.Now().UTC().Format("20060102T150405.000000000Z"),
+		hex.EncodeToString(random),
+	)
+	newPath := filepath.Join(deadDir, name)
+	if err := writeHookSpoolRecordAtomic(newPath, record); err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to remove original hook spool record after dead-letter: %w", err)
+	}
+	return nil
+}
+
+// hookSpoolFilesystemStats is a metadata-only view of the spool directory.
+// It uses directory entry counts and byte sizes only; it never opens record
+// payloads. Required for the ≥2 GiB doctor large-store early path.
+type hookSpoolFilesystemStats struct {
+	PendingCount       int
+	PendingBytes       int64
+	StaleInflightCount int
+	StaleInflightBytes int64
+	DeadCount          int
+	DeadBytes          int64
+}
+
+func inspectHookSpoolFilesystemStats(now time.Time) (hookSpoolFilesystemStats, error) {
+	var stats hookSpoolFilesystemStats
+	dir, err := hookSpoolDir()
+	if err != nil {
+		return stats, err
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return stats, nil
+	}
+	if err != nil {
+		return stats, xerrors.Errorf("failed to read hook spool directory: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		path := filepath.Join(dir, name)
+		if entry.IsDir() {
+			if name != hookSpoolDeadDirName {
+				continue
+			}
+			deadCount, deadBytes, deadErr := countDirJSONEntries(path)
+			if deadErr != nil {
+				return stats, deadErr
+			}
+			stats.DeadCount = deadCount
+			stats.DeadBytes = deadBytes
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return stats, xerrors.Errorf("failed to inspect hook spool entry: %w", infoErr)
+		}
+		switch {
+		case strings.HasSuffix(name, ".json"):
+			stats.PendingCount++
+			stats.PendingBytes += info.Size()
+		case strings.HasSuffix(name, ".inflight"):
+			if now.Sub(info.ModTime()) >= hookSpoolInflightStaleAge {
+				stats.StaleInflightCount++
+				stats.StaleInflightBytes += info.Size()
+			}
+		}
+	}
+	return stats, nil
+}
+
+func countDirJSONEntries(dir string) (int, int64, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, xerrors.Errorf("failed to read directory: %w", err)
+	}
+	count := 0
+	var total int64
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return 0, 0, xerrors.Errorf("failed to inspect directory entry: %w", infoErr)
+		}
+		count++
+		total += info.Size()
+	}
+	return count, total, nil
+}
+
+// inspectHookSpoolFilesystemMetadata builds a doctor check from directory
+// metadata only (entry counts + byte sizes). Safe on the large-store early
+// path: no SQLite open and no payload reads.
+func inspectHookSpoolFilesystemMetadata() doctorCheck {
+	const name = "hook-spool"
+	stats, err := inspectHookSpoolFilesystemStats(time.Now().UTC())
+	if err != nil {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusFail,
+			Message: localizef("failed to inspect hook spool metadata: %v", "hook spool メタデータの検査に失敗しました: %v", err),
+		}
+	}
+	pendingTotal := stats.PendingCount + stats.StaleInflightCount
+	if pendingTotal == 0 && stats.DeadCount == 0 {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusPass,
+			Message: Localize("no pending or terminal hook spool records found", "未処理および terminal の hook spool record はありません"),
+		}
+	}
+	status := doctorStatusPass
+	if pendingTotal > 0 {
+		status = doctorStatusWarn
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: status,
+		Message: localizef(
+			"hook spool filesystem metadata: pending=%d (%s), stale_inflight=%d (%s), dead=%d (%s)",
+			"hook spool ファイルシステムメタデータ: pending=%d (%s), stale_inflight=%d (%s), dead=%d (%s)",
+			stats.PendingCount,
+			formatByteSize(stats.PendingBytes),
+			stats.StaleInflightCount,
+			formatByteSize(stats.StaleInflightBytes),
+			stats.DeadCount,
+			formatByteSize(stats.DeadBytes),
+		),
+		Hint: Localize(
+			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations or `traceary doctor --fix`; dead-letter records are retained under spool/dead/ after the retry cap.",
+			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook または `traceary doctor --fix` で drain され、retry cap 到達後の dead-letter は spool/dead/ に保持されます。",
+		),
+	}
 }
 
 func scanHookSpoolRecords(clients []string) ([]hookSpoolRecord, []string, error) {
@@ -530,6 +786,8 @@ func scanHookSpoolRecords(clients []string) ([]hookSpoolRecord, []string, error)
 	records := []hookSpoolRecord{}
 	unreadable := []string{}
 	for _, entry := range entries {
+		// spool/dead/** is terminal retention and is reported via metadata, not
+		// as pending replay candidates.
 		if entry.IsDir() {
 			continue
 		}
@@ -554,6 +812,11 @@ func scanHookSpoolRecords(clients []string) ([]hookSpoolRecord, []string, error)
 		var record hookSpoolRecord
 		if err := json.Unmarshal(data, &record); err != nil || record.SchemaVersion != hookSpoolSchemaVersion {
 			unreadable = append(unreadable, path)
+			continue
+		}
+		if shouldDeadLetter(record.AttemptCount) {
+			// Terminal records left in the pending directory must not appear as
+			// drain candidates; dead/ is the retained location after requeue.
 			continue
 		}
 		if len(allowed) > 0 {
@@ -583,7 +846,11 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 	if err != nil {
 		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect hook spool: %v", "hook spool の検査に失敗しました: %v", err)}
 	}
-	if len(records) == 0 && len(unreadable) == 0 {
+	stats, statsErr := inspectHookSpoolFilesystemStats(time.Now().UTC())
+	if statsErr != nil {
+		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect hook spool metadata: %v", "hook spool メタデータの検査に失敗しました: %v", statsErr)}
+	}
+	if len(records) == 0 && len(unreadable) == 0 && stats.DeadCount == 0 {
 		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending hook spool records found", "未処理の hook spool record はありません")}
 	}
 	structuredFix := func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
@@ -620,24 +887,32 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 	if len(records) > 0 {
 		latest = fmt.Sprintf("client=%s command=%s action=%s created_at=%s path=%s", emptyAsDash(records[0].Client), emptyAsDash(records[0].Command), emptyAsDash(records[0].Action), records[0].CreatedAt.Format(time.RFC3339Nano), records[0].Path)
 	}
-	return doctorCheck{
-		Name:   name,
-		Status: doctorStatusWarn,
-		Message: localizef(
-			"found %d pending hook spool record(s) and %d unreadable record(s); latest %s",
-			"未処理の hook spool record が %d 件、読めない record が %d 件あります。latest %s",
-			len(records), len(unreadable), latest,
-		),
+	status := doctorStatusPass
+	if len(records) > 0 || len(unreadable) > 0 {
+		status = doctorStatusWarn
+	}
+	message := localizef(
+		"found %d pending hook spool record(s), %d terminal dead-letter record(s), and %d unreadable record(s); latest %s",
+		"未処理の hook spool record が %d 件、terminal dead-letter が %d 件、読めない record が %d 件あります。latest %s",
+		len(records), stats.DeadCount, len(unreadable), latest,
+	)
+	check := doctorCheck{
+		Name:    name,
+		Status:  status,
+		Message: message,
 		Hint: Localize(
-			"records are drained automatically on later hook invocations (bounded batch). Run `traceary doctor --fix` to force a larger drain, or inspect payloads under the hook spool directory before manual removal.",
-			"record は後続 hook 呼び出し時に bounded batch で自動 drain されます。`traceary doctor --fix` で大きめに drain するか、手動削除前に spool ディレクトリの payload を確認してください。",
+			"records are drained automatically on later hook invocations (bounded batch). After 3 failed attempts a record is retained under spool/dead/ and excluded from drain. Run `traceary doctor --fix` to force a larger drain, or inspect payloads under the hook spool directory before manual removal.",
+			"record は後続 hook 呼び出し時に bounded batch で自動 drain されます。3 回失敗すると spool/dead/ に保持され drain 対象外になります。`traceary doctor --fix` で大きめに drain するか、手動削除前に spool ディレクトリの payload を確認してください。",
 		),
-		FixCommand:       "traceary doctor --fix",
-		AutoFixAvailable: true,
-		FixFunc: func(ctx context.Context, dryRun bool) (string, error) {
+	}
+	if status == doctorStatusWarn {
+		check.FixCommand = "traceary doctor --fix"
+		check.AutoFixAvailable = true
+		check.FixFunc = func(ctx context.Context, dryRun bool) (string, error) {
 			result, err := structuredFix(ctx, dryRun)
 			return result.Action, err
-		},
-		StructuredFixFunc: structuredFix,
+		}
+		check.StructuredFixFunc = structuredFix
 	}
+	return check
 }

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -33,6 +33,9 @@ const (
 	// success/failure transition and is safe to make replayable.
 	hookSpoolInflightStaleAge = time.Minute
 	hookSpoolDeadDirName      = "dead"
+	// Claimed paths are pending/*.json.claim-<rand> so listHookSpoolRecordPaths
+	// (suffix .json only) cannot pick them up while another process owns them.
+	hookSpoolClaimMarker = ".claim-"
 )
 
 type hookInvocationSpec struct {
@@ -152,53 +155,76 @@ func (c *RootCLI) drainHookSpoolRecords(ctx context.Context, limit int) (replaye
 }
 
 func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) hookSpoolDrainResult {
-	if err := recoverStaleCurrentHookSpoolRecords(time.Now().UTC()); err != nil {
+	now := time.Now().UTC()
+	if err := recoverStaleCurrentHookSpoolRecords(now); err != nil {
+		return hookSpoolDrainResult{Err: err}
+	}
+	if err := recoverStaleClaimedHookSpoolRecords(now); err != nil {
 		return hookSpoolDrainResult{Err: err}
 	}
 	if limit <= 0 {
-		remaining, err := countHookSpoolPendingPaths(time.Now().UTC())
+		remaining, err := countHookSpoolPendingPaths(now)
 		return hookSpoolDrainResult{Remaining: remaining, Err: err}
 	}
-	records, unreadable, err := loadHookSpoolReplayBatch(limit, readHookSpoolFile)
+	paths, err := listHookSpoolRecordPaths()
 	if err != nil {
 		return hookSpoolDrainResult{Err: err}
 	}
-	result := hookSpoolDrainResult{Unreadable: len(unreadable)}
-	for _, path := range unreadable {
-		if ctx.Err() != nil {
+	result := hookSpoolDrainResult{}
+	claimed := 0
+	for _, path := range paths {
+		if claimed >= limit {
 			break
 		}
-		if err := requeueHookSpoolRecord(path, "unreadable hook spool record"); err != nil {
-			slog.Debug("unreadable hook spool requeue failed", "path", path, "error", err)
-		}
-	}
-	for _, record := range records {
 		if err := ctx.Err(); err != nil {
 			break
 		}
-		if strings.TrimSpace(record.Path) == "" {
-			result.Failed++
+		// Exclusive claim via same-directory rename (CAS). Concurrent drainers
+		// that lose the race see IsNotExist and skip — no shared mutex.
+		claimedPath, ok, claimErr := claimHookSpoolRecord(path)
+		if claimErr != nil {
+			slog.Debug("hook spool claim failed", "path", path, "error", claimErr)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		claimed++
+		record, readable, loadErr := loadClaimedHookSpoolRecord(claimedPath, readHookSpoolFile)
+		if loadErr != nil || !readable {
+			result.Unreadable++
+			if requeueErr := requeueHookSpoolRecord(claimedPath, "unreadable hook spool record"); requeueErr != nil {
+				slog.Debug("unreadable hook spool requeue failed", "path", claimedPath, "error", requeueErr)
+			}
+			continue
+		}
+		// Crash-safety: claimed records already at the retry cap still must
+		// leave the replay queue without consuming a delivery attempt.
+		if shouldDeadLetter(record.AttemptCount) {
+			if moveErr := renameHookSpoolRecordToDead(claimedPath); moveErr != nil {
+				slog.Debug("terminal hook spool claim move failed", "path", claimedPath, "error", moveErr)
+			}
 			continue
 		}
 		if err := c.replayHookSpoolRecord(ctx, record); err != nil {
 			result.Failed++
-			slog.Debug("hook spool replay failed", "path", record.Path, "command", record.Command, "client", record.Client, "error", err)
+			slog.Debug("hook spool replay failed", "path", claimedPath, "command", record.Command, "client", record.Client, "error", err)
 			// Observed unreplayable classes that still hit this path and
 			// eventually dead-letter after the retry cap (validators stay
 			// strict; do not relax them):
 			//  1. "invalid Kimi usage record metadata" — unreplayable input
 			//  2. "conflicting duplicate Claude assistant usage" — unreplayable
 			//     against current identity rules (not last-write-wins)
-			if requeueErr := requeueHookSpoolRecord(record.Path, err.Error()); requeueErr != nil {
-				slog.Debug("failed hook spool requeue failed", "path", record.Path, "error", requeueErr)
+			if requeueErr := requeueHookSpoolRecord(claimedPath, err.Error()); requeueErr != nil {
+				slog.Debug("failed hook spool requeue failed", "path", claimedPath, "error", requeueErr)
 			}
 			continue
 		}
-		if err := os.Remove(record.Path); err != nil && !os.IsNotExist(err) {
+		if err := os.Remove(claimedPath); err != nil && !os.IsNotExist(err) {
 			result.Failed++
-			slog.Debug("hook spool clear failed after replay", "path", record.Path, "error", err)
-			if requeueErr := requeueHookSpoolRecord(record.Path, err.Error()); requeueErr != nil {
-				slog.Debug("committed hook spool requeue failed", "path", record.Path, "error", requeueErr)
+			slog.Debug("hook spool clear failed after replay", "path", claimedPath, "error", err)
+			if requeueErr := requeueHookSpoolRecord(claimedPath, err.Error()); requeueErr != nil {
+				slog.Debug("committed hook spool requeue failed", "path", claimedPath, "error", requeueErr)
 			}
 			continue
 		}
@@ -415,6 +441,115 @@ func recoverStaleCurrentHookSpoolRecords(now time.Time) error {
 		}
 	}
 	return nil
+}
+
+// isHookSpoolClaimFile reports whether name is a drain claim
+// (basename.json.claim-<rand>) that listHookSpoolRecordPaths must ignore.
+func isHookSpoolClaimFile(name string) bool {
+	idx := strings.LastIndex(name, hookSpoolClaimMarker)
+	if idx < 0 {
+		return false
+	}
+	return strings.HasSuffix(name[:idx], ".json")
+}
+
+// claimHookSpoolRecord exclusively claims a pending *.json record by renaming
+// it to a non-replayable claim path in the same directory. ok=false means
+// another worker already claimed or removed the path (lost CAS).
+func claimHookSpoolRecord(path string) (claimedPath string, ok bool, err error) {
+	if strings.TrimSpace(path) == "" {
+		return "", false, xerrors.New("hook spool path is required")
+	}
+	if !strings.HasSuffix(path, ".json") {
+		return "", false, xerrors.New("hook spool claim source must end with .json")
+	}
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		return "", false, xerrors.Errorf("failed to generate hook spool claim ID: %w", err)
+	}
+	claimedPath = path + hookSpoolClaimMarker + hex.EncodeToString(random)
+	if err := os.Rename(path, claimedPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, xerrors.Errorf("failed to claim hook spool record: %w", err)
+	}
+	return claimedPath, true, nil
+}
+
+// recoverStaleClaimedHookSpoolRecords returns claim files left by a killed
+// process to the replayable *.json queue after hookSpoolInflightStaleAge.
+func recoverStaleClaimedHookSpoolRecords(now time.Time) error {
+	dir, err := hookSpoolDir()
+	if err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return xerrors.Errorf("failed to read hook spool directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !isHookSpoolClaimFile(entry.Name()) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return xerrors.Errorf("failed to inspect claimed hook spool record: %w", err)
+		}
+		if now.Sub(info.ModTime()) < hookSpoolInflightStaleAge {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if err := releaseStaleClaimedHookSpoolRecord(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func releaseStaleClaimedHookSpoolRecord(claimedPath string) error {
+	base := filepath.Base(claimedPath)
+	idx := strings.LastIndex(base, hookSpoolClaimMarker)
+	if idx < 0 || !strings.HasSuffix(base[:idx], ".json") {
+		return xerrors.New("claimed hook spool path is malformed")
+	}
+	restored := filepath.Join(filepath.Dir(claimedPath), base[:idx])
+	if _, err := os.Lstat(restored); err == nil {
+		// Basename already occupied; never rename-over another record.
+		return renameHookSpoolRecordToRetryTail(claimedPath)
+	} else if !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to inspect restored hook spool path: %w", err)
+	}
+	if err := os.Rename(claimedPath, restored); err != nil {
+		if os.IsNotExist(err) {
+			return xerrors.Errorf("claimed hook spool record disappeared during release: %w", err)
+		}
+		// Race: basename appeared between Lstat and Rename.
+		return renameHookSpoolRecordToRetryTail(claimedPath)
+	}
+	return nil
+}
+
+// loadClaimedHookSpoolRecord reads a path already owned via claimHookSpoolRecord.
+// readable=false means the bytes could not be parsed as a schema v1 record
+// (caller should dead-letter / requeue without following symlinks).
+func loadClaimedHookSpoolRecord(
+	claimedPath string,
+	readFile func(string) ([]byte, error),
+) (hookSpoolRecord, bool, error) {
+	data, err := readFile(claimedPath)
+	if err != nil {
+		return hookSpoolRecord{}, false, err
+	}
+	var record hookSpoolRecord
+	if err := json.Unmarshal(data, &record); err != nil || record.SchemaVersion != hookSpoolSchemaVersion {
+		return hookSpoolRecord{}, false, nil
+	}
+	record.Path = claimedPath
+	return record, true, nil
 }
 
 func hookSpoolDir() (string, error) {

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -474,6 +474,13 @@ func claimHookSpoolRecord(path string) (claimedPath string, ok bool, err error) 
 		}
 		return "", false, xerrors.Errorf("failed to claim hook spool record: %w", err)
 	}
+	// Rename preserves the original mtime. Bump claim times to now so a
+	// long-pending record is not immediately treated as a stale claim by
+	// recoverStaleClaimedHookSpoolRecords while this process still owns it.
+	now := time.Now()
+	if err := os.Chtimes(claimedPath, now, now); err != nil {
+		slog.Debug("hook spool claim chtimes failed", "path", claimedPath, "error", err)
+	}
 	return claimedPath, true, nil
 }
 

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -13,6 +13,8 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -1432,6 +1434,160 @@ func TestInspectHookSpoolDiagnostics_ReportsPendingAndTerminalCounts(t *testing.
 	}
 	if !strings.Contains(check.Message, "1 pending") || !strings.Contains(check.Message, "1 terminal") {
 		t.Fatalf("message=%q, want pending and terminal counts", check.Message)
+	}
+}
+
+func TestClaimHookSpoolRecord_ConcurrentExclusive(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	path, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	const workers = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var wins atomic.Int32
+	var claimedPath atomic.Value
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			got, ok, claimErr := claimHookSpoolRecord(path)
+			if claimErr != nil {
+				t.Errorf("claimHookSpoolRecord: %v", claimErr)
+				return
+			}
+			if ok {
+				wins.Add(1)
+				claimedPath.Store(got)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := wins.Load(); got != 1 {
+		t.Fatalf("claim winners=%d, want exactly 1", got)
+	}
+	gotPath, _ := claimedPath.Load().(string)
+	if gotPath == "" || !isHookSpoolClaimFile(filepath.Base(gotPath)) {
+		t.Fatalf("claimed path = %q, want *.json.claim-*", gotPath)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("original path must be gone after exclusive claim, stat err=%v", err)
+	}
+	// Exactly one claim file remains; no second copy of the original.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	claimFiles := 0
+	jsonFiles := 0
+	for _, entry := range entries {
+		switch {
+		case isHookSpoolClaimFile(entry.Name()):
+			claimFiles++
+		case strings.HasSuffix(entry.Name(), ".json"):
+			jsonFiles++
+		}
+	}
+	if claimFiles != 1 || jsonFiles != 0 {
+		t.Fatalf("claimFiles=%d jsonFiles=%d, want 1/0", claimFiles, jsonFiles)
+	}
+}
+
+func TestDrainHookSpoolRecords_ConcurrentClaimSingleRecord(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+
+	originalPath, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{"marker":"concurrent-claim"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	// Two concurrent drains share one poison record. Regardless of scheduling
+	// (second worker may or may not see the first worker's zz-retry), the
+	// exclusive claim must keep a single retained file and never resurrect the
+	// original basename as a duplicate replayable copy.
+	const workers = 2
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	results := make([]struct{ replayed, failed int }, workers)
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			root := NewRootCLI(
+				WithStoreManagement(&spoolStoreManagementStub{}),
+				WithEvent(&spoolEventUsecaseStub{}),
+			)
+			<-start
+			results[i].replayed, results[i].failed = root.drainHookSpoolRecords(context.Background(), 5)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	totalReplayed := results[0].replayed + results[1].replayed
+	if totalReplayed != 0 {
+		t.Fatalf("replayed=%d, want 0 for poison record (results=%v)", totalReplayed, results)
+	}
+	if _, err := os.Stat(originalPath); !os.IsNotExist(err) {
+		t.Fatalf("original path must be gone after claim, stat err=%v", err)
+	}
+
+	pending := listTopLevelSpoolJSON(t, spoolDir)
+	deadDir := filepath.Join(spoolDir, hookSpoolDeadDirName)
+	deadCount := 0
+	if entries, err := os.ReadDir(deadDir); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+				deadCount++
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("ReadDir(dead): %v", err)
+	}
+	if len(pending)+deadCount != 1 {
+		t.Fatalf("pending=%v dead=%d, want exactly one retained record (results=%v)", pending, deadCount, results)
+	}
+	if len(pending) == 1 {
+		data, err := os.ReadFile(filepath.Join(spoolDir, pending[0]))
+		if err != nil {
+			t.Fatalf("ReadFile retry: %v", err)
+		}
+		var record hookSpoolRecord
+		if err := json.Unmarshal(data, &record); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if record.AttemptCount < 1 || record.AttemptCount > workers {
+			t.Fatalf("AttemptCount=%d, want 1..%d", record.AttemptCount, workers)
+		}
+	}
+	entries, err := os.ReadDir(spoolDir)
+	if err != nil {
+		t.Fatalf("ReadDir(spool): %v", err)
+	}
+	for _, entry := range entries {
+		if isHookSpoolClaimFile(entry.Name()) {
+			t.Fatalf("leftover claim file %q", entry.Name())
+		}
 	}
 }
 

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1437,6 +1437,63 @@ func TestInspectHookSpoolDiagnostics_ReportsPendingAndTerminalCounts(t *testing.
 	}
 }
 
+func TestClaimHookSpoolRecord_FreshMtimeSurvivesStaleRecovery(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	path, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{}`,
+		CreatedAt:     time.Now().UTC().Add(-2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	// Simulate a long-pending record whose original mtime is already stale.
+	old := time.Now().Add(-2 * hookSpoolInflightStaleAge)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatalf("Chtimes original: %v", err)
+	}
+
+	claimedPath, ok, err := claimHookSpoolRecord(path)
+	if err != nil {
+		t.Fatalf("claimHookSpoolRecord: %v", err)
+	}
+	if !ok {
+		t.Fatal("claimHookSpoolRecord ok=false, want true")
+	}
+
+	// Immediate recovery with wall clock must not restore a live claim whose
+	// mtime was refreshed at claim time (rename alone would keep the old mtime).
+	if err := recoverStaleClaimedHookSpoolRecords(time.Now().UTC()); err != nil {
+		t.Fatalf("recover now: %v", err)
+	}
+	if _, err := os.Lstat(claimedPath); err != nil {
+		t.Fatalf("claimed path must remain after recover(now): %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("original .json must not be restored while claim is live, stat err=%v", err)
+	}
+
+	// Far-future recovery may release the claim once it is truly stale.
+	future := time.Now().UTC().Add(2 * hookSpoolInflightStaleAge)
+	if err := recoverStaleClaimedHookSpoolRecords(future); err != nil {
+		t.Fatalf("recover future: %v", err)
+	}
+	if _, err := os.Lstat(claimedPath); !os.IsNotExist(err) {
+		t.Fatalf("stale claim must be released, Lstat err=%v", err)
+	}
+	// Restored either under the original basename or a unique retry name.
+	pending, err := listHookSpoolRecordPaths()
+	if err != nil {
+		t.Fatalf("listHookSpoolRecordPaths: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending after stale release = %v, want exactly 1", pending)
+	}
+}
+
 func TestClaimHookSpoolRecord_ConcurrentExclusive(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -543,6 +543,59 @@ func TestDrainHookSpoolRecords_DoesNotFollowExternalSymlink(t *testing.T) {
 	if string(data) != sentinelRecord {
 		t.Fatal("sentinel content changed")
 	}
+
+	// Requeue of an unreadable symlink must not materialize a regular retry
+	// JSON that would replay the external target on the next drain.
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("symlink must leave the pending spool, Lstat err=%v", err)
+	}
+	pendingJSON := listTopLevelSpoolJSON(t, spoolDir)
+	if len(pendingJSON) != 0 {
+		t.Fatalf("pending spool JSON after symlink requeue = %v, want none", pendingJSON)
+	}
+	for _, name := range pendingJSON {
+		info, err := os.Lstat(filepath.Join(spoolDir, name))
+		if err != nil {
+			t.Fatalf("Lstat(%s): %v", name, err)
+		}
+		if info.Mode().IsRegular() {
+			body, _ := os.ReadFile(filepath.Join(spoolDir, name))
+			if strings.Contains(string(body), privateMarker) {
+				t.Fatalf("requeue created replayable copy of external sentinel: %s", name)
+			}
+		}
+	}
+
+	replayed, failed = root.drainHookSpoolRecords(context.Background(), 5)
+	if replayed != 0 || failed != 0 || eventStub.logCalls != 0 {
+		t.Fatalf("second drain=%d/%d logCalls=%d, want 0/0/0 (no symlink target replay)", replayed, failed, eventStub.logCalls)
+	}
+	if eventStub.lastMessage == privateMarker || strings.Contains(eventStub.lastMessage, privateMarker) {
+		t.Fatalf("second drain replayed sentinel payload: %q", eventStub.lastMessage)
+	}
+	data, err = os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("sentinel must remain after second drain: %v", err)
+	}
+	if string(data) != sentinelRecord {
+		t.Fatal("sentinel content changed after second drain")
+	}
+}
+
+func listTopLevelSpoolJSON(t *testing.T, spoolDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(spoolDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", spoolDir, err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names
 }
 
 func TestInspectHookSpoolDiagnostics_DoesNotFollowExternalSymlink(t *testing.T) {
@@ -1379,6 +1432,90 @@ func TestInspectHookSpoolDiagnostics_ReportsPendingAndTerminalCounts(t *testing.
 	}
 	if !strings.Contains(check.Message, "1 pending") || !strings.Contains(check.Message, "1 terminal") {
 		t.Fatalf("message=%q, want pending and terminal counts", check.Message)
+	}
+}
+
+func TestRequeueHookSpoolRecord_SingleFileTransition(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+
+	path, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{"marker":"single-transition"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	if err := requeueHookSpoolRecord(path, "first failure"); err != nil {
+		t.Fatalf("requeue: %v", err)
+	}
+	// After a successful requeue there must be exactly one replayable file
+	// (the retry-tail rename of the original), not original+copy.
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("original path must be gone after requeue, stat err=%v", err)
+	}
+	pending := listTopLevelSpoolJSON(t, spoolDir)
+	if len(pending) != 1 {
+		t.Fatalf("pending JSON after requeue = %v, want exactly one retry file", pending)
+	}
+	if !strings.HasPrefix(pending[0], "zz-retry-") {
+		t.Fatalf("retry name = %q, want zz-retry- prefix", pending[0])
+	}
+	// No leftover tmp from the in-place publish step.
+	entries, err := os.ReadDir(spoolDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".tmp") {
+			t.Fatalf("leftover tmp after requeue: %s", entry.Name())
+		}
+	}
+	retryPath := filepath.Join(spoolDir, pending[0])
+	data, err := os.ReadFile(retryPath)
+	if err != nil {
+		t.Fatalf("ReadFile retry: %v", err)
+	}
+	var record hookSpoolRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if record.AttemptCount != 1 || record.LastError != "first failure" {
+		t.Fatalf("record=%#v, want attempt=1 last_error=first failure", record)
+	}
+
+	// Drive remaining attempts to dead-letter; each step must keep exactly one file.
+	for attempt := 1; attempt < hookSpoolRetryLimit; attempt++ {
+		pending = listTopLevelSpoolJSON(t, spoolDir)
+		if len(pending) != 1 {
+			t.Fatalf("pending before attempt %d = %v, want exactly one", attempt+1, pending)
+		}
+		retryPath = filepath.Join(spoolDir, pending[0])
+		if err := requeueHookSpoolRecord(retryPath, "again"); err != nil {
+			t.Fatalf("requeue attempt %d: %v", attempt+1, err)
+		}
+	}
+	if got := listTopLevelSpoolJSON(t, spoolDir); len(got) != 0 {
+		t.Fatalf("pending after dead-letter = %v, want empty", got)
+	}
+	deadDir := filepath.Join(spoolDir, hookSpoolDeadDirName)
+	deadEntries, err := os.ReadDir(deadDir)
+	if err != nil {
+		t.Fatalf("ReadDir(dead): %v", err)
+	}
+	jsonDead := 0
+	for _, entry := range deadEntries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			jsonDead++
+		}
+	}
+	if jsonDead != 1 {
+		t.Fatalf("dead JSON count=%d, want exactly 1", jsonDead)
 	}
 }
 

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1072,3 +1072,371 @@ func (s *spoolStoreManagementStub) PurgeContentEventDedupeRun(context.Context, s
 func (s *spoolStoreManagementStub) ListContentEventDedupeRuns(context.Context) ([]apptypes.ContentEventDedupeRun, error) {
 	return nil, nil
 }
+
+func TestShouldDeadLetter(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		attempt int
+		want    bool
+	}{
+		{0, false},
+		{1, false},
+		{2, false},
+		{3, true},
+		{4, true},
+	}
+	for _, tc := range cases {
+		if got := shouldDeadLetter(tc.attempt); got != tc.want {
+			t.Fatalf("shouldDeadLetter(%d) = %v, want %v", tc.attempt, got, tc.want)
+		}
+	}
+}
+
+func TestRequeueHookSpoolRecord_IncrementsAttemptUntilDeadLetter(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(&spoolEventUsecaseStub{}),
+	)
+	path, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	// First two failures keep the record pending with incremented attempt_count.
+	for wantAttempt := 1; wantAttempt < hookSpoolRetryLimit; wantAttempt++ {
+		replayed, failed := root.drainHookSpoolRecords(context.Background(), 1)
+		if replayed != 0 || failed != 1 {
+			t.Fatalf("attempt %d: drain=%d/%d, want 0/1", wantAttempt, replayed, failed)
+		}
+		records, unreadable, err := scanHookSpoolRecords(nil)
+		if err != nil {
+			t.Fatalf("scan after attempt %d: %v", wantAttempt, err)
+		}
+		if len(unreadable) != 0 || len(records) != 1 {
+			t.Fatalf("attempt %d: records=%#v unreadable=%#v", wantAttempt, records, unreadable)
+		}
+		if records[0].AttemptCount != wantAttempt {
+			t.Fatalf("attempt %d: AttemptCount=%d, want %d", wantAttempt, records[0].AttemptCount, wantAttempt)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("attempt %d: original path should have been renamed, stat err=%v", wantAttempt, err)
+		}
+		path = records[0].Path
+	}
+
+	// Final failure moves the record to spool/dead/ and excludes it from drain.
+	replayed, failed := root.drainHookSpoolRecords(context.Background(), 1)
+	if replayed != 0 || failed != 1 {
+		t.Fatalf("cap drain=%d/%d, want 0/1", replayed, failed)
+	}
+	records, unreadable, err := scanHookSpoolRecords(nil)
+	if err != nil {
+		t.Fatalf("scan after cap: %v", err)
+	}
+	if len(records) != 0 || len(unreadable) != 0 {
+		t.Fatalf("after cap pending records=%#v unreadable=%#v, want empty", records, unreadable)
+	}
+	deadDir := filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
+	deadEntries, err := os.ReadDir(deadDir)
+	if err != nil {
+		t.Fatalf("ReadDir(dead): %v", err)
+	}
+	if len(deadEntries) != 1 {
+		t.Fatalf("dead entries=%d, want 1", len(deadEntries))
+	}
+	deadPath := filepath.Join(deadDir, deadEntries[0].Name())
+	data, err := os.ReadFile(deadPath)
+	if err != nil {
+		t.Fatalf("ReadFile(dead): %v", err)
+	}
+	var dead hookSpoolRecord
+	if err := json.Unmarshal(data, &dead); err != nil {
+		t.Fatalf("Unmarshal dead: %v", err)
+	}
+	if dead.AttemptCount != hookSpoolRetryLimit {
+		t.Fatalf("dead AttemptCount=%d, want %d", dead.AttemptCount, hookSpoolRetryLimit)
+	}
+	if dead.LastError == "" {
+		t.Fatal("dead last_error must be set")
+	}
+
+	// Drain batch must not pick dead-letter files.
+	batch, batchUnreadable, err := loadHookSpoolReplayBatch(5, os.ReadFile)
+	if err != nil {
+		t.Fatalf("loadHookSpoolReplayBatch: %v", err)
+	}
+	if len(batch) != 0 || len(batchUnreadable) != 0 {
+		t.Fatalf("batch after dead-letter records=%#v unreadable=%#v, want empty", batch, batchUnreadable)
+	}
+	replayed, failed = root.drainHookSpoolRecords(context.Background(), 5)
+	if replayed != 0 || failed != 0 {
+		t.Fatalf("post-dead drain=%d/%d, want 0/0", replayed, failed)
+	}
+	// Terminal records are retained, not deleted.
+	if _, err := os.Stat(deadPath); err != nil {
+		t.Fatalf("dead-letter must be retained: %v", err)
+	}
+}
+
+func TestRequeueHookSpoolRecord_MissingAttemptCountTreatedAsZero(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Old schema_version:1 records omit attempt_count; treat as 0 then 1.
+	path := filepath.Join(spoolDir, "20260101T000000.000000000Z-claude-legacy.json")
+	legacy := `{"schema_version":1,"command":"not-a-real-hook","client":"claude","payload":"{}","created_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(path, []byte(legacy+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := requeueHookSpoolRecord(path, "legacy fail"); err != nil {
+		t.Fatalf("requeueHookSpoolRecord: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("legacy path must move, stat err=%v", err)
+	}
+	records, unreadable, err := scanHookSpoolRecords(nil)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(unreadable) != 0 || len(records) != 1 {
+		t.Fatalf("records=%#v unreadable=%#v", records, unreadable)
+	}
+	if records[0].AttemptCount != 1 {
+		t.Fatalf("AttemptCount=%d, want 1 (missing field treated as 0 then incremented)", records[0].AttemptCount)
+	}
+	if records[0].LastError != "legacy fail" {
+		t.Fatalf("LastError=%q, want legacy fail", records[0].LastError)
+	}
+}
+
+func TestLoadHookSpoolReplayBatch_SkipsDeadLetterDirectory(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+	deadDir := filepath.Join(spoolDir, hookSpoolDeadDirName)
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// A live pending record should still load.
+	if _, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"live","session_id":"s-live","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("persist live: %v", err)
+	}
+	// A dead-letter file must never appear in the replay batch.
+	deadRecord := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{}`,
+		CreatedAt:     time.Now().UTC().Add(-2 * time.Minute),
+		AttemptCount:  hookSpoolRetryLimit,
+		LastError:     "poison",
+	}
+	deadPath := filepath.Join(deadDir, "dead-poison.json")
+	if err := writeHookSpoolRecordAtomic(deadPath, deadRecord); err != nil {
+		t.Fatalf("write dead: %v", err)
+	}
+
+	records, unreadable, err := loadHookSpoolReplayBatch(5, os.ReadFile)
+	if err != nil {
+		t.Fatalf("loadHookSpoolReplayBatch: %v", err)
+	}
+	if len(unreadable) != 0 || len(records) != 1 {
+		t.Fatalf("records=%#v unreadable=%#v, want only live pending", records, unreadable)
+	}
+	if !strings.Contains(records[0].Payload, "live") {
+		t.Fatalf("expected live payload, got %#v", records[0])
+	}
+	paths, err := listHookSpoolRecordPaths()
+	if err != nil {
+		t.Fatalf("listHookSpoolRecordPaths: %v", err)
+	}
+	for _, p := range paths {
+		if strings.Contains(p, string(filepath.Separator)+hookSpoolDeadDirName+string(filepath.Separator)) {
+			t.Fatalf("list included dead path %q", p)
+		}
+	}
+}
+
+func TestLoadHookSpoolReplayBatch_SkipsRecordsAtRetryCap(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	if _, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+		AttemptCount:  hookSpoolRetryLimit,
+	}); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	records, unreadable, err := loadHookSpoolReplayBatch(5, os.ReadFile)
+	if err != nil {
+		t.Fatalf("loadHookSpoolReplayBatch: %v", err)
+	}
+	if len(records) != 0 || len(unreadable) != 0 {
+		t.Fatalf("records=%#v unreadable=%#v, want skip at cap", records, unreadable)
+	}
+}
+
+func TestInspectHookSpoolFilesystemMetadata_CountsWithoutReadingPayloads(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+	deadDir := filepath.Join(spoolDir, hookSpoolDeadDirName)
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	const secretPayload = "SECRET_PAYLOAD_MUST_NOT_APPEAR_IN_DOCTOR"
+	pendingPath := filepath.Join(spoolDir, "20260101T000000.000000000Z-claude-pending.json")
+	if err := os.WriteFile(pendingPath, []byte(`{"schema_version":1,"command":"prompt","client":"claude","payload":"`+secretPayload+`","created_at":"2026-01-01T00:00:00Z"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile pending: %v", err)
+	}
+	deadPath := filepath.Join(deadDir, "dead-one.json")
+	if err := os.WriteFile(deadPath, []byte(`{"schema_version":1,"attempt_count":3,"payload":"`+secretPayload+`"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile dead: %v", err)
+	}
+	inflightPath := filepath.Join(spoolDir, "20260101T000001.000000000Z-claude.inflight")
+	if err := os.WriteFile(inflightPath, []byte(`{"schema_version":1,"payload":"`+secretPayload+`"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile inflight: %v", err)
+	}
+	staleAt := time.Now().Add(-2 * hookSpoolInflightStaleAge)
+	if err := os.Chtimes(inflightPath, staleAt, staleAt); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	stats, err := inspectHookSpoolFilesystemStats(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("inspectHookSpoolFilesystemStats: %v", err)
+	}
+	if stats.PendingCount != 1 || stats.DeadCount != 1 || stats.StaleInflightCount != 1 {
+		t.Fatalf("stats=%+v, want pending=1 dead=1 stale_inflight=1", stats)
+	}
+	if stats.PendingBytes <= 0 || stats.DeadBytes <= 0 || stats.StaleInflightBytes <= 0 {
+		t.Fatalf("byte sizes must be positive: %+v", stats)
+	}
+
+	check := inspectHookSpoolFilesystemMetadata()
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q, want warn", check.Status)
+	}
+	if !strings.Contains(check.Message, "pending=1") || !strings.Contains(check.Message, "dead=1") {
+		t.Fatalf("message=%q, want pending and dead counts", check.Message)
+	}
+	if strings.Contains(check.Message, secretPayload) || strings.Contains(check.Hint, secretPayload) {
+		t.Fatalf("doctor leaked payload body: %#v", check)
+	}
+}
+
+func TestInspectHookSpoolDiagnostics_ReportsPendingAndTerminalCounts(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	if _, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"pending","session_id":"s-p","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	deadDir := filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := writeHookSpoolRecordAtomic(filepath.Join(deadDir, "dead.json"), hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{}`,
+		CreatedAt:     time.Now().UTC(),
+		AttemptCount:  hookSpoolRetryLimit,
+	}); err != nil {
+		t.Fatalf("write dead: %v", err)
+	}
+
+	check := (&RootCLI{}).inspectHookSpoolDiagnostics(nil)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q, want warn", check.Status)
+	}
+	if !strings.Contains(check.Message, "1 pending") || !strings.Contains(check.Message, "1 terminal") {
+		t.Fatalf("message=%q, want pending and terminal counts", check.Message)
+	}
+}
+
+func TestRequeueHookSpoolRecord_ClassifiedUnreplayableErrorsIncrementTowardDeadLetter(t *testing.T) {
+	// The two observed poison classes must progress attempt_count via the real
+	// requeue/dead-letter path. Validators stay strict; this only asserts
+	// terminal retention after the cap.
+	cases := []string{
+		"invalid Kimi usage record metadata",
+		"conflicting duplicate Claude assistant usage",
+	}
+	for _, lastError := range cases {
+		t.Run(lastError, func(t *testing.T) {
+			stateDir := t.TempDir()
+			t.Setenv(hookStateDirEnvKey, stateDir)
+			path, err := persistHookSpoolRecord(hookSpoolRecord{
+				SchemaVersion: hookSpoolSchemaVersion,
+				Command:       "usage",
+				Client:        "claude",
+				Payload:       `{}`,
+				CreatedAt:     time.Now().UTC().Add(-time.Minute),
+				AttemptCount:  hookSpoolRetryLimit - 1,
+			})
+			if err != nil {
+				t.Fatalf("persist: %v", err)
+			}
+			if err := requeueHookSpoolRecord(path, lastError); err != nil {
+				t.Fatalf("requeueHookSpoolRecord: %v", err)
+			}
+			deadDir := filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
+			entries, err := os.ReadDir(deadDir)
+			if err != nil {
+				t.Fatalf("ReadDir(dead): %v", err)
+			}
+			if len(entries) != 1 {
+				t.Fatalf("dead entries=%d, want 1", len(entries))
+			}
+			data, err := os.ReadFile(filepath.Join(deadDir, entries[0].Name()))
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+			var dead hookSpoolRecord
+			if err := json.Unmarshal(data, &dead); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if dead.AttemptCount != hookSpoolRetryLimit {
+				t.Fatalf("AttemptCount=%d, want %d", dead.AttemptCount, hookSpoolRetryLimit)
+			}
+			if dead.LastError != lastError {
+				t.Fatalf("LastError=%q, want %q", dead.LastError, lastError)
+			}
+			batch, _, err := loadHookSpoolReplayBatch(5, os.ReadFile)
+			if err != nil {
+				t.Fatalf("loadHookSpoolReplayBatch: %v", err)
+			}
+			if len(batch) != 0 {
+				t.Fatalf("dead-lettered poison still in batch: %#v", batch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1876

Hook spool records that permanently fail (poison / unreplayable input) no longer retry forever or consume the opportunistic drain batch budget.

### Behavior
- Every replayable spool record carries optional `attempt_count` (schema_version stays 1; missing field = 0).
- `hookSpoolRetryLimit = 3` (first delivery + 2 retries), documented next to `hookSpoolReplayBatchLimit`.
- On failed replay or unreadable load: increment `attempt_count`, store optional `last_error`, then either rename to the retry tail or move to `spool/dead/`.
- Dead-letter files are **retained** (not deleted) and excluded from `listHookSpoolRecordPaths` / `loadHookSpoolReplayBatch` / drain.
- Doctor reports pending vs terminal (dead-letter) counts. On the ≥2 GiB metadata-only large-store path this uses directory entry counts + byte sizes only — no SQLite open and no payload body reads.

### Error-class classification (validators stay strict)

These are the two observed classes that dead-letter after the retry cap. This PR does **not** relax either validator.

1. **`invalid Kimi usage record metadata`** (`infrastructure/filesystem/kimi_usage_source.go`) — unreplayable input. Dead-letter after cap. Do not weaken the validator.
2. **`conflicting duplicate Claude assistant usage`** (`infrastructure/filesystem/claude_usage_source.go`) — unreplayable against current identity rules. Dead-letter after cap. Do not switch to last-write-wins.

### Out of scope
- Draining the live `~/.config/traceary` spool / opening `~/.config/traceary/traceary.db`
- #1881 budget math
- #1882 timeout pins
- Parent #1693 (must stay open)

## Test plan
- [x] `go test ./presentation/cli -count=1`
- [x] `go tool golangci-lint run ./presentation/cli/...`
- [x] Failed requeue increments attempt; still pending until cap
- [x] At cap, file lands in `spool/dead/` and drain batch excludes it
- [x] Old JSON without `attempt_count` treated as 0 then 1
- [x] `loadHookSpoolReplayBatch` / drain skip dead-letter files and records at cap
- [x] Doctor large-store fallback reports pending and dead counts without SQLite or payload reads
- [x] Classified Kimi/Claude error strings increment toward dead-letter via the real requeue path