### PR TITLE
fix: do not gate structural search on the literal projection

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,11 @@
 このファイルは、Traceary の各リリースで何が入ったかを時系列で追いやすくするための changelog です。  
 release note と同じ粒度で、版ごとの要点だけをまとめています。
 
+## [Unreleased]
+
+### Fixed
+- **空クエリの structural search を literal projection の状態で拒否しない (#1736)** — workspace / session / kind / time のフィルタは、literal generation が rebuilding / failed / drifted でも正本テーブルに対して動きます。無効な offset / limit / from-to はこれまでどおり fail-closed です。非空クエリは generation が使えないとき decode walk に fail-open します。
+
 ## [v0.36.0] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 This file summarizes what changed in each Traceary release in chronological order.
 It mirrors the same level of detail as the GitHub release notes, but keeps the history in the repository.
 
+## [Unreleased]
+
+### Fixed
+- **Structural (empty-query) search is not gated on the literal projection (#1736)** — workspace, session, kind, and time filters run against canonical tables even while the literal generation is rebuilding, failed, or drifted. Invalid offset, limit, and from/to still fail closed. Non-empty queries still fail open onto a decode walk when the generation is unusable.
+
 ## [v0.36.0] - 2026-08-15
 
 ### Added

--- a/infrastructure/sqlite/event_search_authority.go
+++ b/infrastructure/sqlite/event_search_authority.go
@@ -77,11 +77,16 @@ func (d *EventDatasource) searchFullByPersistedAuthority(ctx context.Context, cr
 }
 
 func (d *EventDatasource) searchTieredMetadataTx(ctx context.Context, tx *sql.Tx, criteria apptypes.EventSearchCriteria) ([]apptypes.EventMetadata, error) {
-	if criteria.Offset() < 0 {
-		return nil, xerrors.New("offset must be greater than or equal to 0")
+	// Shared criteria sanity (offset, limit, from/to, page window) is not a
+	// projection-coherence check. Structural empty-query searches still refuse
+	// these; they must not refuse because the literal generation is unusable.
+	if err := validateSearchCriteriaForAuthority(criteria); err != nil {
+		return nil, err
 	}
-	// Empty queries are structural-only searches. They never traverse the
-	// literal projection, so they are answered before its state is even read.
+	// Empty queries are structural-only searches. They filter workspace,
+	// session, kind, and time on canonical tables and never read
+	// literal_search_fingerprints or search_projection_source_sequence, so
+	// they are answered before projection state is even consulted.
 	if strings.TrimSpace(criteria.Query()) == "" {
 		candidateIDs, queryErr := queryStructuralEventIDs(ctx, tx, criteria)
 		if queryErr != nil {

--- a/infrastructure/sqlite/event_search_authority_internal_test.go
+++ b/infrastructure/sqlite/event_search_authority_internal_test.go
@@ -16,6 +16,7 @@ import (
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
 )
 
 // seedTieredCompleteProjection freezes a complete generation at the current
@@ -80,6 +81,11 @@ func seedLiteralFingerprints(t *testing.T, database *Database, generation, event
 
 func insertTieredSearchEvent(t *testing.T, database *Database, id, body string, at time.Time) {
 	t.Helper()
+	insertTieredSearchEventInWorkspace(t, database, id, "w", body, at)
+}
+
+func insertTieredSearchEventInWorkspace(t *testing.T, database *Database, id, workspace, body string, at time.Time) {
+	t.Helper()
 	ctx := context.Background()
 	raw, err := database.open(ctx)
 	if err != nil {
@@ -88,8 +94,8 @@ func insertTieredSearchEvent(t *testing.T, database *Database, id, body string, 
 	defer func() { _ = raw.Close() }()
 	if _, err = raw.ExecContext(ctx, `
 		INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at)
-		VALUES (?, 'note', 'codex', 'codex', 's', 'w', ?, ?)`,
-		id, body, at.UTC().Format(time.RFC3339Nano),
+		VALUES (?, 'note', 'codex', 'codex', 's', ?, ?, ?)`,
+		id, workspace, body, at.UTC().Format(time.RFC3339Nano),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -363,6 +369,160 @@ func TestLiteralFingerprintCascadeSurvivesCandidateIndexDrop(t *testing.T) {
 	}
 	if diff := cmp.Diff(0, orphaned); diff != "" {
 		t.Fatalf("cascade left fingerprints behind (-want +got):\n%s", diff)
+	}
+}
+
+// TestTieredAuthorityStructuralSearchIgnoresLiteralProjectionState is #1736:
+// an empty-query (structural) search must succeed while the literal
+// generation is in a state that used to refuse with "incomplete or stale".
+// queryStructuralEventIDs reads events + command_audits only, so it does not
+// need a coherent projection generation.
+func TestTieredAuthorityStructuralSearchIgnoresLiteralProjectionState(t *testing.T) {
+	ctx := context.Background()
+	workspace, err := domtypes.WorkspaceFrom("keep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Workspace(workspace).Build()
+	want := []string{"keep-new", "keep-old"}
+	base := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, database *Database)
+	}{
+		{
+			name: "literal projection rebuilding",
+			setup: func(t *testing.T, database *Database) {
+				seedStructuralSearchFixture(t, database, base)
+				forceLiteralProjectionState(t, database, "rebuilding")
+			},
+		},
+		{
+			name: "literal projection stale",
+			setup: func(t *testing.T, database *Database) {
+				seedStructuralSearchFixture(t, database, base)
+				forceLiteralProjectionState(t, database, "stale")
+			},
+		},
+		{
+			name: "literal projection missing",
+			setup: func(t *testing.T, database *Database) {
+				seedStructuralSearchFixture(t, database, base)
+				forceLiteralProjectionState(t, database, "missing")
+			},
+		},
+		{
+			name: "literal generation empty",
+			setup: func(t *testing.T, database *Database) {
+				seedStructuralSearchFixture(t, database, base)
+				raw, openErr := database.open(ctx)
+				if openErr != nil {
+					t.Fatal(openErr)
+				}
+				defer func() { _ = raw.Close() }()
+				if _, execErr := raw.ExecContext(ctx, `UPDATE literal_search_projection_state SET generation_id='' WHERE singleton=1`); execErr != nil {
+					t.Fatal(execErr)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			database, datasource := newTieredAuthorityFixture(t)
+			tc.setup(t, database)
+
+			got, searchErr := datasource.SearchMetadata(ctx, criteria)
+			if searchErr != nil {
+				t.Fatalf("SearchMetadata() error = %v, want structural matches while literal is unusable", searchErr)
+			}
+			if diff := cmp.Diff(want, metadataIDs(got)); diff != "" {
+				t.Fatalf("SearchMetadata() IDs mismatch (-want +got):\n%s", diff)
+			}
+
+			full, pageErr := datasource.SearchPage(ctx, criteria)
+			if pageErr != nil {
+				t.Fatalf("SearchPage() error = %v, want structural matches while literal is unusable", pageErr)
+			}
+			if diff := cmp.Diff(want, eventIDs(full)); diff != "" {
+				t.Fatalf("SearchPage() IDs mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestTieredAuthorityStructuralSearchRefusesInvalidCriteria is the fail-closed
+// half of #1736: structural searches still reject criteria that are invalid
+// on their own. They must not start returning rows for these.
+func TestTieredAuthorityStructuralSearchRefusesInvalidCriteria(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	from := base.Add(time.Hour)
+	to := base
+
+	tests := []struct {
+		name     string
+		criteria apptypes.EventSearchCriteria
+		wantErr  string
+	}{
+		{
+			name:     "negative offset",
+			criteria: apptypes.NewEventSearchCriteriaBuilder(10).Offset(-1).Build(),
+			wantErr:  "offset must be greater than or equal to 0",
+		},
+		{
+			name:     "non-positive limit",
+			criteria: apptypes.NewEventSearchCriteriaBuilder(0).Build(),
+			wantErr:  "limit must be greater than or equal to 1",
+		},
+		{
+			name:     "from after to",
+			criteria: apptypes.NewEventSearchCriteriaBuilder(10).From(from).To(to).Build(),
+			wantErr:  "from must be earlier than to",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			database, datasource := newTieredAuthorityFixture(t)
+			seedStructuralSearchFixture(t, database, base)
+			forceLiteralProjectionState(t, database, "rebuilding")
+
+			_, searchErr := datasource.SearchMetadata(ctx, tc.criteria)
+			if searchErr == nil {
+				t.Fatal("SearchMetadata() error = nil, want invalid-criteria refusal")
+			}
+			if !strings.Contains(searchErr.Error(), tc.wantErr) {
+				t.Fatalf("SearchMetadata() error = %v, want substring %q", searchErr, tc.wantErr)
+			}
+			if strings.Contains(searchErr.Error(), "incomplete or stale") {
+				t.Fatalf("structural refusal must not mention projection availability: %v", searchErr)
+			}
+		})
+	}
+}
+
+func seedStructuralSearchFixture(t *testing.T, database *Database, base time.Time) {
+	t.Helper()
+	insertTieredSearchEventInWorkspace(t, database, "keep-old", "keep", "alpha", base)
+	insertTieredSearchEventInWorkspace(t, database, "other-ws", "other", "beta", base.Add(time.Second))
+	insertTieredSearchEventInWorkspace(t, database, "keep-new", "keep", "gamma", base.Add(2*time.Second))
+	seedTieredCompleteProjection(t, database, "gen-structural")
+}
+
+func forceLiteralProjectionState(t *testing.T, database *Database, state string) {
+	t.Helper()
+	ctx := context.Background()
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err = raw.ExecContext(ctx, `UPDATE literal_search_projection_state SET state=? WHERE singleton=1`, state); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1736

Leaves parent #1905 open.

Empty-query (structural) search already ran against canonical `events` / `command_audits` and never read `literal_search_fingerprints`. This PR pins that contract and applies the same criteria sanity checks (offset, limit, from/to, page window) before the structural branch so invalid criteria still fail closed.

## Design note

- **Requirement:** a structural search under `authority='tiered'` must succeed while the literal generation is rebuilding / stale / missing / empty. It must still refuse invalid offset, limit, and from/to. Non-empty queries stay on the fail-open decode walk from #1718.
- **Boundary:** `searchTieredMetadataTx` validates criteria, then answers empty queries via `queryStructuralEventIDs` *before* reading projection state. The structural SQL does not join `search_projection_source_sequence`.
- **Refuse vs availability:** projection unreadiness is not a structural refusal. Criteria sanity is.

## Tests

- `TestTieredAuthorityStructuralSearchIgnoresLiteralProjectionState` — empty query + workspace filter returns the two matching events while literal is rebuilding, stale, missing, or has an empty generation. Both `SearchMetadata` and `SearchPage`.
- `TestTieredAuthorityStructuralSearchRefusesInvalidCriteria` — negative offset, limit 0, and from>to still error; the message is not `incomplete or stale`.
- Existing `TestTieredAuthoritySearchAnswersWhenProjectionUnusable` still covers non-empty fail-open.

```
go test ./infrastructure/sqlite/ -count=1 -run 'TestTieredAuthorityStructuralSearch|TestTieredAuthoritySearchAnswersWhenProjectionUnusable'
```

## Reviewers

Please review as gpt-5.6-terra medium (and a second of claude opus 5 / antigravity gemini 3.7-flash if available).