### PR TITLE
fix: cancel non-hook command contexts on Ctrl-C

### DIFF
--- a/.ai/spec/1747.md
+++ b/.ai/spec/1747.md
@@ -1,0 +1,18 @@
+# #1747: wire Ctrl-C into non-hook command contexts
+
+## Policy
+
+- Hook commands keep `signal.NotifyContext` plus the existing soft deadline (`TRACEARY_HOOK_SOFT_DEADLINE`). Detached hook workers stay signal-only.
+- Non-hook commands get `signal.NotifyContext` **without** a deadline. After the first signal, `stopSignals()` restores the default handler so a second Ctrl-C hard-kills.
+- The only shipped TUI is `memory inbox review`. That path keeps `context.WithCancel` so Bubble Tea owns SIGINT/SIGTERM and can restore the terminal. `top` is already unknown.
+
+## I/O
+
+- `commandContext` in `main.go` is the single installer. Tests call it from its real start state (hook / detached worker / non-hook / TUI).
+- Non-hook signal coverage uses SIGTERM (same NotifyContext set as SIGINT) so the test process is not killed by the default SIGINT handler.
+- Docs: drop the "does not currently wire signals" caveat from `docs/storage/payload-backfill.md` and the Japanese pair.
+
+## Non-goals
+
+- Changing hook soft-deadline semantics.
+- Adding a new command surface.

--- a/.ai/spec/1747.md
+++ b/.ai/spec/1747.md
@@ -5,6 +5,7 @@
 - Hook commands keep `signal.NotifyContext` plus the existing soft deadline (`TRACEARY_HOOK_SOFT_DEADLINE`). Detached hook workers stay signal-only.
 - Non-hook commands get `signal.NotifyContext` **without** a deadline. After the first signal, `stopSignals()` restores the default handler so a second Ctrl-C hard-kills.
 - The only shipped TUI is `memory inbox review`. That path keeps `context.WithCancel` so Bubble Tea owns SIGINT/SIGTERM and can restore the terminal. `top` is already unknown.
