### PR TITLE
docs: establish what failed=1 means and keep list --failures

### DIFF
--- a/.ai/spec/1767.md
+++ b/.ai/spec/1767.md
@@ -1,0 +1,26 @@
+# #1767: what `failed=1` means
+
+## Policy
+
+- Keep `list --failures`. It is a 記録 surface, not a `doctor` diagnostic.
+- Do not add a CHECK that forbids `failed=1 AND failure_reason='unknown'`. Restore must keep pre-classifier rows.
+- New writes never persist that pair. `ClassifyOutcome` upgrades `unknown` + structural failure to `host_error`. Hook `Failed` is `failureReason.IsFailure()`.
+
+## Answers (source only; no live store)
+
+1. `unknown` + `failed=1` is the `000025` DEFAULT leaking onto rows flagged by `hookPayloadFailed` before `11691479` (2026-07-22).
+2. That commit + `b1daa0e7` (same day) are the 2026-07-21/24 cut. Current hook writes cannot produce the pair. Restore/snapshot still can.
+3. Current `host_error` is hook `PostToolUseFailure` / structured host error (Claude top-level `error`, Gemini `tool_response.error`). Codex has no structured failure field. Grok `PermissionDenied` is `hook_denied`.
+4. Those rows are host-reported tool failures the operator asked to record. Keep `--failures`.
+5. No new CHECK. Domain write path already forbids unclassified new failures.
+
+## I/O
+
+- Docs: `docs/research/failed-flag-meaning.md` (+ `.ja.md`), storage + CLI pairs.
+- Tests drive real `hook audit` + `list --failures` on a scratch SQLite file.
+
+## Non-goals
+
+- Removing or deprecating `list --failures`.
+- Querying the live store.
+- Rewriting historical `unknown` rows.

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Changed
+- **`failed=1` は構造化失敗であり `list --failures` は残す (#1767)** — 現行書き込みはフラグを `failure_reason.IsFailure()` から立て、hook の構造化失敗を `host_error` として保存する。分類器以前の `unknown`+`failed=1` は読める。新しい CHECK は足さない。`docs/research/failed-flag-meaning.ja.md` を参照。
 - **compact の rollback copy は operator が消すまで残る (#1827)** — apply 時の `VerifyPair` は実使用の証明ではない。成功 JSON は `rollback_retained: true` と `rollback_path` を出す。`doctor` は隣の `<db>.rollback-*` を報告する。release サブコマンドは追加しない。
 - **hook 以外の Ctrl-C が command context を cancel する (#1747)** — `store compact` など長い非 hook コマンドは signal 由来の context を使う（hook の soft deadline は付けない）。2 回目の Ctrl-C は即終了。`memory inbox review` の SIGINT はこれまでどおり Bubble Tea が持つ。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Changed
+- **`failed=1` is structured failure; `list --failures` stays (#1767)** — current writes derive the flag from `failure_reason.IsFailure()` and store hook structural failures as `host_error`. Pre-classifier `unknown`+`failed=1` rows remain readable. No new CHECK. See `docs/research/failed-flag-meaning.md`.
 - **Compaction rollback copy stays until the operator deletes it (#1827)** — apply-time `VerifyPair` is not in-use proof. Success JSON includes `rollback_retained: true` and the named `rollback_path`. `doctor` reports leftover `<db>.rollback-*` siblings. No release subcommand.
 - **Ctrl-C cancels non-hook command contexts (#1747)** — `store compact` and other long-running non-hook commands receive a signal-derived context (no hook soft deadline). A second Ctrl-C hard-kills. `memory inbox review` still lets Bubble Tea own SIGINT.
 

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -113,6 +113,7 @@ subcommand なしの `traceary` は TTY / 非 TTY とも常に help を表示し
 - `--from` / `--since`
 - `--to` / `--until`
 - `--timezone`
+- `--failures` — この 記録 フィルタは残す。`command_audits.failed = 1` または取得済みの非ゼロ `exit_code` に一致する。現行の書き込みは構造化された host のツール失敗を `unknown` ではなく `host_error` として保存する。分類器以前の `unknown`+`failed=1` はフラグ側で一致する。意味は [failed-flag の意味](../research/failed-flag-meaning.ja.md) を見てください。
 
 ### `traceary tail`
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -113,6 +113,7 @@ Useful flags:
 - `--from` / `--since`
 - `--to` / `--until`
 - `--timezone`
+- `--failures` — keep this 記録 filter. It matches `command_audits.failed = 1` or a captured non-zero `exit_code`. Current writes store structured host tool failures as `host_error` (not `unknown`). Pre-classifier `unknown`+`failed=1` rows still match the flag half. See [failed-flag meaning](../research/failed-flag-meaning.md).
 
 ### `traceary tail`
 

--- a/docs/research/failed-flag-meaning.ja.md
+++ b/docs/research/failed-flag-meaning.ja.md
@@ -1,0 +1,61 @@
+# 決定: `failed=1` の意味 (#1767)
+
+[English](./failed-flag-meaning.md)
+
+**Status:** 決定済み。`list --failures` は残す。
+
+**Date:** 2026-08-15
+
+**Issue:** #1767
+
+## 決定
+
+`command_audits.failed = 1` は、構造化されたコマンド失敗の互換フラグです。現行の書き込み経路では `failure_reason.IsFailure()` から導出し、独立には立てません。`list --failures`（および `search` / `tail` の同じ述語）は `failed = 1` **または** 取得済みの非ゼロ `exit_code` に一致します。host は今もほぼ exit code を出さないため、生きている面はフラグ側です。
+
+この面は残します。`doctor` には移しません。`failed=1 AND failure_reason='unknown'` を禁じる CHECK は追加しません。restore が分類器以前の行を保持する必要があるためです。新規書き込みはその組を保存できません。
+
+## 回答
+
+### 1. `unknown` は分類器以前の行に漏れた schema default か
+
+はい。migration `000025_normalize_command_audits.sql` が `failure_reason TEXT NOT NULL DEFAULT 'unknown'` を足しました。`11691479`（2026-07-22, `feat: normalize command audit outcomes`）より前は、hook audit が `Failed` を `hookPayloadFailed` から立て、reason を分類しなかったので DEFAULT が載りました。その commit 以降、構造化された hook 失敗は `host_error` です。同日の `b1daa0e7` が `Failed` を `failureReason.IsFailure()` にしたので、フラグと reason は揃います。
+
+`unknown` 自体は失敗理由ではありません。`CommandFailureReason.IsFailure()` は `unknown` と `none` で false です。
+
+### 2. 2026-07-21/24 前後に何が変わり、今も `unknown` + `failed=1` は書けるか
+
+分類器は 2026-07-22 に入りました。その直前で `unknown`+`failed=1` が止まり、直後から `host_error` が始まる live corpus は upgrade 窓であり、共存する二種類の失敗ではありません。
+
+現行の書き込みはその組を残せません。
+
+- `hookPayloadFailureReason`: 構造化 host error → `host_error`。根拠なし → `unknown` かつ `Failed=false`。
+- `ClassifyOutcome`: `unknown` + 構造化失敗かつ exit code なし → `host_error`。
+- restore（`CommandAuditFromSnapshot`）だけが `unknown` + `failed=true` を受け付けるので、履歴行は読めます。
+
+### 3. 現行の `host_error` はどこから来るか
+
+仕組みは一つ、host は複数、常に `client=hook` です。
+
+| Host | 構造化シグナル | Reason |
+|---|---|---|
+| Claude Code | `PostToolUseFailure` のトップレベル `error` | `host_error` |
+| Gemini CLI | `tool_response.error`（spawn/OS のみ。単なる非ゼロ shell exit は出ない） | `host_error` |
+| Codex | 構造化失敗フィールドなし | フラグされない |
+| Grok | `PermissionDenied` / 厳密な `🚫 [hook]` marker | `hook_denied`（`host_error` ではない） |
+| Interrupt / timeout marker | `is_interrupt`, `timed_out`, … | `signal` / `timeout` |
+
+これはソース契約であり、live store の件数ではありません。
+
+### 4. operator はこれらを `list --failures` で見たいか
+
+はい。`host_error` は host が報告したツール失敗（Claude の `PostToolUseFailure`、Gemini の spawn error）です。これは 記録であり、`hook_denied` / `signal` / `timeout` / `exit_code` と同じクラスです。`doctor` には retry-loop 診断が既にあり、`--failures` を doctor に畳むと audit trail が隠れます。分類器以前の `unknown`+`failed=1` は述語の `failed=1` 側で見えます。
+
+### 5. 未分類失敗を不可能にする CHECK を足すべきか
+
+いいえ。既存 CHECK は許可する reason 文字列を列挙しています。`NOT (failed = 1 AND failure_reason = 'unknown')` のような制約は履歴行の restore を拒否します。書き込み経路は未分類の構造化失敗を既に `host_error` へ上げます。
+
+## 対象外
+
+- `list --failures` の削除・非推奨化
+- live store の照会や書き換え
+- 履歴の `unknown` 行を `host_error` へ backfill すること

--- a/docs/research/failed-flag-meaning.md
+++ b/docs/research/failed-flag-meaning.md
@@ -1,0 +1,61 @@
+# Decision: what `failed=1` means (#1767)
+
+[日本語](./failed-flag-meaning.ja.md)
+
+**Status:** decided. `list --failures` stays.
+
+**Date:** 2026-08-15
+
+**Issue:** #1767
+
+## Decision
+
+`command_audits.failed = 1` is a compatibility flag for structured command failure. On the current write path it is derived from `failure_reason.IsFailure()` and is never set independently. `list --failures` (and the same predicate on `search` / `tail`) matches `failed = 1` **or** a captured non-zero `exit_code`. Hosts still almost never report exit codes, so the flag half is the live surface.
+
+Keep that surface. Do not move it into `doctor`. Do not add a CHECK that forbids `failed=1 AND failure_reason='unknown'`: restore must keep pre-classifier rows. New writes already cannot persist that pair.
+
+## Answers
+
+### 1. Is `unknown` the schema default leaking onto pre-classifier rows?
+
+Yes. Migration `000025_normalize_command_audits.sql` added `failure_reason TEXT NOT NULL DEFAULT 'unknown'`. Before `11691479` (2026-07-22, `feat: normalize command audit outcomes`), hook audits set `Failed` from `hookPayloadFailed` and did not classify a reason, so the DEFAULT landed on those rows. After that commit, a structural hook failure is `host_error`. `b1daa0e7` (same day) set `Failed` from `failureReason.IsFailure()`, so the flag and the reason stay aligned.
+
+`unknown` itself is not a failure reason: `CommandFailureReason.IsFailure()` is false for `unknown` and `none`.
+
+### 2. What changed around 2026-07-21/24, and can anything still write `unknown` with `failed=1`?
+
+The classifier landed on 2026-07-22. A live corpus that stops writing `unknown`+`failed=1` just before that date and starts writing `host_error` just after is the upgrade window, not two coexisting kinds of failure.
+
+Current writes cannot persist the pair:
+
+- `hookPayloadFailureReason`: structured host error → `host_error`; no evidence → `unknown` with `Failed=false`.
+- `ClassifyOutcome`: `unknown` + structural failure and no exit code → `host_error`.
+- Restore (`CommandAuditFromSnapshot`) is the only path that still accepts `unknown` + `failed=true`, so historical rows remain readable.
+
+### 3. Where does current `host_error` come from?
+
+One mechanism, several hosts, always `client=hook`:
+
+| Host | Structured signal | Reason |
+|---|---|---|
+| Claude Code | top-level `error` on `PostToolUseFailure` | `host_error` |
+| Gemini CLI | `tool_response.error` (spawn/OS-level only; a plain non-zero shell exit is not reported) | `host_error` |
+| Codex | no structured failure field | not flagged |
+| Grok | `PermissionDenied` / exact `🚫 [hook]` marker | `hook_denied`, not `host_error` |
+| Interrupt / timeout markers | `is_interrupt`, `timed_out`, … | `signal` / `timeout` |
+
+This is source contract, not a live-store count.
+
+### 4. Does the operator want these rows on `list --failures`?
+
+Yes. `host_error` is a host-reported tool failure (Claude `PostToolUseFailure`, Gemini spawn error). That is 記録, the same class as `hook_denied` / `signal` / `timeout` / `exit_code`. `doctor` already has retry-loop diagnostics; folding `--failures` into doctor would hide the audit trail. Pre-classifier `unknown`+`failed=1` rows stay visible through the `failed=1` half of the predicate.
+
+### 5. Should `failure_reason` gain a CHECK that makes unclassified failure impossible?
+
+No. The existing CHECK already enumerates allowed reason strings. A new constraint such as `NOT (failed = 1 AND failure_reason = 'unknown')` would reject restore of historical rows. The write path already upgrades unclassified structural failure to `host_error`.
+
+## Non-goals
+
+- Removing or deprecating `list --failures`.
+- Querying or rewriting the live store.
+- Backfilling historical `unknown` rows to `host_error`.

--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -60,6 +60,8 @@ Traceary は、ローカル状態を 1 つの SQLite DB ファイルに保存し
 - `failed`: 構造化された実行結果から導出する互換用の失敗フラグ
 - `failure_reason`: `none`、`exit_code`、`signal`、`timeout`、`hook_denied`、`host_error`、`unknown` のいずれか
 
+新規書き込みの `failed` は `failure_reason.IsFailure()` から立てます。exit code のない構造化 hook 失敗は `unknown` ではなく `host_error` です。`failed=1` かつ `failure_reason=unknown` は分類器以前の履歴（2026-07-22 より前の schema default）で、restore は残し、新規書き込みは作れません。意味は [failed-flag の意味](../research/failed-flag-meaning.ja.md) を見てください。
+
 Traceary は確認済みのコマンド構造だけを正規化します。直接実行は先頭 token の basename を使い、wrapper として展開するのは観測済みの `rtk <command>` / `rtk proxy <command>` だけです。shell 文字列を実行したり完全評価したりはしません。取得済みの終了コード `0` は常に成功であり、input/output に `failed` のような文字列が含まれていても report の失敗には数えません。report 集計は payload 本文を解析しません。この schema より前の履歴行は、取得していない根拠を推測せず、`command_name=unknown` と `failure_reason=unknown` を明示します。
 
 `input_truncated` または `output_truncated` が true の場合、保存済み payload はすでに上限内の head/tail projection であり、新規 row では対応する `*_original_bytes` column に元の byte 数を記録します。検索 index は `command_text` / `input_text` / `output_text` を `events.body` と独立に持つため、合成 body を消しても audit テキストの検索性は失われません。切り詰められた byte は過去 row から復元できません。

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -60,6 +60,8 @@ Key columns:
 - `failed`: compatibility failure flag derived from structured outcome evidence
 - `failure_reason`: `none`, `exit_code`, `signal`, `timeout`, `hook_denied`, `host_error`, or `unknown`
 
+New writes set `failed` from `failure_reason.IsFailure()`. A structural hook failure with no exit code is stored as `host_error`, not as `unknown`. Rows with `failed=1` and `failure_reason=unknown` are pre-classifier history (schema default before 2026-07-22); restore keeps them, and new writes cannot create them. See [failed-flag meaning](../research/failed-flag-meaning.md).
+
 Traceary normalizes only command structure it has verified. Direct executables use the first token basename, and only the observed `rtk <command>` / `rtk proxy <command>` grammar is unwrapped. It never executes or fully evaluates the shell text. A captured exit code of `0` is authoritative success even if input/output text contains words such as `failed`; report aggregation never parses payload text. Historical rows created before this schema use explicit `command_name=unknown` and `failure_reason=unknown` rather than reconstructing evidence that was not captured.
 
 When `input_truncated` or `output_truncated` is true, the stored payload is already a bounded head/tail projection and the corresponding `*_original_bytes` column records the original size for new rows. Search indexes `command_text` / `input_text` / `output_text` independently of `events.body`, so clearing the composed body does not drop searchable audit text. The omitted truncated bytes are not recoverable from historical rows.

--- a/domain/model/command_audit_outcome_test.go
+++ b/domain/model/command_audit_outcome_test.go
@@ -24,6 +24,7 @@ func TestCommandAuditClassifyOutcome(t *testing.T) {
 		{name: "timeout", reported: types.CommandFailureReasonTimeout, wantReason: types.CommandFailureReasonTimeout, wantFailed: true},
 		{name: "hook denial", reported: types.CommandFailureReasonHookDenied, wantReason: types.CommandFailureReasonHookDenied, wantFailed: true},
 		{name: "generic structural failure", failed: true, wantReason: types.CommandFailureReasonHostError, wantFailed: true},
+		{name: "unclassified structural failure cannot stay unknown", reported: types.CommandFailureReasonUnknown, failed: true, wantReason: types.CommandFailureReasonHostError, wantFailed: true},
 		{name: "unreported outcome", wantReason: types.CommandFailureReasonUnknown},
 	}
 	for _, tc := range tests {

--- a/presentation/cli/failed_flag_meaning_test.go
+++ b/presentation/cli/failed_flag_meaning_test.go
@@ -1,0 +1,180 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+// TestRootCLI_ListFailuresKeepsStructuredAndLegacyFailedRows pins #1767:
+// list --failures stays, current hook writes persist host_error (not
+// unknown+failed), and restored pre-classifier unknown+failed rows still match.
+func TestRootCLI_ListFailuresKeepsStructuredAndLegacyFailedRows(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("session-failed-flag"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	eventDS := sqliteinfra.NewEventDatasource(db)
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	eventUC := usecase.NewEventUsecase(eventDS, eventDS)
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	hookCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeUC),
+		cli.WithEvent(eventUC),
+		cli.WithDatabasePathSetter(db.SetPath),
+	).Command()
+	hookCmd.SetOut(&bytes.Buffer{})
+	hookCmd.SetErr(&bytes.Buffer{})
+	hookCmd.SetIn(strings.NewReader(`{"tool_input":{"command":"go test ./..."},"error":"Exit code 7\nFAIL","is_interrupt":false}`))
+	hookCmd.SetArgs([]string{"hook", "audit", "claude", "--db-path", dbPath})
+	if err := hookCmd.Execute(); err != nil {
+		t.Fatalf("hook audit Execute() error = %v", err)
+	}
+
+	legacyAudit, err := model.CommandAuditFromSnapshot(model.CommandAuditSnapshot{
+		EventID:       "legacy-unknown-failed",
+		Command:       "legacy tool without classifier",
+		CommandName:   types.CommandNameUnknown,
+		Failed:        true,
+		FailureReason: types.CommandFailureReasonUnknown,
+	})
+	if err != nil {
+		t.Fatalf("CommandAuditFromSnapshot() error = %v", err)
+	}
+	legacyEvent := model.EventOf(
+		types.EventID("legacy-unknown-failed"),
+		types.EventKindCommandExecuted,
+		types.Client("hook"),
+		types.Agent("claude"),
+		types.SessionID("session-failed-flag"),
+		types.Workspace("github.com/duck8823/traceary"),
+		"legacy tool without classifier",
+		time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC),
+	)
+	if err := eventDS.SaveWithAudit(ctx, legacyEvent, legacyAudit); err != nil {
+		t.Fatalf("SaveWithAudit(legacy) error = %v", err)
+	}
+
+	successAudit, err := model.NewCommandAudit("success-ok", "echo ok", "", "ok", false, false)
+	if err != nil {
+		t.Fatalf("NewCommandAudit(success) error = %v", err)
+	}
+	if err := successAudit.ClassifyOutcome(types.Some(0), types.CommandFailureReasonNone, false); err != nil {
+		t.Fatalf("ClassifyOutcome(success) error = %v", err)
+	}
+	successEvent := model.EventOf(
+		types.EventID("success-ok"),
+		types.EventKindCommandExecuted,
+		types.Client("hook"),
+		types.Agent("claude"),
+		types.SessionID("session-failed-flag"),
+		types.Workspace("github.com/duck8823/traceary"),
+		"echo ok",
+		time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC),
+	)
+	if err := eventDS.SaveWithAudit(ctx, successEvent, successAudit); err != nil {
+		t.Fatalf("SaveWithAudit(success) error = %v", err)
+	}
+
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	var hookFailed int
+	var hookReason string
+	if err := sqlDB.QueryRowContext(
+		ctx,
+		`SELECT failed, failure_reason FROM command_audits WHERE command_text LIKE '%go test%'`,
+	).Scan(&hookFailed, &hookReason); err != nil {
+		t.Fatalf("query hook audit error = %v", err)
+	}
+	if hookFailed != 1 || hookReason != types.CommandFailureReasonHostError.String() {
+		t.Fatalf("current hook write = failed:%d reason:%q, want failed=1 host_error", hookFailed, hookReason)
+	}
+
+	var legacyFailed int
+	var legacyReason string
+	if err := sqlDB.QueryRowContext(
+		ctx,
+		`SELECT failed, failure_reason FROM command_audits WHERE event_id = 'legacy-unknown-failed'`,
+	).Scan(&legacyFailed, &legacyReason); err != nil {
+		t.Fatalf("query legacy audit error = %v", err)
+	}
+	if legacyFailed != 1 || legacyReason != types.CommandFailureReasonUnknown.String() {
+		t.Fatalf("legacy restore = failed:%d reason:%q, want failed=1 unknown", legacyFailed, legacyReason)
+	}
+
+	stdout := &bytes.Buffer{}
+	listCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeUC),
+		cli.WithEvent(eventUC),
+		cli.WithDatabasePathSetter(db.SetPath),
+	).Command()
+	listCmd.SetOut(stdout)
+	listCmd.SetErr(&bytes.Buffer{})
+	listCmd.SetArgs([]string{"list", "--failures", "--json", "--db-path", dbPath})
+	if err := listCmd.Execute(); err != nil {
+		t.Fatalf("list --failures Execute() error = %v", err)
+	}
+
+	var listed []struct {
+		EventID string `json:"event_id"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &listed); err != nil {
+		t.Fatalf("list --failures JSON = %s, unmarshal error = %v", stdout.String(), err)
+	}
+	got := map[string]bool{}
+	for _, row := range listed {
+		got[row.EventID] = true
+	}
+	if !got["legacy-unknown-failed"] {
+		t.Fatalf("list --failures omitted restored unknown+failed row; got %v", got)
+	}
+	if got["success-ok"] {
+		t.Fatalf("list --failures included success row; got %v", got)
+	}
+	hookListed := false
+	for id := range got {
+		if id != "legacy-unknown-failed" {
+			hookListed = true
+		}
+	}
+	if !hookListed {
+		t.Fatalf("list --failures omitted current host_error write; got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Decision from source (no live store): `failed=1` is the compatibility flag derived from structured `failure_reason`. Pre-classifier `unknown`+`failed=1` is the `000025` DEFAULT leaking onto `hookPayloadFailed` rows before `11691479` (2026-07-22). Current hook writes persist `host_error`.
- Keep `list --failures`. It is a 記録 surface (Claude `PostToolUseFailure` / Gemini spawn error / `hook_denied` / `signal` / `timeout`). Do not fold it into `doctor`.
- No new CHECK forbidding `failed=1 AND failure_reason='unknown'` — restore must keep historical rows.

## Non-goals
- Does not remove or deprecate `list --failures`.
- Does not query or rewrite the live store.
- Does not backfill historical `unknown` rows.
- Leaves parent #1904 open.

## Test plan
- [x] `go test ./domain/model -run 'TestCommandAuditClassifyOutcome|TestCommandAuditFromSnapshotPreservesLegacy'`
- [x] `go test ./presentation/cli -run TestRootCLI_ListFailuresKeepsStructuredAndLegacyFailedRows`
- [x] `go tool golangci-lint run`

Closes #1767
