### PR TITLE
fix: diagnose Antigravity hook permission denials on exit 0

### DIFF
--- a/.ai/spec/1864.md
+++ b/.ai/spec/1864.md
@@ -1,0 +1,13 @@
+# #1864: Antigravity readiness diagnosis
+
+## Policy
+
+- The probe reports a permission denial whenever `agy` stderr mentions permission, **including exit 0 with empty stdout**. That is the live-host failure mode (hooks auto-denied in headless mode).
+- A non-zero `agy` exit without permission wording is still "exited before the marker response".
+- A zero exit without the marker and without permission wording stays "marker was not returned".
+- `traceary doctor --client antigravity` already owns `antigravity-headless-hooks` (exact allow of the four packaged hook commands). Default doctor clients stay `claude,codex,gemini` (existing pin). This ticket does not add a command.
+
+## I/O
+
+- `scripts/verify-antigravity-headless-markers.sh` classifies after capturing stdout/stderr.
+- Tests drive the real script with a fake `agy` on PATH and `TRACEARY_DOGFOOD_BINARY` so they do not build or talk to a live store.

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -10,6 +10,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ### Changed
 - **hook 以外の Ctrl-C が command context を cancel する (#1747)** — `store compact` など長い非 hook コマンドは signal 由来の context を使う（hook の soft deadline は付けない）。2 回目の Ctrl-C は即終了。`memory inbox review` の SIGINT はこれまでどおり Bubble Tea が持つ。
 
+### Fixed
+- **Antigravity headless probe が exit 0 の permission 拒否を報告する (#1864)** — `scripts/verify-antigravity-headless-markers.sh` は `agy` が空 stdout で exit 0 しても stderr の permission 文言を見る。`traceary doctor --client antigravity` の `antigravity-headless-hooks` は既存。
+
 ### Removed
 - **`traceary session active` を `session latest --active` に畳んだ (#1704)** — `session active` は unknown subcommand（非ゼロ、`DEPRECATED` なし）。`session latest --active` が以前の stale 既定（24h、`--stale-after`、`--allow-stale`）を引き継ぐ。`--active` なしの 2 flag は拒否する。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ### Changed
 - **Ctrl-C cancels non-hook command contexts (#1747)** — `store compact` and other long-running non-hook commands receive a signal-derived context (no hook soft deadline). A second Ctrl-C hard-kills. `memory inbox review` still lets Bubble Tea own SIGINT.
 
+### Fixed
+- **Antigravity headless probe reports permission denials on exit 0 (#1864)** — `scripts/verify-antigravity-headless-markers.sh` inspects stderr for permission wording even when `agy` exits 0 with empty stdout. `traceary doctor --client antigravity` already reports `antigravity-headless-hooks`.
+
 ### Removed
 - **`traceary session active` folded into `session latest --active` (#1704)** — `session active` is an unknown subcommand (non-zero, no `DEPRECATED` notice). `session latest --active` keeps the previous stale defaults (24h, `--stale-after`, `--allow-stale`). Those two flags without `--active` are rejected.
 

--- a/cmd/repo-tooling/antigravity_headless_probe_test.go
+++ b/cmd/repo-tooling/antigravity_headless_probe_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyAntigravityHeadlessMarkers_DiagnosesPermissionOnZeroExit(t *testing.T) {
+	t.Parallel()
+
+	root, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("findRepoRoot() error = %v", err)
+	}
+
+	work := t.TempDir()
+	agy := filepath.Join(work, "agy")
+	// Matches the live host: exit 0, empty stdout, permission denial on stderr.
+	script := "#!/bin/sh\nprintf '%s\\n' 'jetski: no output produced — a tool required the \"command\" permission that headless mode cannot prompt for, so it was auto-denied.' >&2\nexit 0\n"
+	if err := os.WriteFile(agy, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	dummy := filepath.Join(work, "traceary")
+	if err := os.WriteFile(dummy, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sh", filepath.Join(root, "scripts/verify-antigravity-headless-markers.sh"))
+	cmd.Dir = work
+	cmd.Env = append(os.Environ(),
+		"PATH="+work+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TRACEARY_DOGFOOD_BINARY="+dummy,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("probe exit = 0, want permission diagnosis; output = %q", out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "scoped hook permission is absent or shadowed") {
+		t.Fatalf("output = %q, want permission diagnosis", got)
+	}
+	if strings.Contains(got, "expected public response marker was not returned") {
+		t.Fatalf("output = %q, must not fold a permission denial into a missing marker", got)
+	}
+}

--- a/cmd/repo-tooling/antigravity_headless_probe_test.go
+++ b/cmd/repo-tooling/antigravity_headless_probe_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestVerifyAntigravityHeadlessMarkers_DiagnosesPermissionOnZeroExit(t *testing.T) {
+func TestVerifyAntigravityHeadlessMarkers_ClassifiesAgyOutcomes(t *testing.T) {
 	t.Parallel()
 
 	root, err := findRepoRoot()
@@ -16,33 +16,56 @@ func TestVerifyAntigravityHeadlessMarkers_DiagnosesPermissionOnZeroExit(t *testi
 		t.Fatalf("findRepoRoot() error = %v", err)
 	}
 
-	work := t.TempDir()
-	agy := filepath.Join(work, "agy")
-	// Matches the live host: exit 0, empty stdout, permission denial on stderr.
-	script := "#!/bin/sh\nprintf '%s\\n' 'jetski: no output produced — a tool required the \"command\" permission that headless mode cannot prompt for, so it was auto-denied.' >&2\nexit 0\n"
-	if err := os.WriteFile(agy, []byte(script), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	dummy := filepath.Join(work, "traceary")
-	if err := os.WriteFile(dummy, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name       string
+		agyScript  string
+		wantNeedle string
+		forbid     string
+	}{
+		{
+			name:       "permission denial on exit 0",
+			agyScript:  "#!/bin/sh\nprintf '%s\\n' 'jetski: no output produced — a tool required the \"command\" permission that headless mode cannot prompt for, so it was auto-denied.' >&2\nexit 0\n",
+			wantNeedle: "scoped hook permission is absent or shadowed",
+			forbid:     "expected public response marker was not returned",
+		},
+		{
+			name:       "nonzero exit without permission wording",
+			agyScript:  "#!/bin/sh\nprintf '%s\\n' 'model crashed' >&2\nexit 3\n",
+			wantNeedle: "agy exited before the marker response",
+			forbid:     "expected public response marker was not returned",
+		},
 	}
 
-	cmd := exec.Command("sh", filepath.Join(root, "scripts/verify-antigravity-headless-markers.sh"))
-	cmd.Dir = work
-	cmd.Env = append(os.Environ(),
-		"PATH="+work+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"TRACEARY_DOGFOOD_BINARY="+dummy,
-	)
-	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("probe exit = 0, want permission diagnosis; output = %q", out)
-	}
-	got := string(out)
-	if !strings.Contains(got, "scoped hook permission is absent or shadowed") {
-		t.Fatalf("output = %q, want permission diagnosis", got)
-	}
-	if strings.Contains(got, "expected public response marker was not returned") {
-		t.Fatalf("output = %q, must not fold a permission denial into a missing marker", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			work := t.TempDir()
+			agy := filepath.Join(work, "agy")
+			if err := os.WriteFile(agy, []byte(tt.agyScript), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			dummy := filepath.Join(work, "traceary")
+			if err := os.WriteFile(dummy, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := exec.Command("sh", filepath.Join(root, "scripts/verify-antigravity-headless-markers.sh"))
+			cmd.Dir = work
+			cmd.Env = append(os.Environ(),
+				"PATH="+work+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"TRACEARY_DOGFOOD_BINARY="+dummy,
+			)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("probe exit = 0, want diagnosis; output = %q", out)
+			}
+			got := string(out)
+			if !strings.Contains(got, tt.wantNeedle) {
+				t.Fatalf("output = %q, want %q", got, tt.wantNeedle)
+			}
+			if tt.forbid != "" && strings.Contains(got, tt.forbid) {
+				t.Fatalf("output = %q, must not contain %q", got, tt.forbid)
+			}
+		})
 	}
 }

--- a/docs/integrations/antigravity.ja.md
+++ b/docs/integrations/antigravity.ja.md
@@ -143,6 +143,10 @@ scripts/verify-antigravity-headless-markers.sh
 
 probe は candidate binary を build して `PATH` の先頭へ置き、
 `--mode plan --sandbox` を維持し、隔離された一時 Traceary DB を使います。
+`agy` が hook を自動拒否した場合（exit 0・空 stdout・stderr に permission
+文言、という形が多い）は、marker 欠落ではなく scoped permission の失敗と
+報告します。同じ条件は `traceary doctor --client antigravity` の
+`antigravity-headless-hooks` でも見えます。
 固定の公開 response marker を検証した後、`id,kind,session,source_hook`
 だけを読み戻します。prompt、response、transcript の本文は表示もコピーも
 しません。現行 host が健全なら `session_start`、`prompt`、`final_turn`、

--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -145,7 +145,11 @@ scripts/verify-antigravity-headless-markers.sh
 ```
 
 The probe builds the candidate binary, puts it first on `PATH`, keeps
-`--mode plan --sandbox`, and uses an isolated temporary Traceary database. It
+`--mode plan --sandbox`, and uses an isolated temporary Traceary database. If
+`agy` auto-denies a hook (often exit 0, empty stdout, permission wording on
+stderr), the probe reports a scoped-permission failure instead of a missing
+marker. `traceary doctor --client antigravity` reports the same condition as
+`antigravity-headless-hooks`. It
 verifies a fixed public response marker and reads back only
 `id,kind,session,source_hook`; it never prints or copies prompt, response, or
 transcript bodies. A healthy current host reports `session_start`, `prompt`,

--- a/scripts/verify-antigravity-headless-markers.sh
+++ b/scripts/verify-antigravity-headless-markers.sh
@@ -38,9 +38,7 @@ stderr_path="$work_dir/agy.stderr"
 # agy can exit 0 with empty stdout when a hook is auto-denied (no TTY to
 # prompt). Diagnose permission wording on stderr regardless of exit status.
 agy_exit=0
-if ! agy --print --mode plan --sandbox --print-timeout 120s "$prompt" >"$stdout_path" 2>"$stderr_path"; then
-  agy_exit=$?
-fi
+agy --print --mode plan --sandbox --print-timeout 120s "$prompt" >"$stdout_path" 2>"$stderr_path" || agy_exit=$?
 if grep -qi "permission" "$stderr_path"; then
   echo "antigravity headless marker probe: scoped hook permission is absent or shadowed" >&2
   exit 1

--- a/scripts/verify-antigravity-headless-markers.sh
+++ b/scripts/verify-antigravity-headless-markers.sh
@@ -35,12 +35,18 @@ stdout_path="$work_dir/agy.stdout"
 stderr_path="$work_dir/agy.stderr"
 
 # Safety invariants: plan mode, terminal sandbox, and no permission bypass.
+# agy can exit 0 with empty stdout when a hook is auto-denied (no TTY to
+# prompt). Diagnose permission wording on stderr regardless of exit status.
+agy_exit=0
 if ! agy --print --mode plan --sandbox --print-timeout 120s "$prompt" >"$stdout_path" 2>"$stderr_path"; then
-  if grep -qi "permission" "$stderr_path"; then
-    echo "antigravity headless marker probe: scoped hook permission is absent or shadowed" >&2
-  else
-    echo "antigravity headless marker probe: agy exited before the marker response" >&2
-  fi
+  agy_exit=$?
+fi
+if grep -qi "permission" "$stderr_path"; then
+  echo "antigravity headless marker probe: scoped hook permission is absent or shadowed" >&2
+  exit 1
+fi
+if [ "$agy_exit" -ne 0 ]; then
+  echo "antigravity headless marker probe: agy exited before the marker response" >&2
   exit 1
 fi
 if ! grep -Fxq "$marker" "$stdout_path"; then


### PR DESCRIPTION
## Summary
- `scripts/verify-antigravity-headless-markers.sh` now diagnoses scoped hook permission denials even when `agy` exits 0 with empty stdout.
- `traceary doctor --client antigravity` already reports `antigravity-headless-hooks`; default doctor clients stay `claude,codex,gemini`.
- Tests drive the real script with a fake `agy` (no live store).

## Non-goals
- Does not add Antigravity to default doctor clients.
- Leaves parent #1904 open.

## Test plan
- [x] `go test ./cmd/repo-tooling -run TestVerifyAntigravityHeadlessMarkers`
- [x] `go tool golangci-lint run ./cmd/repo-tooling/`

Closes #1864
