### PR TITLE
fix: keep hook spool drain inside the host hook budget

### DIFF
--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -28,6 +28,16 @@ const (
 	// failed attempts the record is retained under spool/dead/ and excluded
 	// from opportunistic drain so poison records cannot consume the batch.
 	hookSpoolRetryLimit = 3
+	// packagedHostBudget is the documented packaged host hook timeout. When
+	// ctx has no deadline, remaining drain headroom is measured against this.
+	packagedHostBudget = 10 * time.Second
+	// hookSpoolDrainReserve is headroom kept for process exit after current
+	// delivery. Opportunistic drain is skipped once remaining time is at or
+	// below this reserve.
+	hookSpoolDrainReserve = 2 * time.Second
+	// hookSpoolDrainLowHeadroom is the remaining-time band where drain may
+	// replay a single backlog record only (not a full batch).
+	hookSpoolDrainLowHeadroom = 4 * time.Second
 	// Packaged host hook budgets are 10 seconds. An in-flight record older than
 	// one minute belongs to a process that did not finish its normal
 	// success/failure transition and is safe to make replayable.
@@ -37,6 +47,32 @@ const (
 	// (suffix .json only) cannot pick them up while another process owns them.
 	hookSpoolClaimMarker = ".claim-"
 )
+
+// hookSpoolDrainAllowance returns how many backlog records opportunistic drain
+// may attempt given remaining host budget. Pure policy: no I/O.
+//
+//	remaining <= 2s → 0 (keep drainReserve for exit)
+//	remaining <  4s → 1 (low headroom)
+//	otherwise       → hookSpoolReplayBatchLimit
+func hookSpoolDrainAllowance(remaining time.Duration) int {
+	if remaining <= hookSpoolDrainReserve {
+		return 0
+	}
+	if remaining < hookSpoolDrainLowHeadroom {
+		return 1
+	}
+	return hookSpoolReplayBatchLimit
+}
+
+// hookSpoolDrainRemaining is the wall-clock budget left for opportunistic
+// drain. Prefer an explicit ctx deadline when the host provided one; otherwise
+// assume the packaged 10s budget from startedAt.
+func hookSpoolDrainRemaining(ctx context.Context, startedAt, now time.Time) time.Duration {
+	if deadline, ok := ctx.Deadline(); ok {
+		return deadline.Sub(now)
+	}
+	return packagedHostBudget - now.Sub(startedAt)
+}
 
 type hookInvocationSpec struct {
 	Command string
@@ -84,6 +120,7 @@ func (c *RootCLI) runHookDurably(
 	run func(io.Reader) error,
 ) error {
 	return runHookBestEffort(name, func() error {
+		startedAt := time.Now()
 		payload, err := readHookPayload(input)
 		if err != nil {
 			return err
@@ -122,11 +159,16 @@ func (c *RootCLI) runHookDurably(
 		}
 		// The current delivery is committed and its spool record is cleared
 		// before backlog work can consume the remaining host timeout. Replay is
-		// opportunistic: failures remain durable and never change current
-		// delivery success.
+		// opportunistic and budget-capped: failures remain durable and never
+		// change current delivery success. Drain is skipped entirely when the
+		// remaining budget is inside the reserve window so host watchdogs do
+		// not kill an already-successful hook.
 		if ctx.Err() == nil {
-			if replayed, failed := c.drainHookSpoolRecords(ctx, hookSpoolReplayBatchLimit); replayed > 0 || failed > 0 {
-				slog.Debug("hook spool drain", "replayed", replayed, "failed", failed)
+			limit := hookSpoolDrainAllowance(hookSpoolDrainRemaining(ctx, startedAt, time.Now()))
+			if limit > 0 {
+				if replayed, failed := c.drainHookSpoolRecords(ctx, limit); replayed > 0 || failed > 0 {
+					slog.Debug("hook spool drain", "replayed", replayed, "failed", failed, "limit", limit)
+				}
 			}
 		}
 		return nil

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -203,6 +203,154 @@ func TestRunHookDurably_RetainsSpoolAfterFailure(t *testing.T) {
 	}
 }
 
+func TestHookSpoolDrainAllowance(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		remaining time.Duration
+		want      int
+	}{
+		{name: "1.5s in reserve", remaining: 1500 * time.Millisecond, want: 0},
+		{name: "exactly drainReserve", remaining: hookSpoolDrainReserve, want: 0},
+		{name: "3s low headroom", remaining: 3 * time.Second, want: 1},
+		{name: "just under 4s", remaining: 4*time.Second - time.Nanosecond, want: 1},
+		{name: "exactly 4s full batch", remaining: 4 * time.Second, want: hookSpoolReplayBatchLimit},
+		{name: "8s full batch", remaining: 8 * time.Second, want: hookSpoolReplayBatchLimit},
+		{name: "zero remaining", remaining: 0, want: 0},
+		{name: "negative remaining", remaining: -time.Second, want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hookSpoolDrainAllowance(tc.remaining); got != tc.want {
+				t.Fatalf("hookSpoolDrainAllowance(%v) = %d, want %d", tc.remaining, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHookSpoolDrainRemaining_NoDeadlineUsesPackagedBudget(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	// startedAt 9s ago → remaining 1s → allowance 0
+	startedAt := now.Add(-9 * time.Second)
+	remaining := hookSpoolDrainRemaining(context.Background(), startedAt, now)
+	if remaining != time.Second {
+		t.Fatalf("remaining = %v, want 1s", remaining)
+	}
+	if got := hookSpoolDrainAllowance(remaining); got != 0 {
+		t.Fatalf("allowance for startedAt 9s ago = %d, want 0", got)
+	}
+}
+
+func TestHookSpoolDrainRemaining_PrefersContextDeadline(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	deadline := now.Add(1500 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	// startedAt is fresh, but ctx only has 1.5s left → reserve window.
+	remaining := hookSpoolDrainRemaining(ctx, now, now)
+	if remaining != 1500*time.Millisecond {
+		t.Fatalf("remaining = %v, want 1.5s", remaining)
+	}
+	if got := hookSpoolDrainAllowance(remaining); got != 0 {
+		t.Fatalf("allowance = %d, want 0", got)
+	}
+}
+
+func TestRunHookDurably_SkipsDrainWhenDeadlineInReserve(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	eventStub := &spoolEventUsecaseStub{}
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+	backlog := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"backlog","session_id":"s-backlog","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	}
+	backlogPath, err := persistHookSpoolRecord(backlog)
+	if err != nil {
+		t.Fatalf("persist backlog: %v", err)
+	}
+
+	// Leave only reserve-window headroom so opportunistic drain must skip.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1500*time.Millisecond))
+	defer cancel()
+
+	if err := root.runHookDurably(
+		ctx,
+		"prompt",
+		hookInvocationSpec{Command: "prompt", Client: "claude"},
+		strings.NewReader(`{"prompt":"current"}`),
+		func(io.Reader) error { return nil },
+	); err != nil {
+		t.Fatalf("runHookDurably() error = %v (current delivery must still succeed)", err)
+	}
+	if eventStub.logCalls != 0 {
+		t.Fatalf("drain ran under reserve budget, logCalls=%d", eventStub.logCalls)
+	}
+	if _, err := os.Stat(backlogPath); err != nil {
+		t.Fatalf("backlog must remain untouched when drain skipped: %v", err)
+	}
+	records, unreadable, err := scanHookSpoolRecords(nil)
+	if err != nil {
+		t.Fatalf("scanHookSpoolRecords() error = %v", err)
+	}
+	if len(unreadable) != 0 || len(records) != 1 || records[0].Payload != backlog.Payload {
+		t.Fatalf("records=%#v unreadable=%#v, want only untouched backlog", records, unreadable)
+	}
+}
+
+func TestRunHookDurably_DrainsWhenBudgetAllows(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	eventStub := &spoolEventUsecaseStub{}
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+	backlog := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"backlog","session_id":"s-backlog","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	}
+	if _, err := persistHookSpoolRecord(backlog); err != nil {
+		t.Fatalf("persist backlog: %v", err)
+	}
+
+	// Explicit deadline well above low-headroom so a full batch is allowed.
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	if err := root.runHookDurably(
+		ctx,
+		"prompt",
+		hookInvocationSpec{Command: "prompt", Client: "claude"},
+		strings.NewReader(`{"prompt":"current"}`),
+		func(io.Reader) error { return nil },
+	); err != nil {
+		t.Fatalf("runHookDurably() error = %v", err)
+	}
+	if eventStub.logCalls != 1 {
+		t.Fatalf("logCalls=%d, want 1 (backlog replayed)", eventStub.logCalls)
+	}
+	records, unreadable, err := scanHookSpoolRecords(nil)
+	if err != nil {
+		t.Fatalf("scanHookSpoolRecords() error = %v", err)
+	}
+	if len(unreadable) != 0 || len(records) != 0 {
+		t.Fatalf("records=%#v unreadable=%#v, want empty after drain", records, unreadable)
+	}
+}
+
 func TestDrainHookSpoolRecords_ReplaysAndRemoves(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)


### PR DESCRIPTION
## Summary

Opportunistic hook spool drain after a successful current delivery is now budget-capped so it cannot consume the host hook timeout.

- Pure policy `hookSpoolDrainAllowance(remaining)`:
  - `remaining <= 2s` → 0 (drain reserve)
  - `remaining < 4s` → 1
  - otherwise → `hookSpoolReplayBatchLimit` (5)
- `runHookDurably` records `startedAt` and computes remaining from ctx deadline when set, otherwise `packagedHostBudget (10s) - elapsed`
- When allowance is 0, drain is skipped entirely (backlog untouched); current delivery still succeeds
- No special-case for Grok PreToolUse; same math for every durable hook
- Does not touch live store / live spool or change retry/dead-letter policy beyond passing a smaller limit

## Tests

```sh
go test ./presentation/cli -count=1
go tool golangci-lint run ./presentation/cli/...
```

## Related

Closes #1881

Does **not** close #1693 or #1876.