+- TUI detection strips flag/value pairs (`--db-path /x` and `--db-path=/x`) so a global flag cannot steal the positional match.
 
 ## I/O
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Changed
+- **hook 以外の Ctrl-C が command context を cancel する (#1747)** — `store compact` など長い非 hook コマンドは signal 由来の context を使う（hook の soft deadline は付けない）。2 回目の Ctrl-C は即終了。`memory inbox review` の SIGINT はこれまでどおり Bubble Tea が持つ。
+
 ### Removed
 - **`traceary session active` を `session latest --active` に畳んだ (#1704)** — `session active` は unknown subcommand（非ゼロ、`DEPRECATED` なし）。`session latest --active` が以前の stale 既定（24h、`--stale-after`、`--allow-stale`）を引き継ぐ。`--active` なしの 2 flag は拒否する。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Changed
+- **Ctrl-C cancels non-hook command contexts (#1747)** — `store compact` and other long-running non-hook commands receive a signal-derived context (no hook soft deadline). A second Ctrl-C hard-kills. `memory inbox review` still lets Bubble Tea own SIGINT.
+
 ### Removed
 - **`traceary session active` folded into `session latest --active` (#1704)** — `session active` is an unknown subcommand (non-zero, no `DEPRECATED` notice). `session latest --active` keeps the previous stale defaults (24h, `--stale-after`, `--allow-stale`). Those two flags without `--active` are rejected.
 

--- a/docs/storage/payload-backfill.ja.md
+++ b/docs/storage/payload-backfill.ja.md
@@ -98,10 +98,10 @@ traceary store search-projection status
   fail の終端遷移は、いずれも worker が既に確定させた作業の記録なので、
   キャンセルの届かない context で実行する。ただしその context には期限があり、
   store lease を取れないチェックポイントはハングせずに諦める。
-- プロセスを落とした場合（CLI の `Ctrl-C`。現状 CLI は signal を command context に
-  配線していない。#1747 を参照）はチェックポイントを書かない。実行中のバッチは
-  ロールバックし、run は `running` のまま残る。`resume` は最後にコミットされた
-  バッチから継続できるが、`status` が実行中と報告するため `run` はそれまで拒否される。
+- hook 以外の CLI で `Ctrl-C` すると command context が cancel される（#1747）。
+  実行中の処理は `paused` チェックポイントを書ける。2 回目の `Ctrl-C` は
+  既定ハンドラに戻し、プロセスを即終了する。SIGKILL はチェックポイントを書かない。
+  `resume` は最後にコミットされたバッチから継続できる。
 - キャンセルはエラーの名前を書き換えない。I/O・制約・デコードの失敗が `Ctrl-C` と
   競合した場合も、チェックポイントは残しつつ、報告するのは「cancelled」ではなく
   その失敗そのものである。

--- a/docs/storage/payload-backfill.md
+++ b/docs/storage/payload-backfill.md
@@ -104,11 +104,10 @@ Output is JSON on stdout with aggregate counters only (no body contents).
   context the cancellation cannot reach, because it records what the worker
   already did durably. That context is bounded, so a checkpoint that cannot
   take the store lease gives up instead of hanging.
-- Killing the process instead (`Ctrl-C` on the CLI, which does not currently
-  wire signals into the command context — see #1747) writes no checkpoint. The
-  in-flight batch rolls back and the run stays at `running`; `resume` still
-  continues it from the last committed batch, but `run` refuses until then
-  because `status` reports it active.
+- `Ctrl-C` on a non-hook CLI command cancels the command context (#1747) so
+  in-flight work can persist a `paused` checkpoint. A second `Ctrl-C` restores
+  the default handler and hard-kills. A SIGKILL still writes no checkpoint;
+  `resume` continues from the last committed batch.
 - A cancellation does not rename the error. If an I/O, constraint or decode
   failure happens to race the `Ctrl-C`, the checkpoint still lands but the
   reported error is the failure, not "cancelled".

--- a/main.go
+++ b/main.go
@@ -304,7 +304,32 @@ func commandContext(args []string) (context.Context, context.CancelFunc) {
 		}
 		return ctx, stopSignals
 	}
-	return context.WithCancel(context.Background())
+	if isTUICommandArgs(args) {
+		// Bubble Tea owns SIGINT so it can restore the terminal (#1747).
+		return context.WithCancel(context.Background())
+	}
+	ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	// After the first signal, restore the default handler so a second Ctrl-C
+	// hard-kills a wedged cleanup.
+	go func() {
+		<-ctx.Done()
+		stopSignals()
+	}()
+	return ctx, stopSignals
+}
+
+func isTUICommandArgs(args []string) bool {
+	argv := args
+	if len(argv) > 0 {
+		argv = argv[1:]
+	}
+	for len(argv) > 0 && strings.HasPrefix(argv[0], "-") {
+		argv = argv[1:]
+	}
+	if len(argv) < 3 {
+		return false
+	}
+	return argv[0] == "memory" && argv[1] == "inbox" && argv[2] == "review"
 }
 
 func resolveHookSoftDeadline() time.Duration {

--- a/main.go
+++ b/main.go
@@ -319,17 +319,36 @@ func commandContext(args []string) (context.Context, context.CancelFunc) {
 }
 
 func isTUICommandArgs(args []string) bool {
-	argv := args
-	if len(argv) > 0 {
-		argv = argv[1:]
-	}
-	for len(argv) > 0 && strings.HasPrefix(argv[0], "-") {
-		argv = argv[1:]
-	}
+	argv := commandArgvWithoutFlags(args)
 	if len(argv) < 3 {
 		return false
 	}
 	return argv[0] == "memory" && argv[1] == "inbox" && argv[2] == "review"
+}
+
+// commandArgvWithoutFlags drops the program name and every flag/value pair so
+// positional detection is independent of `--flag value` vs `--flag=value`.
+func commandArgvWithoutFlags(args []string) []string {
+	argv := args
+	if len(argv) > 0 {
+		argv = argv[1:]
+	}
+	out := make([]string, 0, len(argv))
+	for i := 0; i < len(argv); i++ {
+		arg := argv[i]
+		if arg == "--" {
+			out = append(out, argv[i+1:]...)
+			break
+		}
+		if strings.HasPrefix(arg, "-") {
+			if !strings.Contains(arg, "=") && i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "-") {
+				i++
+			}
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
 }
 
 func resolveHookSoftDeadline() time.Duration {

--- a/main_test.go
+++ b/main_test.go
@@ -128,6 +128,30 @@ func TestCommandContext_TUICommandDoesNotInstallNotifyContext(t *testing.T) {
 	// handler would kill the test process. Bubble Tea owns SIGINT (#1747).
 }
 
+func TestIsTUICommandArgs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "bare review", args: []string{"traceary", "memory", "inbox", "review"}, want: true},
+		{name: "equals form of db-path", args: []string{"traceary", "--db-path=/tmp/x", "memory", "inbox", "review"}, want: true},
+		{name: "split form of db-path", args: []string{"traceary", "--db-path", "/tmp/x", "memory", "inbox", "review"}, want: true},
+		{name: "flag after command", args: []string{"traceary", "memory", "inbox", "review", "--db-path", "/tmp/x"}, want: true},
+		{name: "non-tui compact", args: []string{"traceary", "store", "compact"}, want: false},
+		{name: "non-tui list", args: []string{"traceary", "memory", "inbox", "list"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTUICommandArgs(tt.args); got != tt.want {
+				t.Fatalf("isTUICommandArgs(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWriteCLIError(t *testing.T) {
 	t.Parallel()
 

--- a/main_test.go
+++ b/main_test.go
@@ -96,6 +96,38 @@ func TestCommandContext_DetachedWorkerHasNoSoftDeadline(t *testing.T) {
 	}
 }
 
+func TestCommandContext_NonHookHasNoSoftDeadline(t *testing.T) {
+	t.Setenv(hookSoftDeadlineEnvKey, "50ms")
+	ctx, cancel := commandContext([]string{"traceary", "store", "compact"})
+	defer cancel()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("non-hook command must not inherit the hook soft deadline")
+	}
+}
+
+func TestCommandContext_NonHookCancelsOnSIGTERM(t *testing.T) {
+	ctx, cancel := commandContext([]string{"traceary", "store", "compact"})
+	defer cancel()
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("Kill(SIGTERM) error = %v", err)
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("non-hook context was not canceled by SIGTERM")
+	}
+}
+
+func TestCommandContext_TUICommandDoesNotInstallNotifyContext(t *testing.T) {
+	ctx, cancel := commandContext([]string{"traceary", "memory", "inbox", "review"})
+	defer cancel()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("TUI command must not have a deadline")
+	}
+	// Do not send SIGTERM here: this path uses WithCancel so the default
+	// handler would kill the test process. Bubble Tea owns SIGINT (#1747).
+}
+
 func TestWriteCLIError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Non-hook CLI commands now receive a signal-derived context (SIGINT/SIGTERM) with **no** hook soft deadline.
- After the first signal, the default handler is restored so a second Ctrl-C hard-kills a wedged cleanup.
- `memory inbox review` keeps `context.WithCancel` so Bubble Tea owns SIGINT and can restore the terminal.
- Docs drop the "does not currently wire signals" caveat on payload-backfill.

## Non-goals
- Does not change hook soft-deadline semantics or detached worker behaviour.
- Leaves parent #1904 open (implementation PRs must not complete the parent).

## Test plan
- [x] `go test .` (package main, includes SIGTERM-to-context and TUI no-NotifyContext)
- [x] `go tool golangci-lint run .`

Closes #1747
