### PR TITLE
feat: report this store's measured cost from doctor

### DIFF
--- a/.ai/spec/1809.md
+++ b/.ai/spec/1809.md
@@ -1,0 +1,22 @@
+# #1809: report the operator's own storage cost
+
+## Policy
+
+- Lives in `traceary doctor` (`status` is already an alias). `store capacity` stays dbstat-only; this answers rate × bytes-per-unit for **this** store.
+- No new command.
+- Default doctor on stores it already opens (< 2 GiB) runs indexed aggregates on `event_metadata_projection`. It does not scan `events.body`.
+- Stores ≥ 2 GiB stay metadata-only: resident file size only, no SQLite open.
+- Foldable = transcript rows older than the compact cutoff (90 days) whose session has a `session_refinements` row. Undiscardable = retained source bytes minus foldable.
+- Rate window is 30 days. Monthly undiscardable projection = events/day × 30 × undiscardable-bytes-per-event. Omitted when the window is empty.
+
+## I/O
+
+- `application.OperatorCostInspector` / `types.OperatorCostReport` (`traceary.operator_cost/v1`).
+- Doctor JSON adds optional `operator_cost` and check `store-operator-cost`.
+- Tests drive the real inspector against a scratch SQLite file and the real `doctor --json` command.
+
+## Non-goals
+
+- New top-level command.
+- Opening a ≥ 2 GiB store from doctor.
+- Reading event bodies.

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Added
+- **doctor がこのストアの実測コストを出す (#1809)** — `traceary doctor --json` に `operator_cost`（`traceary.operator_cost/v1`）と check `store-operator-cost` を追加。resident の event/session あたり、undiscardable / foldable の source-text、amplification、直近 30 日のレートからの月次予測。2 GiB 以上は metadata-only（resident サイズのみ）。グローバルな月次主張ではない。
+
 ### Changed
 - **compact の rollback copy は operator が消すまで残る (#1827)** — apply 時の `VerifyPair` は実使用の証明ではない。成功 JSON は `rollback_retained: true` と `rollback_path` を出す。`doctor` は隣の `<db>.rollback-*` を報告する。release サブコマンドは追加しない。
 - **hook 以外の Ctrl-C が command context を cancel する (#1747)** — `store compact` など長い非 hook コマンドは signal 由来の context を使う（hook の soft deadline は付けない）。2 回目の Ctrl-C は即終了。`memory inbox review` の SIGINT はこれまでどおり Bubble Tea が持つ。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Added
+- **Doctor reports this store's measured cost (#1809)** — `traceary doctor --json` includes `operator_cost` (`traceary.operator_cost/v1`) and check `store-operator-cost`: resident bytes per event/session, undiscardable vs foldable source-text, amplification, and a monthly projection from the last 30 days of this store's own rate. Stores ≥ 2 GiB stay metadata-only (resident size only). Not a global monthly claim.
+
 ### Changed
 - **Compaction rollback copy stays until the operator deletes it (#1827)** — apply-time `VerifyPair` is not in-use proof. Success JSON includes `rollback_retained: true` and the named `rollback_path`. `doctor` reports leftover `<db>.rollback-*` siblings. No release subcommand.
 - **Ctrl-C cancels non-hook command contexts (#1747)** — `store compact` and other long-running non-hook commands receive a signal-derived context (no hook soft deadline). A second Ctrl-C hard-kills. `memory inbox review` still lets Bubble Tea own SIGINT.

--- a/application/operator_cost.go
+++ b/application/operator_cost.go
@@ -1,0 +1,16 @@
+package application
+
+import (
+	"context"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// OperatorCostWindowDays is the trailing activity window for rate and projection.
+const OperatorCostWindowDays = 30
+
+// OperatorCostInspector measures the operator's own store cost without reading bodies.
+type OperatorCostInspector interface {
+	InspectOperatorCost(ctx context.Context, now time.Time, residentBytes int64) (apptypes.OperatorCostReport, error)
+}

--- a/application/types/operator_cost.go
+++ b/application/types/operator_cost.go
@@ -1,0 +1,32 @@
+package types
+
+// OperatorCostReport is the operator's own measured store cost.
+// SchemaVersion is traceary.operator_cost/v1.
+type OperatorCostReport struct {
+	SchemaVersion                       string               `json:"schema_version"`
+	WindowDays                          int                  `json:"window_days"`
+	ResidentBytes                       int64                `json:"resident_bytes"`
+	EventCount                          int64                `json:"event_count"`
+	SessionCount                        int64                `json:"session_count"`
+	ResidentBytesPerEvent               float64              `json:"resident_bytes_per_event,omitempty"`
+	ResidentBytesPerSession             float64              `json:"resident_bytes_per_session,omitempty"`
+	RetainedSourceBytes                 int64                `json:"retained_source_bytes"`
+	UndiscardableSourceBytes            int64                `json:"undiscardable_source_bytes"`
+	FoldableSourceBytes                 int64                `json:"foldable_source_bytes"`
+	UndiscardableBytesPerEvent          float64              `json:"undiscardable_bytes_per_event,omitempty"`
+	UndiscardableBytesPerSession        float64              `json:"undiscardable_bytes_per_session,omitempty"`
+	Amplification                       float64              `json:"amplification,omitempty"`
+	WindowEventCount                    int64                `json:"window_event_count"`
+	WindowSessionCount                  int64                `json:"window_session_count"`
+	EventsPerDay                        float64              `json:"events_per_day,omitempty"`
+	SessionsPerDay                      float64              `json:"sessions_per_day,omitempty"`
+	ProjectedUndiscardableBytesPerMonth int64                `json:"projected_undiscardable_bytes_per_month,omitempty"`
+	Evidence                            OperatorCostEvidence `json:"evidence"`
+}
+
+// OperatorCostEvidence states how complete the measurement is.
+type OperatorCostEvidence struct {
+	Status string `json:"status"`
+	Method string `json:"method"`
+	Reason string `json:"reason,omitempty"`
+}

--- a/infrastructure/sqlite/operator_cost.go
+++ b/infrastructure/sqlite/operator_cost.go
@@ -1,0 +1,131 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// OperatorCostInspector measures operator-local store cost from the
+// event metadata projection. It does not read event bodies.
+type OperatorCostInspector struct {
+	db *Database
+}
+
+// NewOperatorCostInspector creates a projection-backed operator cost inspector.
+func NewOperatorCostInspector(db *Database) *OperatorCostInspector {
+	return &OperatorCostInspector{db: db}
+}
+
+// InspectOperatorCost returns indexed aggregates for this store.
+func (i *OperatorCostInspector) InspectOperatorCost(ctx context.Context, now time.Time, residentBytes int64) (_ apptypes.OperatorCostReport, err error) {
+	report := apptypes.OperatorCostReport{
+		SchemaVersion: "traceary.operator_cost/v1",
+		WindowDays:    application.OperatorCostWindowDays,
+		ResidentBytes: residentBytes,
+		Evidence: apptypes.OperatorCostEvidence{
+			Status: "skipped",
+			Method: "event_metadata_projection",
+		},
+	}
+	if residentBytes <= 0 && i.db != nil && i.db.Path() != "" {
+		if info, statErr := os.Stat(i.db.Path()); statErr == nil {
+			report.ResidentBytes = info.Size()
+		}
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	db, err := i.db.openReadOnly(ctx)
+	if err != nil {
+		return report, xerrors.Errorf("failed to open store for operator cost: %w", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = xerrors.Errorf("failed to close operator cost inspection: %w", closeErr)
+		}
+	}()
+
+	var projectionExists int
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='event_metadata_projection'`).Scan(&projectionExists); err != nil {
+		return report, xerrors.Errorf("failed to inspect event metadata schema: %w", err)
+	}
+	if projectionExists == 0 {
+		report.Evidence.Reason = "event metadata projection unavailable"
+		return report, nil
+	}
+
+	if err := db.QueryRowContext(ctx, `
+SELECT COUNT(*), COUNT(DISTINCT session_id), COALESCE(SUM(COALESCE(body_stored_bytes, 0)), 0)
+  FROM event_metadata_projection`).Scan(&report.EventCount, &report.SessionCount, &report.RetainedSourceBytes); err != nil {
+		return report, xerrors.Errorf("failed to aggregate retained source bytes: %w", err)
+	}
+
+	var refinementsExist int
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='session_refinements'`).Scan(&refinementsExist); err != nil {
+		return report, xerrors.Errorf("failed to inspect session refinements schema: %w", err)
+	}
+	cutoff := formatTimestamp(application.CompactCutoff(now, application.DefaultCompactKeepDays))
+	if refinementsExist > 0 {
+		if err := db.QueryRowContext(ctx, `
+SELECT COALESCE(SUM(COALESCE(p.body_stored_bytes, 0)), 0)
+  FROM event_metadata_projection AS p
+ WHERE p.kind = 'transcript'
+   AND p.created_at_norm IS NOT NULL
+   AND p.created_at_norm < ?
+   AND EXISTS (
+         SELECT 1 FROM session_refinements AS r WHERE r.session_id = p.session_id
+       )`, cutoff).Scan(&report.FoldableSourceBytes); err != nil {
+			return report, xerrors.Errorf("failed to aggregate foldable source bytes: %w", err)
+		}
+	}
+	report.UndiscardableSourceBytes = report.RetainedSourceBytes - report.FoldableSourceBytes
+	if report.UndiscardableSourceBytes < 0 {
+		report.UndiscardableSourceBytes = 0
+	}
+
+	windowStart := formatTimestamp(now.UTC().AddDate(0, 0, -application.OperatorCostWindowDays))
+	if err := db.QueryRowContext(ctx, `
+SELECT COUNT(*), COUNT(DISTINCT session_id)
+  FROM event_metadata_projection
+ WHERE created_at_norm IS NOT NULL
+   AND created_at_norm >= ?`, windowStart).Scan(&report.WindowEventCount, &report.WindowSessionCount); err != nil {
+		return report, xerrors.Errorf("failed to aggregate trailing window activity: %w", err)
+	}
+
+	finishOperatorCost(&report)
+	return report, nil
+}
+
+func finishOperatorCost(report *apptypes.OperatorCostReport) {
+	report.ResidentBytesPerEvent = perUnit(report.ResidentBytes, report.EventCount)
+	report.ResidentBytesPerSession = perUnit(report.ResidentBytes, report.SessionCount)
+	report.UndiscardableBytesPerEvent = perUnit(report.UndiscardableSourceBytes, report.EventCount)
+	report.UndiscardableBytesPerSession = perUnit(report.UndiscardableSourceBytes, report.SessionCount)
+	if report.RetainedSourceBytes > 0 {
+		report.Amplification = float64(report.ResidentBytes) / float64(report.RetainedSourceBytes)
+	}
+	days := float64(report.WindowDays)
+	if days <= 0 {
+		days = float64(application.OperatorCostWindowDays)
+	}
+	report.EventsPerDay = float64(report.WindowEventCount) / days
+	report.SessionsPerDay = float64(report.WindowSessionCount) / days
+	if report.WindowEventCount > 0 {
+		report.ProjectedUndiscardableBytesPerMonth = int64(report.EventsPerDay * 30 * report.UndiscardableBytesPerEvent)
+	}
+	report.Evidence.Status = "complete"
+	report.Evidence.Method = "event_metadata_projection"
+}
+
+func perUnit(total, count int64) float64 {
+	if count <= 0 {
+		return 0
+	}
+	return float64(total) / float64(count)
+}

--- a/infrastructure/sqlite/operator_cost_test.go
+++ b/infrastructure/sqlite/operator_cost_test.go
@@ -1,0 +1,90 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestOperatorCostInspectorMeasuresProjectionAggregates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "operator-cost.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-24 * time.Hour).Format(time.RFC3339Nano)
+	old := now.AddDate(0, 0, -120).Format(time.RFC3339Nano)
+	statements := []string{
+		`CREATE TABLE event_metadata_projection (
+			id TEXT PRIMARY KEY,
+			kind TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			created_at_norm TEXT,
+			body_stored_bytes INTEGER
+		)`,
+		`CREATE TABLE session_refinements (session_id TEXT PRIMARY KEY)`,
+		`INSERT INTO event_metadata_projection VALUES ('e1', 'transcript', 's1', '` + recent + `', 2000)`,
+		`INSERT INTO event_metadata_projection VALUES ('e2', 'transcript', 's1', '` + old + `', 4000)`,
+		`INSERT INTO event_metadata_projection VALUES ('e3', 'prompt', 's2', '` + recent + `', 500)`,
+		`INSERT INTO session_refinements VALUES ('s1')`,
+	}
+	for i, statement := range statements {
+		if _, execErr := db.Exec(statement); execErr != nil {
+			t.Fatalf("exec fixture %d: %v", i, execErr)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := infra.NewOperatorCostInspector(infra.NewDatabase(path, nil)).InspectOperatorCost(context.Background(), now, 16500)
+	if err != nil {
+		t.Fatalf("InspectOperatorCost() error = %v", err)
+	}
+	if report.EventCount != 3 || report.SessionCount != 2 {
+		t.Fatalf("counts event=%d session=%d", report.EventCount, report.SessionCount)
+	}
+	if report.RetainedSourceBytes != 6500 || report.FoldableSourceBytes != 4000 || report.UndiscardableSourceBytes != 2500 {
+		t.Fatalf("bytes retained=%d foldable=%d undiscardable=%d", report.RetainedSourceBytes, report.FoldableSourceBytes, report.UndiscardableSourceBytes)
+	}
+	if report.WindowEventCount != 2 || report.WindowSessionCount != 2 {
+		t.Fatalf("window events=%d sessions=%d", report.WindowEventCount, report.WindowSessionCount)
+	}
+	if report.Evidence.Status != "complete" {
+		t.Fatalf("evidence = %+v", report.Evidence)
+	}
+	if report.ProjectedUndiscardableBytesPerMonth <= 0 {
+		t.Fatalf("projected = %d", report.ProjectedUndiscardableBytesPerMonth)
+	}
+	if diff := cmp.Diff("traceary.operator_cost/v1", report.SchemaVersion); diff != "" {
+		t.Fatalf("schema %s", diff)
+	}
+}
+
+func TestOperatorCostInspectorSkipsWithoutProjection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE sample (value TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	report, err := infra.NewOperatorCostInspector(infra.NewDatabase(path, nil)).InspectOperatorCost(context.Background(), time.Now().UTC(), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Evidence.Status != "skipped" {
+		t.Fatalf("evidence = %+v", report.Evidence)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -241,6 +241,7 @@ func run() error {
 		cli.WithReplay(replayUsecase),
 		cli.WithStoreManagement(storeManagementUsecase),
 		cli.WithCapacityInspector(sqlite.NewCapacityInspector(db)),
+		cli.WithOperatorCostInspector(sqlite.NewOperatorCostInspector(db)),
 		cli.WithPayloadCodecInspector(sqlite.NewPayloadCodecInspector(db)),
 		cli.WithAttestationAnchorInspector(sqlite.NewAttestationAnchorInspector(db)),
 		cli.WithSearchProjection(usecase.NewSearchProjectionUsecase(db)),

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -76,12 +77,13 @@ type doctorReport struct {
 	// large live store is deliberately not opened by the default doctor path:
 	// opening it can run migrations and content diagnostics that are neither
 	// necessary nor safe for a quick operator health check.
-	Mode     string          `json:"mode,omitempty"`
-	Checks   []doctorCheck   `json:"checks"`
-	Sections []doctorSection `json:"sections"`
-	Summary  doctorSummary   `json:"summary"`
-	ExitCode int             `json:"exit_code"`
-	Fixes    []doctorFixLog  `json:"fixes,omitempty"`
+	Mode         string                       `json:"mode,omitempty"`
+	OperatorCost *apptypes.OperatorCostReport `json:"operator_cost,omitempty"`
+	Checks       []doctorCheck                `json:"checks"`
+	Sections     []doctorSection              `json:"sections"`
+	Summary      doctorSummary                `json:"summary"`
+	ExitCode     int                          `json:"exit_code"`
+	Fixes        []doctorFixLog               `json:"fixes,omitempty"`
 }
 
 type doctorExitError struct {
@@ -285,11 +287,14 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 	snapshot := inspectStoreFileSnapshot(resolvedDBPath, os.Stat)
 	if isLargeStoreForBoundedDoctor(snapshot) {
 		report.Mode = doctorModeMetadataOnlyLargeStore
+		residentCost := residentOnlyOperatorCost(snapshot.Size)
+		report.OperatorCost = &residentCost
 		report.Checks = append(report.Checks, unknownStoreGrowthCheck(snapshot.Size, resolvedDBPath, "default doctor is filesystem-metadata-only for stores at or above 2 GiB; inspect a reviewed copy for detailed signals"))
 		// Sibling rollback copies are a directory listing only; they do not
 		// open SQLite. Large stores are the ones most likely to still hold
 		// a source-sized rollback inode (#1827).
 		report.Checks = append(report.Checks, inspectCompactRollbackCopies(resolvedDBPath))
+		report.Checks = append(report.Checks, buildOperatorCostCheck(residentCost))
 		report.Checks = append(report.Checks, inspectTracearyOnPath())
 		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(snapshot, resolvedDBPath))
 		if c.attestationAnchorInspector != nil {
@@ -333,6 +338,13 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		report.Checks = append(report.Checks, c.inspectSensitiveAccessAuditCoverage(ctx))
 		if c.attestationAnchorInspector != nil {
 			report.Checks = append(report.Checks, c.inspectAttestationAnchor(ctx, resolvedDBPath, true))
+		}
+		if c.operatorCostInspector != nil {
+			cost, costCheck := c.inspectOperatorCost(ctx, snapshot.Size)
+			if cost.SchemaVersion != "" {
+				report.OperatorCost = &cost
+			}
+			report.Checks = append(report.Checks, costCheck)
 		}
 	}
 

--- a/presentation/cli/doctor_operator_cost.go
+++ b/presentation/cli/doctor_operator_cost.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+const doctorOperatorCostTimeout = 2 * time.Second
+
+func (c *RootCLI) inspectOperatorCost(ctx context.Context, residentBytes int64) (apptypes.OperatorCostReport, doctorCheck) {
+	const name = "store-operator-cost"
+	if c.operatorCostInspector == nil {
+		return apptypes.OperatorCostReport{}, doctorCheck{
+			Name:    name,
+			Status:  doctorStatusSkip,
+			Message: Localize("operator cost inspector is not configured", "operator cost inspector が設定されていません"),
+		}
+	}
+	inspectCtx, cancel := context.WithTimeout(ctx, doctorOperatorCostTimeout)
+	defer cancel()
+	report, err := c.operatorCostInspector.InspectOperatorCost(inspectCtx, time.Now().UTC(), residentBytes)
+	if err != nil {
+		return apptypes.OperatorCostReport{}, doctorCheck{
+			Name:    name,
+			Status:  doctorStatusWarn,
+			Message: localizef("failed to measure operator store cost: %v", "operator のストアコストを計測できません: %v", err),
+		}
+	}
+	return report, buildOperatorCostCheck(report)
+}
+
+func residentOnlyOperatorCost(residentBytes int64) apptypes.OperatorCostReport {
+	return apptypes.OperatorCostReport{
+		SchemaVersion: "traceary.operator_cost/v1",
+		WindowDays:    30,
+		ResidentBytes: residentBytes,
+		Evidence: apptypes.OperatorCostEvidence{
+			Status: "skipped",
+			Method: "filesystem",
+			Reason: "default doctor is filesystem-metadata-only for stores at or above 2 GiB",
+		},
+	}
+}
+
+func buildOperatorCostCheck(report apptypes.OperatorCostReport) doctorCheck {
+	const name = "store-operator-cost"
+	if report.Evidence.Status == "skipped" {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorStatusSkip,
+			Message: localizef(
+				"operator store cost is incomplete (%s): resident=%s",
+				"operator のストアコストは不完全です (%s): resident=%s",
+				report.Evidence.Reason,
+				formatByteSize(report.ResidentBytes),
+			),
+			Hint: Localize(
+				"Detailed per-event and rate figures need a store under 2 GiB, or a reviewed copy. This is this store's measured size, not a project-wide monthly claim.",
+				"イベントあたりとレートの詳細は 2 GiB 未満のストア、または確認済みコピーが必要です。これはこのストアの実測であり、プロジェクト全体の月次主張ではありません。",
+			),
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorStatusPass,
+		Message: localizef(
+			"this store: resident=%s (%s/event, %s/session) undiscardable=%s/event amplification=%.2fx rate=%.1f events/day projected undiscardable ~%s/month",
+			"このストア: resident=%s（%s/event、%s/session）undiscardable=%s/event amplification=%.2fx rate=%.1f events/day 予測 undiscardable 約%s/月",
+			formatByteSize(report.ResidentBytes),
+			formatByteSize(int64(report.ResidentBytesPerEvent)),
+			formatByteSize(int64(report.ResidentBytesPerSession)),
+			formatByteSize(int64(report.UndiscardableBytesPerEvent)),
+			report.Amplification,
+			report.EventsPerDay,
+			formatByteSize(report.ProjectedUndiscardableBytesPerMonth),
+		),
+		Hint: Localize(
+			"These figures are measured from this store. They are not a global monthly bound.",
+			"これらの数値はこのストアの実測です。グローバルな月次上限ではありません。",
+		),
+	}
+}

--- a/presentation/cli/doctor_operator_cost_test.go
+++ b/presentation/cli/doctor_operator_cost_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestBuildOperatorCostCheckReportsThisStore(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	check := buildOperatorCostCheck(apptypes.OperatorCostReport{
+		ResidentBytes:                       7360,
+		ResidentBytesPerEvent:               7360,
+		ResidentBytesPerSession:             41700,
+		UndiscardableBytesPerEvent:          2670,
+		Amplification:                       2.55,
+		EventsPerDay:                        10000,
+		ProjectedUndiscardableBytesPerMonth: 800 << 20,
+		Evidence:                            apptypes.OperatorCostEvidence{Status: "complete"},
+	})
+	if check.Name != "store-operator-cost" || check.Status != doctorStatusPass {
+		t.Fatalf("check = %#v", check)
+	}
+	if !strings.Contains(check.Message, "this store") || strings.Contains(strings.ToLower(check.Message), "0.5 gib") {
+		t.Fatalf("message = %q", check.Message)
+	}
+	if !strings.Contains(check.Hint, "this store") {
+		t.Fatalf("hint = %q", check.Hint)
+	}
+}
+
+func TestResidentOnlyOperatorCostDoesNotOpenStore(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	report := residentOnlyOperatorCost(3 << 30)
+	check := buildOperatorCostCheck(report)
+	if check.Status != doctorStatusSkip {
+		t.Fatalf("check = %#v", check)
+	}
+	if report.EventCount != 0 || report.Evidence.Method != "filesystem" {
+		t.Fatalf("report = %+v", report)
+	}
+}

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -21,14 +21,23 @@ import (
 )
 
 type doctorReport struct {
-	DBPath   string          `json:"db_path"`
-	Clients  []string        `json:"clients"`
-	Mode     string          `json:"mode"`
-	Checks   []doctorCheck   `json:"checks"`
-	Sections []doctorSection `json:"sections"`
-	Summary  doctorSummary   `json:"summary"`
-	ExitCode int             `json:"exit_code"`
-	Fixes    []doctorFixLog  `json:"fixes"`
+	DBPath       string                       `json:"db_path"`
+	Clients      []string                     `json:"clients"`
+	Mode         string                       `json:"mode"`
+	OperatorCost *apptypes.OperatorCostReport `json:"operator_cost"`
+	Checks       []doctorCheck                `json:"checks"`
+	Sections     []doctorSection              `json:"sections"`
+	Summary      doctorSummary                `json:"summary"`
+	ExitCode     int                          `json:"exit_code"`
+	Fixes        []doctorFixLog               `json:"fixes"`
+}
+
+type operatorCostInspectorStub struct {
+	report apptypes.OperatorCostReport
+}
+
+func (s operatorCostInspectorStub) InspectOperatorCost(context.Context, time.Time, int64) (apptypes.OperatorCostReport, error) {
+	return s.report, nil
 }
 
 type panicCapacityInspector struct{ calls int }
@@ -581,6 +590,50 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 	rollback := statusByName(report, "compact-rollback-copy")
 	if rollback.Status != "warn" || !strings.Contains(rollback.Message, rollbackPath) {
 		t.Fatalf("compact-rollback-copy = %#v, want warn naming %s", rollback, rollbackPath)
+	}
+	cost := statusByName(report, "store-operator-cost")
+	if cost.Status != "skip" || report.OperatorCost == nil || report.OperatorCost.ResidentBytes != 2<<30 {
+		t.Fatalf("operator cost = %#v report=%+v", cost, report.OperatorCost)
+	}
+}
+
+func TestRootCLI_DoctorJSONIncludesOperatorCost(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	stub := operatorCostInspectorStub{report: apptypes.OperatorCostReport{
+		SchemaVersion:                       "traceary.operator_cost/v1",
+		WindowDays:                          30,
+		ResidentBytes:                       1000,
+		EventCount:                          10,
+		SessionCount:                        2,
+		UndiscardableSourceBytes:            400,
+		FoldableSourceBytes:                 100,
+		Amplification:                       2,
+		EventsPerDay:                        1,
+		ProjectedUndiscardableBytesPerMonth: 1200,
+		Evidence:                            apptypes.OperatorCostEvidence{Status: "complete", Method: "event_metadata_projection"},
+	}}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithOperatorCostInspector(stub),
+	).Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", dbPath, "--json", "--warnings-ok"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	report := decodeDoctorReport(t, stdout.Bytes())
+	if report.OperatorCost == nil || report.OperatorCost.SchemaVersion != "traceary.operator_cost/v1" {
+		t.Fatalf("operator_cost = %+v", report.OperatorCost)
+	}
+	if report.OperatorCost.EventCount != 10 || report.OperatorCost.Amplification != 2 {
+		t.Fatalf("operator_cost = %+v", report.OperatorCost)
+	}
+	check := statusByName(report, "store-operator-cost")
+	if check.Status != "pass" || !strings.Contains(check.Message, "this store") {
+		t.Fatalf("check = %#v", check)
 	}
 }
 

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -599,6 +599,11 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 
 func TestRootCLI_DoctorJSONIncludesOperatorCost(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
+	setTracearyPathToCurrentExecutable(t)
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
 	stub := operatorCostInspectorStub{report: apptypes.OperatorCostReport{
 		SchemaVersion:                       "traceary.operator_cost/v1",
@@ -621,9 +626,7 @@ func TestRootCLI_DoctorJSONIncludesOperatorCost(t *testing.T) {
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{"doctor", "--db-path", dbPath, "--json", "--warnings-ok"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
-	}
+	executeDoctorAllowWarnings(t, rootCmd)
 	report := decodeDoctorReport(t, stdout.Bytes())
 	if report.OperatorCost == nil || report.OperatorCost.SchemaVersion != "traceary.operator_cost/v1" {
 		t.Fatalf("operator_cost = %+v", report.OperatorCost)

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -42,6 +42,7 @@ type RootCLI struct {
 	replay                     usecase.ReplayUsecase
 	storeManagement            usecase.StoreManagementUsecase
 	capacityInspector          application.CapacityInspector
+	operatorCostInspector      application.OperatorCostInspector
 	payloadCodecInspector      application.PayloadCodecInspector
 	attestationAnchorInspector application.AttestationAnchorInspector
 	searchProjection           *usecase.SearchProjectionUsecase
@@ -227,6 +228,11 @@ func WithStoreManagement(storeManagement usecase.StoreManagementUsecase) RootCLI
 // WithCapacityInspector injects metadata-only SQLite capacity diagnostics.
 func WithCapacityInspector(inspector application.CapacityInspector) RootCLIOption {
 	return func(c *RootCLI) { c.capacityInspector = inspector }
+}
+
+// WithOperatorCostInspector injects this-store measured cost for doctor.
+func WithOperatorCostInspector(inspector application.OperatorCostInspector) RootCLIOption {
+	return func(c *RootCLI) { c.operatorCostInspector = inspector }
 }
 
 // WithPayloadCodecInspector injects read-only payload representation status.


### PR DESCRIPTION
## Summary
- `traceary doctor` (already aliased as `status`) reports this store's measured cost. `store capacity` stays dbstat-only.
- JSON adds `operator_cost` (`traceary.operator_cost/v1`) and check `store-operator-cost`: resident bytes per event/session, undiscardable vs foldable source-text (projection + refinements, no body reads), amplification, and a monthly projection from the last 30 days of *this* store's rate.
- Stores ≥ 2 GiB stay metadata-only (resident file size only). No new command.

## Non-goals
- Does not open a ≥ 2 GiB store.
- Does not publish a global monthly bound.
- Leaves parent #1904 open.

## Test plan
- [x] `go test ./infrastructure/sqlite -run TestOperatorCost`
- [x] `go test ./presentation/cli -run 'TestBuildOperatorCost|TestResidentOnly|TestRootCLI_DoctorJSONIncludesOperatorCost|TestRootCLI_DoctorLargeStoreReturnsBounded'`
- [x] `go tool golangci-lint run ./application/... ./infrastructure/sqlite/ ./presentation/cli/ .`

Closes #1809
