### PR TITLE
docs: keep compact rollback copies until the operator deletes them

### DIFF
--- a/.ai/spec/1827.md
+++ b/.ai/spec/1827.md
@@ -1,0 +1,23 @@
+# #1827: when the compaction rollback copy is released
+
+## Policy
+
+Apply-time `VerifyPair` is real (compatibility, filtered/logical digest, attestation) and is **not** proof the compacted store is correct in use. Auto-deleting the rollback inode on commit, or on the next successful open, trades a disk problem for an unrecoverable data-loss risk.
+
+Therefore:
+
+- The rollback copy is **retained until the operator deletes it**.
+- No new command. `store compact rollback RUN_ID` restores; `rm` on the named `rollback_path` is the release.
+- Success JSON always names `rollback_path` and sets `rollback_retained: true`.
+- `doctor` reports a sibling `<db>.rollback-*` so the operator does not have to remember the filename.
+
+## I/O
+
+- CLI encode in `store compact` (existing JSON object).
+- Doctor walks only `filepath.Glob(dbPath + ".rollback-*")` — no extra store open, no live-store requirement.
+- Tests drive the real `store compact` command and the doctor check from a scratch path.
+
+## Non-goals
+
+- A `store compact release` / `forget` subcommand.
+- Deleting the copy from the apply or open path.

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Changed
+- **compact の rollback copy は operator が消すまで残る (#1827)** — apply 時の `VerifyPair` は実使用の証明ではない。成功 JSON は `rollback_retained: true` と `rollback_path` を出す。`doctor` は隣の `<db>.rollback-*` を報告する。release サブコマンドは追加しない。
 - **hook 以外の Ctrl-C が command context を cancel する (#1747)** — `store compact` など長い非 hook コマンドは signal 由来の context を使う（hook の soft deadline は付けない）。2 回目の Ctrl-C は即終了。`memory inbox review` の SIGINT はこれまでどおり Bubble Tea が持つ。
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Changed
+- **Compaction rollback copy stays until the operator deletes it (#1827)** — apply-time `VerifyPair` is not in-use proof. Success JSON includes `rollback_retained: true` and the named `rollback_path`. `doctor` reports leftover `<db>.rollback-*` siblings. No release subcommand.
 - **Ctrl-C cancels non-hook command contexts (#1747)** — `store compact` and other long-running non-hook commands receive a signal-derived context (no hook soft deadline). A second Ctrl-C hard-kills. `memory inbox review` still lets Bubble Tea own SIGINT.
 
 ### Fixed

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -62,6 +62,18 @@ filesystem安全性は協調モデルです。参加するlive openerはすべ�
 元へ戻す場合は `rollback RUN_ID` を使います。確認完了前に
 `.traceary-compaction` journalやrollback artifactを削除しないでください。
 
+## rollback copy をいつ解放するか
+
+apply 末尾の `VerifyPair` は実在する検査です（互換性、filtered / logical digest、
+attestation）。しかし compacted store が実使用で正しいことの証明ではありません。
+そのため Traceary は commit 時にも次回の成功 open 時にも
+`<db>.rollback-<run>` を削除せず、release 用の新コマンドも追加しません。
+
+operator が解放する手段は、compact 成功 JSON の `rollback_path`
+（`rollback_retained: true`）を削除することです。削除するとその run の
+`traceary store compact rollback RUN_ID` は使えなくなります。
+`traceary doctor` は隣に残った copy を `compact-rollback-copy` として報告します。
+
 ## maintenance手順
 
 1. live storeをcopyまたはbackupし、旧版・非協調processを停止します。

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -73,6 +73,19 @@ journal when one exists. Use `rollback RUN_ID` to atomically restore the
 retained original. Never delete the external `.traceary-compaction` journal or
 rollback artifact until the run has been inspected and accepted.
 
+## When the rollback copy is released
+
+`VerifyPair` at the end of apply is a real check (compatibility, filtered or
+logical digest, attestation). It is not proof that the compacted store is
+correct in use. Traceary therefore **does not** delete `<db>.rollback-<run>`
+on commit or on the next successful open, and it does not add a release
+subcommand.
+
+The operator releases the copy by deleting the path named in the compact
+success JSON (`rollback_path`, with `rollback_retained: true`). Deleting it
+gives up `traceary store compact rollback RUN_ID` for that run.
+`traceary doctor` reports a leftover sibling as `compact-rollback-copy`.
+
 ## Maintenance sequence
 
 1. Copy or back up the live store and stop older/non-cooperating processes.

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -286,6 +286,10 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 	if isLargeStoreForBoundedDoctor(snapshot) {
 		report.Mode = doctorModeMetadataOnlyLargeStore
 		report.Checks = append(report.Checks, unknownStoreGrowthCheck(snapshot.Size, resolvedDBPath, "default doctor is filesystem-metadata-only for stores at or above 2 GiB; inspect a reviewed copy for detailed signals"))
+		// Sibling rollback copies are a directory listing only; they do not
+		// open SQLite. Large stores are the ones most likely to still hold
+		// a source-sized rollback inode (#1827).
+		report.Checks = append(report.Checks, inspectCompactRollbackCopies(resolvedDBPath))
 		report.Checks = append(report.Checks, inspectTracearyOnPath())
 		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(snapshot, resolvedDBPath))
 		if c.attestationAnchorInspector != nil {

--- a/presentation/cli/doctor_compact_rollback_test.go
+++ b/presentation/cli/doctor_compact_rollback_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInspectCompactRollbackCopies(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+
+	t.Run("pass when no sibling exists", func(t *testing.T) {
+		dir := t.TempDir()
+		check := inspectCompactRollbackCopies(filepath.Join(dir, "traceary.db"))
+		if check.Status != doctorStatusPass {
+			t.Fatalf("Status = %q, want pass; %+v", check.Status, check)
+		}
+	})
+
+	t.Run("warn names the retained file and size", func(t *testing.T) {
+		dir := t.TempDir()
+		db := filepath.Join(dir, "traceary.db")
+		rollback := db + ".rollback-abc123"
+		if err := os.WriteFile(rollback, []byte("old-store"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		check := inspectCompactRollbackCopies(db)
+		if check.Name != "compact-rollback-copy" {
+			t.Fatalf("Name = %q", check.Name)
+		}
+		if check.Status != doctorStatusWarn {
+			t.Fatalf("Status = %q, want warn", check.Status)
+		}
+		if !strings.Contains(check.Message, rollback) {
+			t.Fatalf("Message = %q, want path", check.Message)
+		}
+		if !strings.Contains(check.Hint, "compact rollback") {
+			t.Fatalf("Hint = %q", check.Hint)
+		}
+	})
+}

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -44,7 +45,68 @@ func inspectStoreFileSnapshot(path string, stat func(string) (os.FileInfo, error
 }
 
 func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string, snapshot storeFileSnapshot) []doctorCheck {
-	return c.inspectStoreGrowthBudgetWithClock(ctx, dbPath, snapshot, time.Now)
+	checks := c.inspectStoreGrowthBudgetWithClock(ctx, dbPath, snapshot, time.Now)
+	return append(checks, inspectCompactRollbackCopies(dbPath))
+}
+
+// inspectCompactRollbackCopies reports leftover <db>.rollback-<run> files.
+// The copy is retained until the operator deletes it (#1827); doctor only names it.
+func inspectCompactRollbackCopies(dbPath string) doctorCheck {
+	const name = "compact-rollback-copy"
+	if strings.TrimSpace(dbPath) == "" {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusSkip,
+			Message: Localize("store path is empty, so compact rollback copies were not inspected", "store path が空のため compact rollback copy は検査しません"),
+		}
+	}
+	matches, err := filepath.Glob(dbPath + ".rollback-*")
+	if err != nil {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusWarn,
+			Message: localizef("failed to inspect compact rollback copies: %v", "compact rollback copy を検査できません: %v", err),
+		}
+	}
+	type retained struct {
+		path string
+		size int64
+	}
+	var copies []retained
+	for _, match := range matches {
+		info, statErr := os.Lstat(match)
+		if statErr != nil || info == nil || !info.Mode().IsRegular() {
+			continue
+		}
+		copies = append(copies, retained{path: match, size: info.Size()})
+	}
+	if len(copies) == 0 {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusPass,
+			Message: Localize("no compact rollback copy is retained beside the store", "store の隣に compact rollback copy は残っていません"),
+		}
+	}
+	parts := make([]string, 0, len(copies))
+	var total int64
+	for _, copy := range copies {
+		total += copy.size
+		parts = append(parts, fmt.Sprintf("%s (%s)", copy.path, formatByteSize(copy.size)))
+	}
+	return doctorCheck{
+		Name: name,
+		Status: doctorStatusWarn,
+		Message: localizef(
+			"compact rollback copy still retained (%s total): %s",
+			"compact rollback copy が残っています（合計 %s）: %s",
+			formatByteSize(total),
+			strings.Join(parts, ", "),
+		),
+		Hint: Localize(
+			"Apply-time verification is not in-use proof. Keep the file until you accept the rewrite, then delete it. Deleting it gives up `traceary store compact rollback RUN_ID` for that run.",
+			"apply 時の検証は実使用の正しさの証明ではありません。書き換えを受け入れるまで残し、その後削除してください。削除するとその run の `traceary store compact rollback RUN_ID` は使えなくなります。",
+		),
+	}
 }
 
 // inspectStoreGrowthBudgetWithClock returns the store-size check and, when the

--- a/presentation/cli/doctor_store_size_test.go
+++ b/presentation/cli/doctor_store_size_test.go
@@ -63,8 +63,11 @@ func TestInspectStoreGrowthBudgetSeparatesRetiredIndexFromProjection(t *testing.
 		},
 	}}}
 	checks := root.inspectStoreGrowthBudget(context.Background(), path, inspectStoreFileSnapshot(path, os.Stat))
-	if len(checks) != 2 {
+	if len(checks) != 3 {
 		t.Fatalf("checks=%#v", checks)
+	}
+	if checks[2].Name != "compact-rollback-copy" || checks[2].Status != doctorStatusPass {
+		t.Fatalf("rollback check=%#v", checks[2])
 	}
 	legacy := checks[1]
 	if legacy.Name != "legacy-search-index" || legacy.Status != doctorStatusWarn {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -530,6 +530,10 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 	if err := file.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
 	}
+	rollbackPath := largeStore + ".rollback-deadbeef"
+	if err := os.WriteFile(rollbackPath, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	store := &storeManagementUsecaseStub{}
 	events := &eventUsecaseStub{}
@@ -573,6 +577,10 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 	check := statusByName(report, "large-store-diagnostics")
 	if check.Status != "warn" || !strings.Contains(check.Message, "were not read") {
 		t.Fatalf("large-store-diagnostics = %#v, want explicit metadata-only warning", check)
+	}
+	rollback := statusByName(report, "compact-rollback-copy")
+	if rollback.Status != "warn" || !strings.Contains(rollback.Message, rollbackPath) {
+		t.Fatalf("compact-rollback-copy = %#v, want warn naming %s", rollback, rollbackPath)
 	}
 }
 

--- a/presentation/cli/store_compaction.go
+++ b/presentation/cli/store_compaction.go
@@ -47,6 +47,9 @@ func (c *RootCLI) newStoreCompactionCommand() *cobra.Command {
 				"unrefined_bytes":      result.UnrefinedBytes,
 				"mechanical_summaries": result.MechanicalSummaries,
 				"rollback_path":        result.Run.RollbackPath,
+				// Apply-time VerifyPair is not in-use proof. The operator
+				// deletes this file when they accept the rewrite (#1827).
+				"rollback_retained": true,
 			})
 		},
 	}

