### PR TITLE
fix: watch decoder columns on search projection invalidators

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **search-projection の invalidator が decoder の全列を見る (#1737)** — 投影済み event の codec metadata だけの UPDATE は complete generation を drift させ、rebuild 中は `search_projection_source_revision` を進めます。`events.id` は watch せず DB で不変です。`body` を既に含む body / retention / redaction 経路は変わりません。
 - **空クエリの structural search を literal projection の状態で拒否しない (#1736)** — workspace / session / kind / time のフィルタは、literal generation が rebuilding / failed / drifted でも正本テーブルに対して動きます。無効な offset / limit / from-to はこれまでどおり fail-closed です。非空クエリは generation が使えないとき decode walk に fail-open します。
 
 ## [v0.36.0] - 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Search-projection invalidators watch every decoder column (#1737)** — a codec-metadata-only update of a projected event now drifts a complete generation and bumps `search_projection_source_revision` during rebuild. `events.id` is immutable at the database instead of being watched. Body / retention / redaction paths that already mention `body` are unchanged.
 - **Structural (empty-query) search is not gated on the literal projection (#1736)** — workspace, session, kind, and time filters run against canonical tables even while the literal generation is rebuilding, failed, or drifted. Invalid offset, limit, and from/to still fail closed. Non-empty queries still fail open onto a decode walk when the generation is unusable.
 
 ## [v0.36.0] - 2026-08-15

--- a/infrastructure/sqlite/event_search_authority_internal_test.go
+++ b/infrastructure/sqlite/event_search_authority_internal_test.go
@@ -1105,6 +1105,176 @@ func TestTieredAuthorityBodyUpdateOfProjectedEventDriftsAndAnswersMutated(t *tes
 	}
 }
 
+// TestTieredAuthorityCodecMetadataUpdateDriftsProjectedEvent is #1737:
+// a codec-column-only UPDATE must drift a complete generation so stale
+// fingerprints cannot silently exclude the row.
+func TestTieredAuthorityCodecMetadataUpdateDriftsProjectedEvent(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	updates := []struct {
+		name string
+		sql  string
+	}{
+		{name: "body_codec", sql: `UPDATE events SET body_codec='identity' WHERE id='projected'`},
+		{name: "body_format_version", sql: `UPDATE events SET body_format_version=1 WHERE id='projected'`},
+		{name: "body_plaintext_bytes", sql: `UPDATE events SET body_plaintext_bytes=6 WHERE id='projected'`},
+		{name: "body_encoded_bytes", sql: `UPDATE events SET body_encoded_bytes=6 WHERE id='projected'`},
+		{name: "body_sha256", sql: `UPDATE events SET body_sha256='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' WHERE id='projected'`},
+	}
+
+	for _, tc := range updates {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			database, _ := newTieredAuthorityFixture(t)
+			insertTieredSearchEvent(t, database, "projected", "needle", base)
+			seedTieredCompleteProjection(t, database, "gen-codec")
+			seedLiteralFingerprints(t, database, "gen-codec", "projected", "needle")
+
+			raw, err := database.open(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = raw.ExecContext(ctx, tc.sql); err != nil {
+				_ = raw.Close()
+				t.Fatal(err)
+			}
+			_ = raw.Close()
+
+			literalState, boundedState := readProjectionStates(t, database)
+			if boundedState != "drifted" {
+				t.Fatalf("bounded state = %q, want drifted after codec-only %s", boundedState, tc.name)
+			}
+			if literalState != "stale" {
+				t.Fatalf("literal state = %q, want stale after codec-only %s", literalState, tc.name)
+			}
+		})
+	}
+}
+
+func TestTieredAuthorityCompleteIdentityCodecUpdateStillAnswers(t *testing.T) {
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "projected", "needle", base)
+	seedTieredCompleteProjection(t, database, "gen-codec-full")
+	seedLiteralFingerprints(t, database, "gen-codec-full", "projected", "needle")
+
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.ExecContext(ctx, `
+		UPDATE events
+		   SET body_codec='identity',
+		       body_format_version=1,
+		       body_plaintext_bytes=6,
+		       body_encoded_bytes=6,
+		       body_sha256='09881f6ed93360a2f6ad81f435a8ca51ca4575d0f954f197ff8f7d16c6565562'
+		 WHERE id='projected'`); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+
+	_, boundedState := readProjectionStates(t, database)
+	if boundedState != "drifted" {
+		t.Fatalf("bounded state = %q, want drifted after complete identity codec write", boundedState)
+	}
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	got, searchErr := datasource.SearchMetadata(ctx, criteria)
+	if searchErr != nil {
+		t.Fatalf("SearchMetadata() error = %v, want decode after drift", searchErr)
+	}
+	if diff := cmp.Diff([]string{"projected"}, metadataIDs(got)); diff != "" {
+		t.Fatalf("SearchMetadata() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTieredAuthorityCodecMetadataUpdateBumpsRebuildRevision(t *testing.T) {
+	ctx := context.Background()
+	database, _ := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "projected", "needle", base)
+	seedTieredCompleteProjection(t, database, "gen-rebuild")
+
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err = raw.ExecContext(ctx, `UPDATE search_projection_state SET state='rebuilding', phase='source' WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+	var before int64
+	if err = raw.QueryRowContext(ctx, `SELECT revision FROM search_projection_source_revision WHERE singleton=1`).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.ExecContext(ctx, `UPDATE events SET body_codec='identity' WHERE id='projected'`); err != nil {
+		t.Fatal(err)
+	}
+	var after int64
+	if err = raw.QueryRowContext(ctx, `SELECT revision FROM search_projection_source_revision WHERE singleton=1`).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after <= before {
+		t.Fatalf("source revision %d -> %d, want bump after codec-only update during rebuild", before, after)
+	}
+}
+
+func TestSearchInvalidatorsWatchEveryDecoderColumn(t *testing.T) {
+	ctx := context.Background()
+	database, _ := newTieredAuthorityFixture(t)
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+
+	triggers := []string{
+		"search_projection_complete_event_update",
+		"search_projection_events_update",
+		"literal_search_event_update",
+	}
+	for _, name := range triggers {
+		var sqlText string
+		if err = raw.QueryRowContext(ctx, `SELECT sql FROM sqlite_master WHERE type='trigger' AND name=?`, name).Scan(&sqlText); err != nil {
+			t.Fatalf("read trigger %s: %v", name, err)
+		}
+		upper := strings.ToUpper(sqlText)
+		of := strings.Index(upper, "UPDATE OF ")
+		on := strings.Index(upper, " ON EVENTS")
+		if of < 0 || on < 0 || on <= of {
+			t.Fatalf("trigger %s has no UPDATE OF … ON events clause: %s", name, sqlText)
+		}
+		watched := "," + strings.ReplaceAll(strings.ToLower(sqlText[of+len("UPDATE OF "):on]), " ", "") + ","
+		for _, column := range eventPayloadDecoderColumns {
+			if !strings.Contains(watched, ","+column+",") {
+				t.Fatalf("trigger %s does not watch decoder column %s: %s", name, column, sqlText)
+			}
+		}
+	}
+}
+
+func TestEventsIDIsImmutable(t *testing.T) {
+	ctx := context.Background()
+	database, _ := newTieredAuthorityFixture(t)
+	insertTieredSearchEvent(t, database, "projected", "needle", time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	_, err = raw.ExecContext(ctx, `UPDATE events SET id='renamed' WHERE id='projected'`)
+	if err == nil {
+		t.Fatal("UPDATE events.id error = nil, want immutable abort")
+	}
+	if !strings.Contains(err.Error(), "events.id is immutable") {
+		t.Fatalf("UPDATE events.id error = %v, want immutable abort", err)
+	}
+}
+
 func TestTieredAuthorityAuditInsertOnProjectedEventDriftsAndAnswers(t *testing.T) {
 	// Case 3: command_audits insert against an already-projected event
 	// (sequence <= high_water) → bounded drifted → search still finds the

--- a/infrastructure/sqlite/event_search_authority_internal_test.go
+++ b/infrastructure/sqlite/event_search_authority_internal_test.go
@@ -1224,6 +1224,16 @@ func TestTieredAuthorityCodecMetadataUpdateBumpsRebuildRevision(t *testing.T) {
 }
 
 func TestSearchInvalidatorsWatchEveryDecoderColumn(t *testing.T) {
+	selectSQL := eventPayloadDecoderSelectSQL()
+	for _, column := range eventPayloadDecoderColumns {
+		if !strings.Contains(selectSQL, column) {
+			t.Fatalf("decoder SELECT does not include %s: %s", column, selectSQL)
+		}
+	}
+	if got, want := len((&payloadRow{}).scanDestinations()), len(eventPayloadDecoderColumns); got != want {
+		t.Fatalf("scanDestinations() len = %d, want %d to match eventPayloadDecoderColumns", got, want)
+	}
+
 	ctx := context.Background()
 	database, _ := newTieredAuthorityFixture(t)
 	raw, err := database.open(ctx)

--- a/infrastructure/sqlite/migrate_offline_test.go
+++ b/infrastructure/sqlite/migrate_offline_test.go
@@ -51,8 +51,8 @@ func TestStoreInitAppliesOfflineMigrations(t *testing.T) {
 	if err := current.InitializeAuthorized(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 62 {
-		t.Fatalf("schema version=%d, want 62", got)
+	if got := maxSchemaVersion(t, path); got != 63 {
+		t.Fatalf("schema version=%d, want 63", got)
 	}
 }
 
@@ -64,8 +64,8 @@ func TestEmptyStoreReachesCurrentSchemaImplicitly(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 62 {
-		t.Fatalf("schema version=%d, want 62", got)
+	if got := maxSchemaVersion(t, path); got != 63 {
+		t.Fatalf("schema version=%d, want 63", got)
 	}
 }
 

--- a/infrastructure/sqlite/payload_hydration.go
+++ b/infrastructure/sqlite/payload_hydration.go
@@ -14,6 +14,19 @@ type queryRowContexter interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
+// eventPayloadDecoderColumns is the events-column set hydrateEventPayload
+// reads when codec metadata exists. Search-projection invalidators must
+// watch every name here. body_availability is a visibility gate, not a
+// decode input, and is already watched separately.
+var eventPayloadDecoderColumns = []string{
+	"body",
+	"body_codec",
+	"body_format_version",
+	"body_plaintext_bytes",
+	"body_encoded_bytes",
+	"body_sha256",
+}
+
 // hydrateEventPayload is the central logical-body boundary. Metadata-free rows
 // are legacy identity. Physical bytes never escape this adapter.
 func hydrateEventPayload(ctx context.Context, q queryRowContexter, event *model.Event) (*model.Event, error) {

--- a/infrastructure/sqlite/payload_hydration.go
+++ b/infrastructure/sqlite/payload_hydration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 
 	"golang.org/x/xerrors"
 
@@ -27,6 +28,29 @@ var eventPayloadDecoderColumns = []string{
 	"body_sha256",
 }
 
+// eventPayloadDecoderSelectSQL is the single SELECT hydrateEventPayload and
+// loadEventPlaintext issue. Column order matches payloadRow.scanDestinations
+// plus the stored-length bound. Adding a decoder dependency means adding it
+// here; TestSearchInvalidatorsWatchEveryDecoderColumn then fails until the
+// invalidators watch it.
+func eventPayloadDecoderSelectSQL() string {
+	body := eventPayloadDecoderColumns[0]
+	var builder strings.Builder
+	builder.WriteString("SELECT CASE WHEN length(CAST(")
+	builder.WriteString(body)
+	builder.WriteString(" AS BLOB)) <= ? THEN ")
+	builder.WriteString(body)
+	builder.WriteString(" END")
+	for _, column := range eventPayloadDecoderColumns[1:] {
+		builder.WriteString(", ")
+		builder.WriteString(column)
+	}
+	builder.WriteString(", length(CAST(")
+	builder.WriteString(body)
+	builder.WriteString(" AS BLOB)) FROM events WHERE id=?")
+	return builder.String()
+}
+
 // hydrateEventPayload is the central logical-body boundary. Metadata-free rows
 // are legacy identity. Physical bytes never escape this adapter.
 func hydrateEventPayload(ctx context.Context, q queryRowContexter, event *model.Event) (*model.Event, error) {
@@ -46,7 +70,7 @@ func hydrateEventPayload(ctx context.Context, q queryRowContexter, event *model.
 	var row payloadRow
 	var storedLength sql.NullInt64
 	destinations := append(row.scanDestinations(), &storedLength)
-	if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxStoredPayloadBytes, event.EventID().String()).Scan(destinations...); err != nil {
+	if err := q.QueryRowContext(ctx, eventPayloadDecoderSelectSQL(), maxStoredPayloadBytes, event.EventID().String()).Scan(destinations...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, xerrors.Errorf("event payload disappeared: %s", event.EventID())
 		}
@@ -160,7 +184,7 @@ func loadEventPlaintext(ctx context.Context, q queryRowContexter, eventID string
 	var row payloadRow
 	var storedLength sql.NullInt64
 	destinations := append(row.scanDestinations(), &storedLength)
-	if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxStoredPayloadBytes, eventID).Scan(destinations...); err != nil {
+	if err := q.QueryRowContext(ctx, eventPayloadDecoderSelectSQL(), maxStoredPayloadBytes, eventID).Scan(destinations...); err != nil {
 		return nil, xerrors.Errorf("read event payload row: %w", err)
 	}
 	if storedLength.Valid && storedLength.Int64 > maxStoredPayloadBytes {

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -89,6 +89,9 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	// (one row per budget-rejected source event, not events), so this stays
 	// constant_in_place rather than a prepared offline rewrite.
 	62: {62, "000062_search_projection_exclusion_row_work.sql", "0c5999e55f7019cbe30235e30696a104b20e2261d8c7a0289fed11dfbc5e1d47", MigrationConstantInPlace},
+	// 63 only drops and recreates three invalidator triggers plus one
+	// events.id immutability guard. No data scan or rewrite.
+	63: {63, "000063_watch_decoder_columns_on_search_invalidators.sql", "3cd33611da576a9b544c214f0e9b49ae6067f422f4c21ffd28f546f3bad25ef2", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 62 || len(plan.Pending) != 27 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 63 || len(plan.Pending) != 28 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -59,6 +59,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		60: MigrationConstantInPlace,
 		61: MigrationConstantInPlace,
 		62: MigrationConstantInPlace,
+		63: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 62 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 63 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/schema/sqlite/migrations/000063_watch_decoder_columns_on_search_invalidators.sql
+++ b/schema/sqlite/migrations/000063_watch_decoder_columns_on_search_invalidators.sql
@@ -1,0 +1,26 @@
+-- Search-projection invalidators must watch every events column the decoder
+-- reads. A codec-metadata-only UPDATE used to leave fingerprints describing
+-- a superseded decode (silent false negative). Constant-time DROP/CREATE only.
+-- events.id is immutable rather than watched: changing it would orphan
+-- search_projection_source_sequence.event_id without a joinable events row.
+
+DROP TRIGGER search_projection_complete_event_update;
+CREATE TRIGGER search_projection_complete_event_update AFTER UPDATE OF body,body_availability,session_id,kind,created_at,body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256 ON events
+WHEN (SELECT state FROM search_projection_state WHERE singleton=1)='complete'
+BEGIN
+ UPDATE search_projection_state SET state='drifted',phase='cleanup',cleanup_scope='all',active_generation_id=NULL WHERE singleton=1;
+ UPDATE search_projection_generation_lifecycle SET state='drifted' WHERE generation_id=(SELECT generation_id FROM search_projection_state WHERE singleton=1) AND state='complete';
+END;
+
+DROP TRIGGER search_projection_events_update;
+CREATE TRIGGER search_projection_events_update AFTER UPDATE OF body,body_availability,session_id,kind,created_at,body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256 ON events WHEN EXISTS(SELECT 1 FROM search_projection_state s WHERE s.state='rebuilding' AND (EXISTS(SELECT 1 FROM search_projection_inventory_compat c WHERE c.requires_inventory=1) OR EXISTS(SELECT 1 FROM search_projection_source_sequence q WHERE q.event_id=new.id AND q.sequence<=s.high_water))) BEGIN UPDATE search_projection_source_revision SET revision=revision+1; END;
+
+DROP TRIGGER literal_search_event_update;
+CREATE TRIGGER literal_search_event_update AFTER UPDATE OF workspace,client,agent,session_id,kind,created_at,body,body_availability,body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256 ON events BEGIN
+ UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
+END;
+
+CREATE TRIGGER events_id_immutable BEFORE UPDATE OF id ON events
+BEGIN
+ SELECT RAISE(ABORT, 'events.id is immutable');
+END;


### PR DESCRIPTION
## Summary

Closes #1737

Leaves parent #1905 open.

Search-projection invalidators watched a narrower `UPDATE OF` set than `hydrateEventPayload` reads. A codec-metadata-only mutation left fingerprints describing a superseded decode (silent false negative).

## Design note

- **Requirement:** a codec-only update of a projected event must drift a complete generation and bump `search_projection_source_revision` during rebuild. Decoder columns and invalidators must not be able to drift apart silently. Existing `body` / retention / redaction paths stay the same.
- **Choice:** extend `UPDATE OF` on the three event invalidator families (`search_projection_complete_event_update`, `search_projection_events_update`, `literal_search_event_update`) with `body_codec`, `body_format_version`, `body_plaintext_bytes`, `body_encoded_bytes`, `body_sha256`.
- **`events.id`:** immutable via `BEFORE UPDATE OF id` abort, not an invalidation. Changing id would orphan `search_projection_source_sequence.event_id`.
- **Migration 063:** constant_in_place DROP/CREATE only. No store-sized scan.

## Tests

- Per-column codec-only UPDATE drifts bounded+literal state.
- Complete identity codec tuple drifts and `SearchMetadata` still finds the event (no stale-fingerprint miss).
- Codec-only UPDATE during rebuild bumps `search_projection_source_revision`.
- Pin: the three triggers' `UPDATE OF` lists contain every `eventPayloadDecoderColumns` name.
- `events.id` update aborts.
- Existing body-update drift test is unchanged.

```
go test ./infrastructure/sqlite/ -count=1 -run 'TestTieredAuthorityCodecMetadata|TestTieredAuthorityCompleteIdentityCodecUpdate|TestSearchInvalidatorsWatchEveryDecoderColumn|TestEventsIDIsImmutable|TestBuildPreparedMigrationPlanClassifiesExactSuffix'
```