### PR TITLE
feat: inventory remaining CLI surface against the two pillars

### DIFF
--- a/.ai/spec/1692.md
+++ b/.ai/spec/1692.md
@@ -1,0 +1,84 @@
+# Issue 1692: final surface sweep against the two pillars
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — public CLI deprecation notice, documentation contract,
+and a shipped inventory that every later command addition must update.
+Not High: no store schema, no new command tree, no live-store walk, no
+v0.35 deletions of remaining #1870 groups.
+
+### Requirement summary
+
+- 目的: 残っている public / admin leaf を 記録 / 記憶 / keep-reason に
+  分類し、v0.35 で果たした削除を historical log に残し、根拠があるもの
+  だけ v0.36 の非推奨通知を出す。
+- 現状: Wave 1–4 の削除は historical log にある。`Currently deprecated`
+  は空。public / admin リストは `session run` や `store archive` などを
+  欠く。#1870 の 97→29 は予告なし削除を要求するが、残グループは v0.34
+  registry に無い。
+- 期待する振る舞い:
+  - 出荷 Cobra の可視 leaf がレジストリと 1:1
+  - `memory store remember` だけが stderr 1 行の `DEPRECATED` を出し、
+    置換は `traceary memory store propose`、削除予定は v0.36.0
+  - remember の stdout / exit は変わらない
+  - tail / timeline / handoff / hooks print / replay / memory admin は
+    通知しない（置換 flag が無い、または空 backing の証拠が無い）
+  - #1870 / #1693 / #1686 は閉じない。VERSION は触らない
+- 非対象: 残グループの削除、absorb flag の実装、`traceary attest`、
+  live store、tag / Homebrew。
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Visible leaf | public or admin action | 記録 / 記憶 / keep | Hidden hook は plumbing。usage 件数は理由にしない |
+| 記録 | capture / summarise / compress / evict | 残す | 置換 flag が無い absorb は通知しない |
+| 記憶 | consolidate / supply | 残す | inbox / store / admin / decay は backing がある |
+| Keep | どちらでもない | 残す + 理由 | 空 backing / 重複 / 柱なし、だけが削除根拠 |
+| Notice | one stderr line | remember のみ | 置換が既に動く。one-minor window |
+| Historical log | v0.35 removals | 読むだけ | この PR で削除はしない |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| 分類表 | `presentation/cli/pillar_inventory.go` | コマンドが増えたとき | domain / sqlite は知らない |
+| 通知の付け方 | 既存 `applyCommandDeprecation` | 文言契約 | 各 command の RunE を手で包まない |
+| help への注記 | `annotateDeprecationHelp` | `--help` は run しない | Cobra `Deprecated` は stdout に出すので使わない |
+| 公開リスト | `docs/cli-stability.md` (+ ja) | 可視 surface | 97→29 を達成したとは書かない |
+| 履歴 | 既存 Historical removal log | 果たした削除 | この PR で新しい Removed 行は足さない |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `pillarInventory` | apply + tests | 理由文 | keep は Reason 必須。notice は RemovalTarget |
+| `applyInventoryDeprecations` | `Command()` | path lookup | 無い path は no-op。test が 1:1 を守る |
+| `applyCommandDeprecation` | remember | RunE wrap | 既存 PreRun / required flag のあと |
+| `writeDeprecationNotice` | run | 1 行 stderr | stderr 失敗で本処理を変えない |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| 1:1 | shipped root | walk visible actions | レジストリと集合が一致 | unit |
+| keep 理由 | 各 keep 行 | 読む | Reason が空でない | unit |
+| remember 通知 | stub memory | `memory store remember` | stderr 1 行、stdout は事実の出力、exit 0 | behavior |
+| remember help | root | `--help` | Short が deprecated を言う。stderr に DEPRECATED 行は無い | behavior |
+| propose は黙る | stub | `memory store propose` | stderr に DEPRECATED が無い | behavior |
+| absorb しない | stub | tail / timeline / handoff / hooks print | 通知無し | behavior |
+| 既に削除 | root | `top` / `mcp-server` / `store gc` | unknown。この PR では触らない | existing |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| 1:1 walk | 空テーブル | 可視 leaf を全部載せる | 理由文だけ直す |
+| remember notice | テストだけ | apply で remember に付ける | help 注記を同じ apply に寄せる |
+
+### Risks / rollback
+
+- 手続き化リスク: 分類をコメントや Issue だけに置くと次のコマンド追加で壊れる。出荷テーブル + walk test にする。
+- premature abstraction: absorb 予定の flag を先に作らない。
+- migration / compatibility: remember は v0.36 まで動く。#1870 をこの PR で閉じると 97→29 が終わったように見える。
+- rollback trigger: 通知を外すなら `RemovalTarget` を消し、docs の Currently deprecated を空に戻す。

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -24,6 +24,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 - **`traceary search --json` は events/sessions オブジェクトになりました (#1775)** — v0.34.0 の #1717 予告を完了します。stdout は常に `{"events": [...], "sessions": [...]}` で、どちらのキーも存在します（ヒットがない tier は空配列）。明示的な `--fields` はこれまでどおり `.events` 内の event フィールドを選び、session オブジェクトは `session_id` / `summary` / `event_count` / `started_at` のままです。v0.34 の「sessions が `--json` から省略された」stderr 通知は削除しました。テキスト検索出力は変更していません。
 - **v0.34 の置き換え先なし非推奨を削除 (#1691)** — `traceary memory admin graph add` / `graph list`、`traceary session label`、`traceary session list --label`、`session list` テキストの `LABEL` 列、`session list` JSON の `label` フィールドを削除しました。呼び出しは unknown command/flag として非ゼロ終了し、`DEPRECATED` 通知は出しません。`memory_edges` テーブルと `sessions.label` 列は gc / bundle / schema 互換のためストアに残しています。
 
+### Deprecated
+- **`traceary memory store remember` は v0.35.0 で非推奨、v0.36.0 で削除 (#1692)** — `traceary memory store propose` を使ってください。`remember` は即座に `status=accepted` で書き inbox review を迂回します。skill が使う書き込みは `propose`（`status=candidate`）です。stdout / `--json` / `--id-only` はこの期間中変わりません。残りの可視 public / admin 面は `presentation/cli/pillar_inventory.go` で分類して残します。#1870 の残グループは v0.34 registry に無いので削除しません。
+
 ## [v0.34.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 - **`traceary search --json` is now the events/sessions object (#1775)** — completes the v0.34.0 announcement from #1717. stdout is always `{"events": [...], "sessions": [...]}` with both keys present (empty arrays when a tier has no hits). Explicit `--fields` still selects event fields inside `.events`; session objects keep `session_id`, `summary`, `event_count`, and `started_at`. The v0.34 stderr notice that sessions were omitted from `--json` is removed. Text search output is unchanged.
 - **Removed the v0.34 no-replacement deprecations (#1691)** — `traceary memory admin graph add` / `graph list`, `traceary session label`, `traceary session list --label`, the `LABEL` column in `session list` text output, and the `label` field in `session list` JSON output are gone. Invocations fail as unknown commands/flags with a non-zero exit and no `DEPRECATED` notice. The `memory_edges` table and `sessions.label` column remain in the store for gc, bundle, and schema compatibility.
 
+### Deprecated
+- **`traceary memory store remember` is deprecated in v0.35.0 and removed in v0.36.0 (#1692)** — use `traceary memory store propose`. `remember` writes `status=accepted` immediately and bypasses inbox review; the skill-facing write is `propose` (`status=candidate`). stdout / `--json` / `--id-only` stay unchanged during the window. The rest of the visible public/admin surface is classified in `presentation/cli/pillar_inventory.go` and stays; remaining #1870 groups were never in the v0.34 registry.
+
 ## [v0.34.0] - 2026-08-12
 
 ### Added

--- a/docs/cli-stability.ja.md
+++ b/docs/cli-stability.ja.md
@@ -31,16 +31,17 @@ Traceary の各サブコマンドは必ず以下のいずれか 1 ティアに�
 
 公開サーフェスは運用者の日常用途サーフェスです。コマンドパス・フラグ名・stdout テキスト形状・`--json` / `--id-only` / NDJSON のバイト形状をマイナーリリースを跨いで安定に保ちます。
 
-v0.15 以降に追加された互換 alias も含む現在の公開コマンド（用途別）：
+v0.15 以降に追加された互換 alias も含む現在の公開コマンド（用途別）。可視の public / admin leaf の出荷分類は `presentation/cli/pillar_inventory.go`（#1692）です。
 
 - **イベント記録** — `traceary log`、`traceary audit`
 - **読み取り / 観察** — `traceary list`、`traceary search`、`traceary tail`、`traceary timeline`、`traceary show`、`traceary context`、`traceary sessions`（および `traceary sessions --snapshot` / `--snapshot --json`）
-- **セッション** — `traceary session start`、`traceary session end`、`traceary session handoff`（`--compact-only` を含む）、`traceary session list`、`traceary session refine`、`traceary session latest`、`traceary session active`
+- **セッション** — `traceary session start`、`traceary session end`、`traceary session run`、`traceary session handoff`（`--compact-only` を含む）、`traceary session list`、`traceary session refine`、`traceary session latest`、`traceary session active`
 - **durable memory 日常 read** — `traceary memory list`、`traceary memory search`、`traceary memory show`
-- **durable memory inbox** — `traceary memory inbox list`、`traceary memory inbox accept`、`traceary memory inbox reject`、`traceary memory inbox review`（TTY のみ）
-- **durable memory store** — `traceary memory store remember`、`traceary memory store propose`、`traceary memory store distill`
-- **hooks** — `traceary hooks print`、`traceary hooks install`、`traceary hooks guide`、`traceary completion`
-- **診断** — `traceary doctor`（alias `traceary status`）
+- **durable memory inbox** — `traceary memory inbox list`、`traceary memory inbox show`、`traceary memory inbox accept`、`traceary memory inbox reject`、`traceary memory inbox attach`、`traceary memory inbox cleanup`、`traceary memory inbox restore`、`traceary memory inbox review`（TTY のみ）
+- **durable memory store** — `traceary memory store remember`（非推奨、削除予定 v0.36.0）、`traceary memory store propose`、`traceary memory store distill`
+- **durable memory decay** — `traceary memory decay`
+- **hooks** — `traceary hooks print`、`traceary hooks install`、`traceary hooks guide`、`traceary completion`（`bash` / `zsh` / `fish` / `powershell`）
+- **診断** — `traceary doctor`（alias `traceary status`）、`traceary report`
 - **replay / archive** — `traceary replay`
 - **bundle import / export** — `traceary bundle export`、`traceary bundle import`
 
@@ -56,11 +57,12 @@ v0.15 以降に追加された互換 alias も含む現在の公開コマンド�
 
 admin コマンドは運用者向けのメンテサーフェスです。`--help` には引き続き掲載され CLI リファレンスでも文書化されますが、日常 read 経路ではありません。対象が運用者だけのときは公開コマンドより速いペースで進化してよいですが、後述の非推奨通知ルールには従います。
 
-v0.15 の admin コマンド：
+v0.35 時点の admin コマンド：
 
-- **ストア管理** — `traceary store init`、`traceary store backup create`、`traceary store backup restore`、`traceary store compact`
-- **セッション管理** — `traceary session gc`（stale なセッションを終了する。`session` 名前空間配下に公開セッションサブコマンドと同じ位置で登録されているが、扱いとしては admin ティアのメンテナンス入口）
+- **ストア管理** — `traceary store init`、`traceary store backup create`、`traceary store backup restore`、`traceary store compact`、`traceary store compact rollback`、`traceary store archive create`、`traceary store archive restore`、`traceary store archive verify`、`traceary store capacity`、`traceary store retention files plan`、`traceary store retention files apply`、`traceary store search-projection start`、`traceary store search-projection resume`、`traceary store search-projection status`、`traceary store search-projection abort`、`traceary store search-projection probe`、`traceary store workspace-alias add`、`traceary store workspace-alias list`、`traceary store workspace-alias remove`
+- **セッション管理** — `traceary session gc`（stale なセッションを終了する。`session` 名前空間配下に公開セッションサブコマンドと同じ位置で登録されているが、扱いとしては admin ティアのメンテナンス入口）、`traceary session repair-one-shot`
 - **durable memory admin** — `traceary memory admin extract`、`traceary memory admin import codex`、`traceary memory admin import instructions`、`traceary memory admin export`、`traceary memory admin activate`、`traceary memory admin hygiene scan`、`traceary memory admin hygiene apply`、`traceary memory admin supersede`、`traceary memory admin expire`、`traceary memory admin set-validity`
+- **レポート管理** — `traceary report workspace-identity`
 
 ### plumbing / hidden / deprecated コマンド (v0.15)
 
@@ -83,7 +85,13 @@ v0.15 の admin コマンド：
 
 現在非推奨：
 
-- _（なし）_
+- `traceary memory store remember` → `traceary memory store propose`（削除予定 v0.36.0。#1692 / #1870 の owner 決定）。`remember` は即座に `status=accepted` で書き、inbox review を迂回します。`traceary-memory-remember` は `status=candidate` で着地する必要があります。コマンド自体は動き、stdout / `--json` / `--id-only` はこの期間中変わりません。
+
+### 柱ごとの棚卸し（v0.35）
+
+#1692 は可視の public / admin leaf を 2 本の柱（記録 = 捕捉 / 要約 / 圧縮 / 破棄、記憶 = 統合して自動供給）に突き合わせました。hidden な hook 入口は plumbing のままです（後述）。出荷テーブルは `presentation/cli/pillar_inventory.go` で、可視 action を行なしで追加するとテストが失敗します。
+
+削除根拠は空の backing、重複、柱なしだけです。usage 件数は理由にしません。#1870 の 97→29 keep-list に残っているグループは v0.34 の非推奨 registry に無いので、v0.35 では削除しません。予定している吸収（`list --follow`、`list --blocks`、`hooks install --dry-run`、`memory search --all`）は、その flag ができるまで通知しません。`sessions --snapshot` は v0.34 で既に予告済みなので残します。`replay` は単一ファイル HTML export だけで、#1870 も usage を弱い削除根拠だと書いています。
 
 過去の削除履歴：
 

--- a/docs/cli-stability.md
+++ b/docs/cli-stability.md
@@ -31,16 +31,17 @@ The tier sets the rules for what may change, when it may change, and what notice
 
 The public surface is the operator-facing daily-use surface. Public commands keep their command path, flag names, stdout text shape, and `--json` / `--id-only` / NDJSON byte shape stable across minor releases.
 
-Current public commands, including compatibility aliases introduced after v0.15, are grouped by intent:
+Current public commands, including compatibility aliases introduced after v0.15, are grouped by intent. The shipped classification of every visible public/admin leaf is `presentation/cli/pillar_inventory.go` (#1692).
 
 - **Event recording** — `traceary log`, `traceary audit`
 - **Read / inspection** — `traceary list`, `traceary search`, `traceary tail`, `traceary timeline`, `traceary show`, `traceary context`, `traceary sessions` (and `traceary sessions --snapshot` / `--snapshot --json`)
-- **Sessions** — `traceary session start`, `traceary session end`, `traceary session handoff` (including `--compact-only`), `traceary session list`, `traceary session refine`, `traceary session latest`, `traceary session active`
+- **Sessions** — `traceary session start`, `traceary session end`, `traceary session run`, `traceary session handoff` (including `--compact-only`), `traceary session list`, `traceary session refine`, `traceary session latest`, `traceary session active`
 - **Durable memory daily read** — `traceary memory list`, `traceary memory search`, `traceary memory show`
-- **Durable memory inbox** — `traceary memory inbox list`, `traceary memory inbox accept`, `traceary memory inbox reject`, `traceary memory inbox review` (TTY-only)
-- **Durable memory store** — `traceary memory store remember`, `traceary memory store propose`, `traceary memory store distill`
-- **Hooks** — `traceary hooks print`, `traceary hooks install`, `traceary hooks guide`, `traceary completion`
-- **Diagnostics** — `traceary doctor` (alias `traceary status`)
+- **Durable memory inbox** — `traceary memory inbox list`, `traceary memory inbox show`, `traceary memory inbox accept`, `traceary memory inbox reject`, `traceary memory inbox attach`, `traceary memory inbox cleanup`, `traceary memory inbox restore`, `traceary memory inbox review` (TTY-only)
+- **Durable memory store** — `traceary memory store remember` (deprecated; removal target v0.36.0), `traceary memory store propose`, `traceary memory store distill`
+- **Durable memory decay** — `traceary memory decay`
+- **Hooks** — `traceary hooks print`, `traceary hooks install`, `traceary hooks guide`, `traceary completion` (`bash` / `zsh` / `fish` / `powershell`)
+- **Diagnostics** — `traceary doctor` (alias `traceary status`), `traceary report`
 - **Replay / archive** — `traceary replay`
 - **Bundle import / export** — `traceary bundle export`, `traceary bundle import`
 
@@ -56,11 +57,12 @@ The v0.19.0 text snapshot for `traceary sessions --snapshot` intentionally inser
 
 Admin commands are operator-facing maintenance surfaces. They are still listed in `--help` and documented in the CLI reference, but they are not part of the daily read path. Admin commands may evolve faster than public commands when the affected audience is operators only, but they still follow the deprecation notice expectations below.
 
-Admin commands in v0.15:
+Admin commands as of v0.35:
 
-- **Store administration** — `traceary store init`, `traceary store backup create`, `traceary store backup restore`, `traceary store compact`
-- **Session administration** — `traceary session gc` (closes stale sessions; visible under the `session` namespace and registered alongside the public session subcommands, but treated as an admin-tier maintenance entrypoint)
+- **Store administration** — `traceary store init`, `traceary store backup create`, `traceary store backup restore`, `traceary store compact`, `traceary store compact rollback`, `traceary store archive create`, `traceary store archive restore`, `traceary store archive verify`, `traceary store capacity`, `traceary store retention files plan`, `traceary store retention files apply`, `traceary store search-projection start`, `traceary store search-projection resume`, `traceary store search-projection status`, `traceary store search-projection abort`, `traceary store search-projection probe`, `traceary store workspace-alias add`, `traceary store workspace-alias list`, `traceary store workspace-alias remove`
+- **Session administration** — `traceary session gc` (closes stale sessions; visible under the `session` namespace and registered alongside the public session subcommands, but treated as an admin-tier maintenance entrypoint), `traceary session repair-one-shot`
 - **Durable memory admin** — `traceary memory admin extract`, `traceary memory admin import codex`, `traceary memory admin import instructions`, `traceary memory admin export`, `traceary memory admin activate`, `traceary memory admin hygiene scan`, `traceary memory admin hygiene apply`, `traceary memory admin supersede`, `traceary memory admin expire`, `traceary memory admin set-validity`
+- **Report administration** — `traceary report workspace-identity`
 
 ### Plumbing / hidden / deprecated commands (v0.15)
 
@@ -83,7 +85,13 @@ Stability and deprecation expectations for these runtime entrypoints:
 
 Currently deprecated:
 
-- _(none)_
+- `traceary memory store remember` → `traceary memory store propose` (removal target v0.36.0; #1692 / owner decision on #1870). `remember` writes `status=accepted` immediately and bypasses inbox review. `traceary-memory-remember` must land as `status=candidate`. The command still runs; stdout / `--json` / `--id-only` stay unchanged during the window.
+
+### Pillar inventory (v0.35)
+
+#1692 walked every visible public/admin leaf against the two pillars (記録 = capture / summarise / compress / evict; 記憶 = consolidate and supply automatically). Hidden hook entrypoints stay plumbing (see below). The shipped table is `presentation/cli/pillar_inventory.go`; a test fails if a visible action is added without a row.
+
+A command is removed only for empty backing data, duplication, or serving no pillar. Usage counts are not grounds. Remaining groups from the #1870 97→29 keep-list were never in the v0.34 deprecation registry, so v0.35 does not delete them. Planned absorbs (`list --follow`, `list --blocks`, `hooks install --dry-run`, `memory search --all`) are not noticed until those flags exist. `sessions --snapshot` stays because the v0.34 announcement already published it. `replay` stays: it is the only single-file HTML export, and #1870 called usage a weak removal basis.
 
 Historical removal log:
 

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -415,7 +415,7 @@ durable memory を一覧表示します。scope flag を明示しない場合は
 
 #### `traceary memory store remember`
 
-accepted な durable memory を直接記録します。
+**v0.35.0 で非推奨、削除予定は v0.36.0。** `traceary memory store propose` を使ってください。このコマンドは引き続き accepted な durable memory を直接記録します（stdout / `--json` / `--id-only` は変更なし）。inbox review を迂回します。skill が使う書き込みは `propose` です。
 
 主な flag:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -415,7 +415,7 @@ Every command under `memory store` writes a durable-memory row, regardless of wh
 
 #### `traceary memory store remember`
 
-Record an accepted durable memory directly.
+**Deprecated in v0.35.0; removal target v0.36.0.** Use `traceary memory store propose`. This command still records an accepted durable memory directly (stdout / `--json` / `--id-only` unchanged). It bypasses inbox review; the skill-facing write is `propose`.
 
 Useful flags:
 

--- a/docs/operations/memory-command-surface.ja.md
+++ b/docs/operations/memory-command-surface.ja.md
@@ -6,6 +6,8 @@
 
 この文書は v0.14 で進めた「memory コマンド面のスリム化」のベースラインです。v0.15.0 時点で、以下に出てくる hidden deprecated alias は削除済みです。このページは旧 flat path から canonical grouped path への歴史的な対応表として残します。
 
+v0.35.0 (#1692): `memory store remember` は `memory store propose` に向けて非推奨です（削除予定 v0.36.0）。以下の v0.14 グルーピングはそれ以外は変更しません。
+
 ## 目的
 
 - `memory` コマンドを「日常 read」「inbox レビュー」「durable 書き込み」「admin / host 連携」の 4 グループに整理する。

--- a/docs/operations/memory-command-surface.md
+++ b/docs/operations/memory-command-surface.md
@@ -6,6 +6,8 @@
 
 This document is the v0.14 baseline that the memory namespace migration was built on. As of v0.15.0 the hidden deprecated aliases described below have been removed; keep this page as the historical mapping from the old flat paths to the canonical grouped paths.
 
+v0.35.0 (#1692): `memory store remember` is deprecated in favor of `memory store propose` (removal target v0.36.0). The v0.14 grouping below is otherwise unchanged.
+
 ## Goals
 
 - Group memory commands by intent: daily read, inbox curation, durable write, and admin/host-side operations.

--- a/presentation/cli/deprecation.go
+++ b/presentation/cli/deprecation.go
@@ -16,6 +16,7 @@ const noReplacement = ""
 // required flags between the two, so a PreRunE notice would fire for
 // invocations that never run. See the notice rules in docs/cli-stability.md.
 func applyCommandDeprecation(cmd *cobra.Command, replacement string, removalVersion string) {
+	annotateDeprecationHelp(cmd, replacement, removalVersion)
 	previous := cmd.RunE
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		writeDeprecationNotice(cmd, "this command", "このコマンド", replacement, removalVersion)
@@ -48,4 +49,28 @@ func writeDeprecationNotice(cmd *cobra.Command, subject string, japaneseSubject 
 	}
 	// The notice is advisory; a broken stderr writer must not change the command contract.
 	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), message)
+}
+
+// annotateDeprecationHelp puts the replacement and removal target on Short
+// (and Long when present). --help never reaches RunE, so the run-step notice
+// alone would leave help silent.
+func annotateDeprecationHelp(cmd *cobra.Command, replacement string, removalVersion string) {
+	suffix := Localize(
+		fmt.Sprintf("Deprecated with no replacement. Removal target: %s.", removalVersion),
+		fmt.Sprintf("非推奨です。置き換え先はありません。削除予定: %s。", removalVersion),
+	)
+	if replacement != noReplacement {
+		suffix = Localize(
+			fmt.Sprintf("Deprecated; use `%s`. Removal target: %s.", replacement, removalVersion),
+			fmt.Sprintf("非推奨です。代わりに `%s` を使用してください。削除予定: %s。", replacement, removalVersion),
+		)
+	}
+	if cmd.Short == "" {
+		cmd.Short = suffix
+	} else {
+		cmd.Short = cmd.Short + " (" + suffix + ")"
+	}
+	if cmd.Long != "" {
+		cmd.Long = cmd.Long + "\n\n" + suffix
+	}
 }

--- a/presentation/cli/deprecation_test.go
+++ b/presentation/cli/deprecation_test.go
@@ -62,6 +62,9 @@ func TestApplyCommandDeprecation(t *testing.T) {
 			if diff := cmp.Diff(1, strings.Count(stderr.String(), "\n")); diff != "" {
 				t.Errorf("notice line count mismatch (-want +got):\n%s", diff)
 			}
+			if !strings.Contains(cmd.Short, "Deprecated") && !strings.Contains(cmd.Short, "非推奨") {
+				t.Errorf("Short %q does not name the deprecation", cmd.Short)
+			}
 		})
 	}
 }
@@ -100,5 +103,3 @@ func TestWriteDeprecationNoticeWithoutReplacement(t *testing.T) {
 		})
 	}
 }
-
-

--- a/presentation/cli/memory_namespace_test.go
+++ b/presentation/cli/memory_namespace_test.go
@@ -157,7 +157,10 @@ func TestRootCLI_MemoryGroupedCanonicalPaths_ExecuteSameUseCase(t *testing.T) {
 			tc.assertCall(t, stub)
 
 			if strings.Contains(stderr.String(), "DEPRECATED") {
-				t.Errorf("canonical grouped path emitted deprecation notice: %q", stderr.String())
+				rememberPath := len(tc.args) >= 3 && tc.args[0] == "memory" && tc.args[1] == "store" && tc.args[2] == "remember"
+				if !rememberPath {
+					t.Errorf("canonical grouped path emitted deprecation notice: %q", stderr.String())
+				}
 			}
 			if strings.Contains(stderr.String(), "removed in v0.15.0") {
 				t.Errorf("canonical grouped path emitted removal notice: %q", stderr.String())

--- a/presentation/cli/pillar_inventory.go
+++ b/presentation/cli/pillar_inventory.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// pillarKind is which of the two product pillars a visible command serves.
+// keep is the explicit third state: neither pillar, with a written reason.
+type pillarKind string
+
+const (
+	pillarRecord pillarKind = "record"
+	pillarMemory pillarKind = "memory"
+	pillarKeep   pillarKind = "keep"
+)
+
+const rememberRemovalTarget = "v0.36.0"
+
+// pillarInventoryEntry is one visible public or admin operator action.
+// Hidden hook plumbing is not listed. RemovalTarget is empty unless this
+// sweep publishes a one-minor notice.
+type pillarInventoryEntry struct {
+	Path          string
+	Pillar        pillarKind
+	Reason        string
+	RemovalTarget string
+	Replacement   string
+}
+
+// pillarInventory is the v0.35 surface sweep (#1692). Every surviving
+// visible leaf maps to 記録 (record), 記憶 (memory), or a keep-reason.
+// Usage counts are not grounds. The only notice is remember → propose.
+var pillarInventory = []pillarInventoryEntry{
+	{Path: "audit", Pillar: pillarRecord, Reason: "persist command-audit records"},
+	{Path: "log", Pillar: pillarRecord, Reason: "persist a manual event"},
+	{Path: "list", Pillar: pillarRecord, Reason: "read recorded events; list --follow does not exist so tail is not a duplicate"},
+	{Path: "search", Pillar: pillarRecord, Reason: "search recorded events and session summaries"},
+	{Path: "tail", Pillar: pillarRecord, Reason: "stream recorded events; no absorb flag on list"},
+	{Path: "timeline", Pillar: pillarRecord, Reason: "workspace timeline of recorded work; list --blocks does not exist"},
+	{Path: "show", Pillar: pillarRecord, Reason: "show one recorded event"},
+	{Path: "context", Pillar: pillarRecord, Reason: "assemble recorded context for a session"},
+	{Path: "sessions", Pillar: pillarRecord, Reason: "sessions snapshot; v0.34 already published --snapshot as the surviving view, so the #1870 keep-list omission does not win"},
+	{Path: "session start", Pillar: pillarRecord, Reason: "open a recorded session"},
+	{Path: "session end", Pillar: pillarRecord, Reason: "close a recorded session"},
+	{Path: "session run", Pillar: pillarRecord, Reason: "run a bounded recorded session"},
+	{Path: "session refine", Pillar: pillarRecord, Reason: "store the L2 summary that makes transcript bodies discardable"},
+	{Path: "session handoff", Pillar: pillarRecord, Reason: "structured session summary for the next session; context does not absorb it"},
+	{Path: "session list", Pillar: pillarRecord, Reason: "list recorded sessions"},
+	{Path: "session latest", Pillar: pillarRecord, Reason: "resolve the most recent recorded session"},
+	{Path: "session active", Pillar: pillarRecord, Reason: "resolve the currently active recorded session"},
+	{Path: "session gc", Pillar: pillarRecord, Reason: "close stale sessions (evict)"},
+	{Path: "session repair-one-shot", Pillar: pillarRecord, Reason: "repair one-shot classification of recorded sessions"},
+	{Path: "hooks install", Pillar: pillarRecord, Reason: "enable automatic capture"},
+	{Path: "hooks print", Pillar: pillarRecord, Reason: "preview hook scripts without writing; hooks install --dry-run does not exist"},
+	{Path: "hooks guide", Pillar: pillarKeep, Reason: "operator documentation for hook setup; not itself capture or memory"},
+	{Path: "replay", Pillar: pillarKeep, Reason: "only single-file HTML export of recorded sessions; #1870 called usage a weak removal basis and there is no replacement"},
+	{Path: "report", Pillar: pillarRecord, Reason: "period digest of recorded work"},
+	{Path: "report workspace-identity", Pillar: pillarKeep, Reason: "workspace-attribution diagnostics; doctor does not absorb this report"},
+	{Path: "bundle export", Pillar: pillarKeep, Reason: "export the store (both pillars' data) for transfer"},
+	{Path: "bundle import", Pillar: pillarKeep, Reason: "import a transferred store"},
+	{Path: "completion", Pillar: pillarKeep, Reason: "shell-completion parent; not a product pillar"},
+	{Path: "completion bash", Pillar: pillarKeep, Reason: "Bash completion generator"},
+	{Path: "completion fish", Pillar: pillarKeep, Reason: "Fish completion generator"},
+	{Path: "completion powershell", Pillar: pillarKeep, Reason: "PowerShell completion generator"},
+	{Path: "completion zsh", Pillar: pillarKeep, Reason: "Zsh completion generator"},
+	{Path: "doctor", Pillar: pillarKeep, Reason: "install and store health (alias status); prerequisite, not a pillar"},
+	{Path: "memory list", Pillar: pillarMemory, Reason: "list durable memories; search --all does not exist"},
+	{Path: "memory search", Pillar: pillarMemory, Reason: "search durable memories"},
+	{Path: "memory show", Pillar: pillarMemory, Reason: "show one durable memory"},
+	{Path: "memory inbox list", Pillar: pillarMemory, Reason: "list memory candidates awaiting review"},
+	{Path: "memory inbox show", Pillar: pillarMemory, Reason: "evidence-first card for one candidate"},
+	{Path: "memory inbox accept", Pillar: pillarMemory, Reason: "accept a reviewed candidate"},
+	{Path: "memory inbox reject", Pillar: pillarMemory, Reason: "reject a reviewed candidate"},
+	{Path: "memory inbox attach", Pillar: pillarMemory, Reason: "attach evidence or artifact refs to a candidate"},
+	{Path: "memory inbox cleanup", Pillar: pillarMemory, Reason: "bulk-reject stale or low-quality candidates; not the same transition as decay"},
+	{Path: "memory inbox restore", Pillar: pillarMemory, Reason: "restore expired memories to candidates"},
+	{Path: "memory inbox review", Pillar: pillarMemory, Reason: "TTY review of the memory review queue"},
+	{Path: "memory store propose", Pillar: pillarMemory, Reason: "write a candidate; the skill-facing remember path"},
+	{
+		Path:          "memory store remember",
+		Pillar:        pillarMemory,
+		Reason:        "duplicate write that accepts immediately and bypasses inbox review; traceary-memory-remember must land as status=candidate",
+		RemovalTarget: rememberRemovalTarget,
+		Replacement:   "traceary memory store propose",
+	},
+	{Path: "memory store distill", Pillar: pillarMemory, Reason: "operator-authored accepted fact from existing candidates"},
+	{Path: "memory decay", Pillar: pillarMemory, Reason: "expire stale auto-extracted candidates; distinct from inbox cleanup reject"},
+	{Path: "memory admin extract", Pillar: pillarMemory, Reason: "extract candidates from a recorded session"},
+	{Path: "memory admin import codex", Pillar: pillarMemory, Reason: "import host Codex memories as candidates"},
+	{Path: "memory admin import instructions", Pillar: pillarMemory, Reason: "import host instruction bullets as candidates"},
+	{Path: "memory admin export", Pillar: pillarMemory, Reason: "export accepted memories to a host instruction file"},
+	{Path: "memory admin activate", Pillar: pillarMemory, Reason: "plan host-native memory activation"},
+	{Path: "memory admin hygiene scan", Pillar: pillarMemory, Reason: "scan memories for hygiene issues"},
+	{Path: "memory admin hygiene apply", Pillar: pillarMemory, Reason: "apply hygiene suggestions by id"},
+	{Path: "memory admin supersede", Pillar: pillarMemory, Reason: "replace an accepted memory"},
+	{Path: "memory admin expire", Pillar: pillarMemory, Reason: "expire an accepted memory"},
+	{Path: "memory admin set-validity", Pillar: pillarMemory, Reason: "set a memory validity window"},
+	{Path: "store init", Pillar: pillarKeep, Reason: "create the SQLite store; prerequisite"},
+	{Path: "store backup create", Pillar: pillarKeep, Reason: "operator safety copy"},
+	{Path: "store backup restore", Pillar: pillarKeep, Reason: "restore a safety copy"},
+	{Path: "store archive create", Pillar: pillarKeep, Reason: "offsite archive of the store; not folded into compact"},
+	{Path: "store archive restore", Pillar: pillarKeep, Reason: "restore an archive"},
+	{Path: "store archive verify", Pillar: pillarKeep, Reason: "verify an archive"},
+	{Path: "store capacity", Pillar: pillarKeep, Reason: "metadata-only growth diagnostics; doctor does not absorb it"},
+	{Path: "store compact", Pillar: pillarRecord, Reason: "compress, drop retired index, discard covered bodies, vacuum"},
+	{Path: "store compact rollback", Pillar: pillarRecord, Reason: "restore the pre-compact inode"},
+	{Path: "store retention files plan", Pillar: pillarKeep, Reason: "plan filesystem retention of backup/archive files; distinct from body retention folded into compact"},
+	{Path: "store retention files apply", Pillar: pillarKeep, Reason: "apply filesystem file retention"},
+	{Path: "store search-projection start", Pillar: pillarRecord, Reason: "build the search index over recorded events"},
+	{Path: "store search-projection resume", Pillar: pillarRecord, Reason: "resume a search-projection generation"},
+	{Path: "store search-projection status", Pillar: pillarRecord, Reason: "inspect search-projection progress"},
+	{Path: "store search-projection abort", Pillar: pillarRecord, Reason: "park a search-projection generation"},
+	{Path: "store search-projection probe", Pillar: pillarRecord, Reason: "probe search-projection capacity without starting a generation"},
+	{Path: "store workspace-alias add", Pillar: pillarKeep, Reason: "live alias mechanism; Wave 4 of #1693 found 147 distinct conflict pairs, not empty backing"},
+	{Path: "store workspace-alias list", Pillar: pillarKeep, Reason: "list workspace aliases"},
+	{Path: "store workspace-alias remove", Pillar: pillarKeep, Reason: "remove a workspace alias"},
+}
+
+func applyInventoryDeprecations(root *cobra.Command) {
+	for _, entry := range pillarInventory {
+		if entry.RemovalTarget == "" {
+			continue
+		}
+		cmd := lookupCommandPath(root, entry.Path)
+		if cmd == nil {
+			continue
+		}
+		applyCommandDeprecation(cmd, entry.Replacement, entry.RemovalTarget)
+	}
+}
+
+func lookupCommandPath(root *cobra.Command, path string) *cobra.Command {
+	current := root
+	for _, part := range strings.Fields(path) {
+		var next *cobra.Command
+		for _, child := range current.Commands() {
+			if child.Name() == part {
+				next = child
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		current = next
+	}
+	if current == root {
+		return nil
+	}
+	return current
+}

--- a/presentation/cli/pillar_inventory_internal_test.go
+++ b/presentation/cli/pillar_inventory_internal_test.go
@@ -78,7 +78,7 @@ func collectVisibleOperatorActions(cmd *cobra.Command, prefix string, out []stri
 		if prefix != "" {
 			path = prefix + " " + child.Name()
 		}
-		if child.Runnable() && child.Args != nil {
+		if isVisibleOperatorAction(child) {
 			out = append(out, path)
 		}
 		if len(child.Commands()) > 0 {
@@ -86,6 +86,46 @@ func collectVisibleOperatorActions(cmd *cobra.Command, prefix string, out []stri
 		}
 	}
 	return out
+}
+
+func isVisibleOperatorAction(cmd *cobra.Command) bool {
+	if cmd.Hidden || !cmd.Runnable() {
+		return false
+	}
+	if len(cmd.Commands()) == 0 {
+		// A childless runnable is an operator leaf even when Args is unset.
+		// Requiring Args would let a new RunE-only command skip the inventory.
+		return true
+	}
+	// Parents that are themselves actions (report, store compact, completion)
+	// set Args. applyStrictGroups gives other parents RunE with Args == nil.
+	return cmd.Args != nil
+}
+
+func TestCollectVisibleOperatorActionsIncludesChildlessRunnableWithoutArgs(t *testing.T) {
+	root := &cobra.Command{Use: "traceary"}
+	foo := &cobra.Command{
+		Use: "foo",
+		RunE: func(*cobra.Command, []string) error {
+			return nil
+		},
+	}
+	bar := &cobra.Command{Use: "bar"}
+	bar.AddCommand(&cobra.Command{
+		Use: "baz",
+		RunE: func(*cobra.Command, []string) error {
+			return nil
+		},
+		Args: cobra.NoArgs,
+	})
+	root.AddCommand(foo, bar)
+	applyStrictGroups(root)
+
+	got := collectVisibleOperatorActions(root, "", nil)
+	sort.Strings(got)
+	if diff := cmp.Diff([]string{"bar baz", "foo"}, got); diff != "" {
+		t.Errorf("visible actions mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestLookupCommandPathRejectsMissing(t *testing.T) {

--- a/presentation/cli/pillar_inventory_internal_test.go
+++ b/presentation/cli/pillar_inventory_internal_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/cobra"
+)
+
+func TestPillarInventoryMatchesShippedTree(t *testing.T) {
+	root := NewRootCLI().Command()
+	got := collectVisibleOperatorActions(root, "", nil)
+	sort.Strings(got)
+
+	want := make([]string, 0, len(pillarInventory))
+	seen := map[string]struct{}{}
+	for _, entry := range pillarInventory {
+		if entry.Path == "" {
+			t.Fatal("inventory entry has empty Path")
+		}
+		if _, dup := seen[entry.Path]; dup {
+			t.Fatalf("duplicate inventory path %q", entry.Path)
+		}
+		seen[entry.Path] = struct{}{}
+		want = append(want, entry.Path)
+		if entry.Reason == "" {
+			t.Errorf("%s: empty Reason", entry.Path)
+		}
+		switch entry.Pillar {
+		case pillarRecord, pillarMemory, pillarKeep:
+		default:
+			t.Errorf("%s: unknown pillar %q", entry.Path, entry.Pillar)
+		}
+		if entry.RemovalTarget == "" && entry.Replacement != "" {
+			t.Errorf("%s: Replacement without RemovalTarget", entry.Path)
+		}
+		if lookupCommandPath(root, entry.Path) == nil {
+			t.Errorf("%s: not found on shipped tree", entry.Path)
+		}
+	}
+	sort.Strings(want)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("visible operator actions vs inventory (-want +got):\n%s", diff)
+	}
+}
+
+func TestPillarInventoryOnlyRemembersHasNotice(t *testing.T) {
+	var noticed []string
+	for _, entry := range pillarInventory {
+		if entry.RemovalTarget == "" {
+			continue
+		}
+		noticed = append(noticed, entry.Path)
+		if entry.Path != "memory store remember" {
+			t.Errorf("unexpected notice on %s", entry.Path)
+		}
+		if entry.RemovalTarget != rememberRemovalTarget {
+			t.Errorf("remember RemovalTarget = %q, want %q", entry.RemovalTarget, rememberRemovalTarget)
+		}
+		if entry.Replacement != "traceary memory store propose" {
+			t.Errorf("remember Replacement = %q", entry.Replacement)
+		}
+	}
+	if diff := cmp.Diff([]string{"memory store remember"}, noticed); diff != "" {
+		t.Errorf("noticed paths mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func collectVisibleOperatorActions(cmd *cobra.Command, prefix string, out []string) []string {
+	children := append([]*cobra.Command(nil), cmd.Commands()...)
+	sort.Slice(children, func(i, j int) bool { return children[i].Name() < children[j].Name() })
+	for _, child := range children {
+		if child.Hidden {
+			continue
+		}
+		path := child.Name()
+		if prefix != "" {
+			path = prefix + " " + child.Name()
+		}
+		if child.Runnable() && child.Args != nil {
+			out = append(out, path)
+		}
+		if len(child.Commands()) > 0 {
+			out = collectVisibleOperatorActions(child, path, out)
+		}
+	}
+	return out
+}
+
+func TestLookupCommandPathRejectsMissing(t *testing.T) {
+	root := NewRootCLI().Command()
+	if got := lookupCommandPath(root, ""); got != nil {
+		t.Fatalf("empty path = %s, want nil", got.Name())
+	}
+	if got := lookupCommandPath(root, "memory store missing"); got != nil {
+		t.Fatalf("missing path = %s, want nil", got.Name())
+	}
+	if got := lookupCommandPath(root, "memory store remember"); got == nil || got.Name() != "remember" {
+		t.Fatalf("remember lookup = %v", got)
+	}
+}

--- a/presentation/cli/pillar_inventory_test.go
+++ b/presentation/cli/pillar_inventory_test.go
@@ -1,0 +1,101 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/presentation/cli"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRootCLI_MemoryStoreRememberEmitsV036Notice(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	stub := &memoryUsecaseStub{
+		rememberDetails: mustMemoryDetails(t, "memory-remembered", "Remember release discipline", types.MemoryStatusAccepted),
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{
+		"memory", "store", "remember",
+		"--db-path", "/tmp/test-traceary.db",
+		"--type", "decision",
+		"--fact", "Remember release discipline",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	wantNotice := "DEPRECATED: this command is deprecated, use `traceary memory store propose` instead. Removal target: v0.36.0.\n"
+	if diff := cmp.Diff(wantNotice, stderr.String()); diff != "" {
+		t.Errorf("stderr notice mismatch (-want +got):\n%s", diff)
+	}
+	if !strings.Contains(stdout.String(), "Remember release discipline") {
+		t.Errorf("stdout = %q, want remembered fact", stdout.String())
+	}
+}
+
+func TestRootCLI_MemoryStoreRememberHelpNamesDeprecation(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root := cli.NewRootCLI().Command()
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"memory", "store", "remember", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if strings.Contains(stderr.String(), "DEPRECATED:") {
+		t.Errorf("help must not emit the run-step notice:\n%s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Deprecated; use `traceary memory store propose`") {
+		t.Errorf("help stdout missing Short annotation:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Removal target: v0.36.0") {
+		t.Errorf("help stdout missing removal target:\n%s", stdout.String())
+	}
+}
+
+func TestRootCLI_SurfacesWithoutV036Notice(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "propose", args: []string{"memory", "store", "propose", "--db-path", "/tmp/test-traceary.db", "--type", "decision", "--fact", "Candidate"}},
+		{name: "tail", args: []string{"tail", "--help"}},
+		{name: "timeline", args: []string{"timeline", "--help"}},
+		{name: "handoff", args: []string{"session", "handoff", "--help"}},
+		{name: "hooks print", args: []string{"hooks", "print", "--help"}},
+		{name: "replay", args: []string{"replay", "--help"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			root := cli.NewRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithMemory(&memoryUsecaseStub{
+					proposeDetails: mustMemoryDetails(t, "memory-proposed", "Candidate", types.MemoryStatusCandidate),
+				}),
+				cli.WithSession(&sessionUsecaseStub{}),
+			).Command()
+			root.SetOut(stdout)
+			root.SetErr(stderr)
+			root.SetArgs(tt.args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if strings.Contains(stderr.String(), "DEPRECATED:") || strings.Contains(stdout.String(), "DEPRECATED:") {
+				t.Errorf("unexpected deprecation notice\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+			}
+		})
+	}
+}

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -448,6 +448,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	// instead of silently printing help and exiting 0. The root keeps its own
 	// RunE (help + stray-arg guard) and is left untouched.
 	applyStrictGroups(rootCmd)
+	applyInventoryDeprecations(rootCmd)
 	attachCompactReclaimWarning(rootCmd)
 
 	return rootCmd


### PR DESCRIPTION
## Summary

- Walk every visible public/admin leaf into 記録 (record), 記憶 (memory), or a written keep-reason
- The shipped table is `presentation/cli/pillar_inventory.go`; a test fails if a visible action is added without a row
- The only new notice is `traceary memory store remember` → `traceary memory store propose` (removal target v0.36.0). stdout / `--json` / `--id-only` stay unchanged
- Do not notice `tail` / `timeline` / `handoff` / `hooks print` — absorb flags (`list --follow`, `list --blocks`, `hooks install --dry-run`) do not exist
- Update the stale public/admin lists in `docs/cli-stability.md`. Fulfilled v0.35 removals were already in the historical log
- Remaining #1870 groups stay. They were never in the v0.34 deprecation registry

Closes #1692

Leaves parent #1693 open

## Test plan

- [x] `go test ./...`
- [x] `go tool golangci-lint run`
- [x] Shipped Cobra visible actions match the inventory 1:1
- [x] `memory store remember` emits one stderr `DEPRECATED` line naming `traceary memory store propose` and `v0.36.0`
- [x] `memory store remember --help` names the deprecation; the run-step notice does not fire
- [x] `propose` / `tail` / `timeline` / `handoff` / `hooks print` / `replay` emit no `DEPRECATED` notice
- [ ] Codex gpt-5.6-sol review (CRITICAL/HIGH empty or addressed)

## Notes

- #1870 stays open. The 97→29 keep-list is aspirational; this PR does not claim that count.
- `sessions --snapshot` stays because the v0.34 announcement already published it.
- `replay` stays: only single-file HTML export; usage counts are not grounds.
- `VERSION` is still 0.34.0. No tag.