--- a/presentation/cli/store_compaction_test.go
+++ b/presentation/cli/store_compaction_test.go
@@ -18,7 +18,11 @@ type compactionCLIStub struct {
 func (s *compactionCLIStub) Compact(_ context.Context, in application.CompactInput) (application.CompactResult, error) {
 	s.compacted = in.Source
 	s.forced = in.Force
-	return application.CompactResult{Run: domain.CompactionRun{ID: "run", Phase: domain.CompactionCommitted}}, nil
+	return application.CompactResult{Run: domain.CompactionRun{
+		ID:           "run",
+		Phase:        domain.CompactionCommitted,
+		RollbackPath: in.Source + ".rollback-run",
+	}}, nil
 }
 func (*compactionCLIStub) Plan(context.Context, string) (domain.CompactionRun, error) {
 	return domain.CompactionRun{}, nil
@@ -55,6 +59,12 @@ func TestStoreCompactUsesDedicatedPathBoundComposition(t *testing.T) {
 	}
 	if payload["run_id"] != "run" {
 		t.Fatalf("run_id = %v", payload["run_id"])
+	}
+	if payload["rollback_retained"] != true {
+		t.Fatalf("rollback_retained = %v, want true", payload["rollback_retained"])
+	}
+	if payload["rollback_path"] != path+".rollback-run" {
+		t.Fatalf("rollback_path = %v", payload["rollback_path"])
 	}
 }
 

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -25,6 +25,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "compact-rollback-copy",
+      "status": "pass",
+      "severity": "PASS",
+      "section": "Hooks",
+      "message": "no compact rollback copy is retained beside the store",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "path",
       "status": "pass",
       "severity": "PASS",
@@ -354,6 +364,16 @@
           "auto_fix_available": false
         },
         {
+          "name": "compact-rollback-copy",
+          "status": "pass",
+          "severity": "PASS",
+          "section": "Hooks",
+          "message": "no compact rollback copy is retained beside the store",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
           "name": "hook-spool",
           "status": "pass",
           "severity": "PASS",
@@ -427,7 +447,7 @@
     }
   ],
   "summary": {
-    "pass": 19,
+    "pass": 20,
     "warn": 1,
     "fail": 0
   },


### PR DESCRIPTION
## Summary
- Decision: the compact rollback copy is retained until the operator deletes it. Apply-time `VerifyPair` is not in-use proof.
- No new command. Success JSON adds `rollback_retained: true` and keeps `rollback_path`.
- `doctor` reports leftover `<db>.rollback-*` siblings as `compact-rollback-copy`.

## Non-goals
- Does not auto-delete on commit or the next successful open.
- Does not add `store compact release`.
- Leaves parent #1904 open.

## Test plan
- [x] `go test ./presentation/cli -run 'TestStoreCompact|TestInspectCompactRollback|TestDoctor_JSON_Golden'`
- [x] `go tool golangci-lint run ./presentation/cli/`

Closes #1827
