### PR TITLE
fix: return session hits and readiness from one snapshot

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **session-tier の hits と readiness を同じ snapshot から返す (#1822)** — `SearchSessionPage` が 1 つの read transaction で hits と `ready` / `not_ready` / `not_applicable` を返します。空クエリ、`--kind`、2 ページ目以降は store を開かず `not_applicable` です。`SearchSessionProjectionReady` は廃止し、空ページと後から読んだ generation の readiness を組み合わせられないようにします。`traceary search` の session notice もこの page を使います。
 - **search-projection の invalidator が decoder の全列を見る (#1737)** — 投影済み event の codec metadata だけの UPDATE は complete generation を drift させ、rebuild 中は `search_projection_source_revision` を進めます。`events.id` は watch せず DB で不変です。`body` を既に含む body / retention / redaction 経路は変わりません。
 - **空クエリの structural search を literal projection の状態で拒否しない (#1736)** — workspace / session / kind / time のフィルタは、literal generation が rebuilding / failed / drifted でも正本テーブルに対して動きます。無効な offset / limit / from-to はこれまでどおり fail-closed です。非空クエリは generation が使えないとき decode walk に fail-open します。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Session-tier hits and readiness share one snapshot (#1822)** — `SearchSessionPage` returns hits plus `ready` / `not_ready` / `not_applicable` from a single read transaction. Empty query, `--kind`, and later pages report `not_applicable` without opening the store. `SearchSessionProjectionReady` is gone so callers cannot pair an empty page with a later generation's readiness. `traceary search` uses that page for the session notice.
 - **Search-projection invalidators watch every decoder column (#1737)** — a codec-metadata-only update of a projected event now drifts a complete generation and bumps `search_projection_source_revision` during rebuild. `events.id` is immutable at the database instead of being watched. Body / retention / redaction paths that already mention `body` are unchanged.
 - **Structural (empty-query) search is not gated on the literal projection (#1736)** — workspace, session, kind, and time filters run against canonical tables even while the literal generation is rebuilding, failed, or drifted. Invalid offset, limit, and from/to still fail closed. Non-empty queries still fail open onto a decode walk when the generation is unusable.
 

--- a/application/queryservice/event_query.go
+++ b/application/queryservice/event_query.go
@@ -84,28 +84,14 @@ type EventBoundedQueryService interface {
 	LoadCanonicalBodies(ctx context.Context, eventIDs []types.EventID) (map[types.EventID]string, error)
 }
 
-// ProjectionSessionSearchQuery returns session-tier hits from the bounded
-// search projection. Callers that only need event rows do not depend on this
-// port. Hits are never events: a session row means "the trail is here, open it".
+// ProjectionSessionSearch is the port for surfaces that must tell "no session
+// matched" apart from "the projection could not be consulted at all". Hits
+// and that disposition come from one read snapshot so a generation
+// transition cannot make the reason contradict the page.
+//
+// Hits are never events: a session row means "the trail is here, open it".
 // Sessions already represented by event hits in the same response should be
 // passed in excludeSessionIDs so they are omitted.
-type ProjectionSessionSearchQuery interface {
-	SearchSessionHits(ctx context.Context, criteria apptypes.EventSearchCriteria, excludeSessionIDs []types.SessionID) ([]apptypes.SearchSessionHit, error)
-}
-
-// ProjectionSessionSearchReadiness reports whether the session-tier search
-// projection has a published complete generation.
-type ProjectionSessionSearchReadiness interface {
-	SearchSessionProjectionReady(ctx context.Context) (bool, error)
-}
-
-// ProjectionSessionSearch is the port for surfaces that must tell "no session
-// matched" apart from "the projection could not be consulted at all". Both
-// answers arrive as an empty page without error, so readiness is required
-// rather than probed for: a surface that loses the distinction reports
-// "nothing found" for history that exists, and nothing about that failure is
-// visible to the caller.
 type ProjectionSessionSearch interface {
-	ProjectionSessionSearchQuery
-	ProjectionSessionSearchReadiness
+	SearchSessionPage(ctx context.Context, criteria apptypes.EventSearchCriteria, excludeSessionIDs []types.SessionID) (apptypes.SearchSessionPage, error)
 }

--- a/application/types/search_session_hit.go
+++ b/application/types/search_session_hit.go
@@ -41,3 +41,36 @@ func (h SearchSessionHit) EventCount() int { return h.eventCount }
 
 // StartedAt returns the session start time used for ordering and display.
 func (h SearchSessionHit) StartedAt() time.Time { return h.startedAt }
+
+// SearchSessionTierState is the session-tier disposition for one snapshot.
+// ready: the published generation was consulted. not_ready: it was refused.
+// not_applicable: the tier was never opened (empty query, --kind, or a
+// page after the first).
+type SearchSessionTierState string
+
+const (
+	SearchSessionTierReady         SearchSessionTierState = "ready"
+	SearchSessionTierNotReady      SearchSessionTierState = "not_ready"
+	SearchSessionTierNotApplicable SearchSessionTierState = "not_applicable"
+)
+
+// SearchSessionPage is hits plus the readiness that explains an empty page,
+// taken from the same read snapshot.
+type SearchSessionPage struct {
+	hits  []SearchSessionHit
+	state SearchSessionTierState
+}
+
+// SearchSessionPageOf constructs a SearchSessionPage.
+func SearchSessionPageOf(hits []SearchSessionHit, state SearchSessionTierState) SearchSessionPage {
+	if hits == nil {
+		hits = []SearchSessionHit{}
+	}
+	return SearchSessionPage{hits: hits, state: state}
+}
+
+// Hits returns the session-tier matches from this snapshot.
+func (p SearchSessionPage) Hits() []SearchSessionHit { return p.hits }
+
+// State reports whether the session tier was consulted, refused, or skipped.
+func (p SearchSessionPage) State() SearchSessionTierState { return p.state }

--- a/application/types/search_session_hit.go
+++ b/application/types/search_session_hit.go
@@ -49,8 +49,11 @@ func (h SearchSessionHit) StartedAt() time.Time { return h.startedAt }
 type SearchSessionTierState string
 
 const (
-	SearchSessionTierReady         SearchSessionTierState = "ready"
-	SearchSessionTierNotReady      SearchSessionTierState = "not_ready"
+	// SearchSessionTierReady means the published generation was consulted.
+	SearchSessionTierReady SearchSessionTierState = "ready"
+	// SearchSessionTierNotReady means the snapshot refused the session tier.
+	SearchSessionTierNotReady SearchSessionTierState = "not_ready"
+	// SearchSessionTierNotApplicable means the tier was never opened.
 	SearchSessionTierNotApplicable SearchSessionTierState = "not_applicable"
 )
 

--- a/infrastructure/sqlite/search_projection_catchup_test.go
+++ b/infrastructure/sqlite/search_projection_catchup_test.go
@@ -109,10 +109,11 @@ func TestSearchProjectionCatchUp_IsBoundedCompleteAndResumable(t *testing.T) {
 	}
 	// Old event is outside recent retention of the projection; event tier may
 	// be empty while the session tier still finds the trail.
-	sessions, err := events.SearchSessionHits(ctx, criteria, nil)
+	page, err := events.SearchSessionPage(ctx, criteria, nil)
 	if err != nil {
-		t.Fatalf("SearchSessionHits() error = %v", err)
+		t.Fatalf("SearchSessionPage() error = %v", err)
 	}
+	sessions := page.Hits()
 	if len(sessions) != 1 {
 		t.Fatalf("session hits = %d (events=%v), want 1 session for old-history-needle", len(sessions), eventIDs(gotEvents))
 	}

--- a/infrastructure/sqlite/search_projection_read_path_test.go
+++ b/infrastructure/sqlite/search_projection_read_path_test.go
@@ -132,10 +132,14 @@ func TestSearchProjectionReadPath_SessionTierSummaryOnly(t *testing.T) {
 	if len(events) != 0 {
 		t.Fatalf("len(events) = %d, want 0", len(events))
 	}
-	sessions, err := sut.SearchSessionHits(ctx, criteria, nil)
+	page, err := sut.SearchSessionPage(ctx, criteria, nil)
 	if err != nil {
-		t.Fatalf("SearchSessionHits() error = %v", err)
+		t.Fatalf("SearchSessionPage() error = %v", err)
 	}
+	if page.State() != apptypes.SearchSessionTierReady {
+		t.Fatalf("State() = %q, want ready", page.State())
+	}
+	sessions := page.Hits()
 	if len(sessions) != 1 {
 		t.Fatalf("len(sessions) = %d, want 1", len(sessions))
 	}
@@ -195,10 +199,11 @@ func TestSearchProjectionReadPath_SessionExcludedWhenEventHitExists(t *testing.T
 		t.Fatalf("event IDs mismatch (-want +got):\n%s", diff)
 	}
 	exclude := []types.SessionID{types.SessionID("sess-shared")}
-	sessions, err := sut.SearchSessionHits(ctx, criteria, exclude)
+	page, err := sut.SearchSessionPage(ctx, criteria, exclude)
 	if err != nil {
-		t.Fatalf("SearchSessionHits() error = %v", err)
+		t.Fatalf("SearchSessionPage() error = %v", err)
 	}
+	sessions := page.Hits()
 	gotIDs := make([]string, 0, len(sessions))
 	for _, hit := range sessions {
 		gotIDs = append(gotIDs, hit.SessionID().String())
@@ -262,10 +267,11 @@ func TestSearchProjectionReadPath_FiltersApplyToBothTiers(t *testing.T) {
 		if diff := cmp.Diff([]string{"evt-a"}, eventIDs(events)); diff != "" {
 			t.Fatalf("events (-want +got):\n%s", diff)
 		}
-		sessions, err := sut.SearchSessionHits(ctx, criteria, nil)
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
 		if err != nil {
-			t.Fatalf("SearchSessionHits() error = %v", err)
+			t.Fatalf("SearchSessionPage() error = %v", err)
 		}
+		sessions := page.Hits()
 		if diff := cmp.Diff([]string{"sess-old-a"}, sessionHitIDs(sessions)); diff != "" {
 			t.Fatalf("sessions (-want +got):\n%s", diff)
 		}
@@ -283,10 +289,11 @@ func TestSearchProjectionReadPath_FiltersApplyToBothTiers(t *testing.T) {
 		if diff := cmp.Diff([]string{"evt-a"}, eventIDs(events)); diff != "" {
 			t.Fatalf("events (-want +got):\n%s", diff)
 		}
-		sessions, err := sut.SearchSessionHits(ctx, criteria, nil)
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
 		if err != nil {
-			t.Fatalf("SearchSessionHits() error = %v", err)
+			t.Fatalf("SearchSessionPage() error = %v", err)
 		}
+		sessions := page.Hits()
 		if len(sessions) != 0 {
 			t.Fatalf("session-id filter matched event session should not invent extra sessions: %+v", sessions)
 		}
@@ -298,9 +305,13 @@ func TestSearchProjectionReadPath_FiltersApplyToBothTiers(t *testing.T) {
 			Workspace(wsA).
 			Kind(types.EventKindNote).
 			Build()
-		sessions, err := sut.SearchSessionHits(ctx, criteria, nil)
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
 		if err != nil {
-			t.Fatalf("SearchSessionHits() error = %v", err)
+			t.Fatalf("SearchSessionPage() error = %v", err)
+		}
+		sessions := page.Hits()
+		if page.State() != apptypes.SearchSessionTierNotApplicable {
+			t.Fatalf("kind State() = %q, want not_applicable", page.State())
 		}
 		if len(sessions) != 0 {
 			t.Fatalf("kind filter must fail closed for sessions, got %d", len(sessions))
@@ -313,9 +324,13 @@ func TestSearchProjectionReadPath_FiltersApplyToBothTiers(t *testing.T) {
 			Workspace(wsA).
 			Offset(10).
 			Build()
-		sessions, err := sut.SearchSessionHits(ctx, criteria, nil)
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
 		if err != nil {
-			t.Fatalf("SearchSessionHits() error = %v", err)
+			t.Fatalf("SearchSessionPage() error = %v", err)
+		}
+		sessions := page.Hits()
+		if page.State() != apptypes.SearchSessionTierNotApplicable {
+			t.Fatalf("offset State() = %q, want not_applicable", page.State())
 		}
 		if len(sessions) != 0 {
 			t.Fatalf("offset page repeated the session group: %+v", sessions)
@@ -338,10 +353,11 @@ func TestSearchProjectionReadPath_FiltersApplyToBothTiers(t *testing.T) {
 		if len(events) != 0 {
 			t.Fatalf("len(events) = %d, want 0", len(events))
 		}
-		sessions, err := sut.SearchSessionHits(ctx, criteria, nil)
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
 		if err != nil {
-			t.Fatalf("SearchSessionHits() error = %v", err)
+			t.Fatalf("SearchSessionPage() error = %v", err)
 		}
+		sessions := page.Hits()
 		// sess-old-a starts 2026-06-01 00:00 which is before from; only sess-old-b.
 		if diff := cmp.Diff([]string{"sess-old-b"}, sessionHitIDs(sessions)); diff != "" {
 			t.Fatalf("sessions (-want +got):\n%s", diff)
@@ -467,10 +483,11 @@ func TestSearchProjectionReadPath_SessionFromFilterHandlesSubSecondStartedAt(t *
 		Workspace(workspace).
 		From(from).
 		Build()
-	sessions, err := sut.SearchSessionHits(ctx, criteria, nil)
+	page, err := sut.SearchSessionPage(ctx, criteria, nil)
 	if err != nil {
-		t.Fatalf("SearchSessionHits() error = %v", err)
+		t.Fatalf("SearchSessionPage() error = %v", err)
 	}
+	sessions := page.Hits()
 	if diff := cmp.Diff([]string{"sess-subsecond"}, sessionHitIDs(sessions)); diff != "" {
 		t.Fatalf("sessions (-want +got):\n%s", diff)
 	}
@@ -634,6 +651,98 @@ func sessionHitIDs(hits []apptypes.SearchSessionHit) []string {
 		out = append(out, hit.SessionID().String())
 	}
 	return out
+}
+
+func TestSearchSessionPageReportsStateFromTheSameSnapshot(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	seedCompleteProjection(t, dbPath, "gen-session-page", nil, []projectionSessionSeed{
+		{
+			sessionID:  "sess-old-summary",
+			summary:    "discussed unique-session-marker during planning",
+			eventCount: 12,
+			startedAt:  time.Date(2026, 6, 19, 10, 0, 0, 0, time.UTC),
+			workspace:  workspace.String(),
+			client:     "cli",
+			agent:      "codex",
+		},
+	}, nil)
+
+	t.Run("ready with hits", func(t *testing.T) {
+		criteria := apptypes.NewEventSearchCriteriaBuilder(20).
+			Query("unique-session-marker").
+			Workspace(workspace).
+			Build()
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
+		if err != nil {
+			t.Fatalf("SearchSessionPage() error = %v", err)
+		}
+		if page.State() != apptypes.SearchSessionTierReady {
+			t.Fatalf("State() = %q, want ready", page.State())
+		}
+		if diff := cmp.Diff([]string{"sess-old-summary"}, sessionHitIDs(page.Hits())); diff != "" {
+			t.Fatalf("hits (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("ready and empty", func(t *testing.T) {
+		criteria := apptypes.NewEventSearchCriteriaBuilder(20).
+			Query("does-not-match-any-session").
+			Workspace(workspace).
+			Build()
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
+		if err != nil {
+			t.Fatalf("SearchSessionPage() error = %v", err)
+		}
+		if page.State() != apptypes.SearchSessionTierReady {
+			t.Fatalf("State() = %q, want ready (consulted, no match)", page.State())
+		}
+		if len(page.Hits()) != 0 {
+			t.Fatalf("hits = %+v, want empty", page.Hits())
+		}
+	})
+
+	t.Run("empty query is not applicable", func(t *testing.T) {
+		criteria := apptypes.NewEventSearchCriteriaBuilder(20).Workspace(workspace).Build()
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
+		if err != nil {
+			t.Fatalf("SearchSessionPage() error = %v", err)
+		}
+		if page.State() != apptypes.SearchSessionTierNotApplicable {
+			t.Fatalf("State() = %q, want not_applicable", page.State())
+		}
+		if len(page.Hits()) != 0 {
+			t.Fatalf("hits = %+v, want empty", page.Hits())
+		}
+	})
+
+	t.Run("idle generation is not ready", func(t *testing.T) {
+		openRawDB(t, dbPath, func(db *sql.DB) {
+			if _, err := db.Exec(`UPDATE search_projection_state SET state='idle', active_generation_id=NULL WHERE singleton=1`); err != nil {
+				t.Fatalf("clear projection state: %v", err)
+			}
+		})
+		criteria := apptypes.NewEventSearchCriteriaBuilder(20).
+			Query("unique-session-marker").
+			Workspace(workspace).
+			Build()
+		page, err := sut.SearchSessionPage(ctx, criteria, nil)
+		if err != nil {
+			t.Fatalf("SearchSessionPage() error = %v", err)
+		}
+		if page.State() != apptypes.SearchSessionTierNotReady {
+			t.Fatalf("State() = %q, want not_ready", page.State())
+		}
+		if len(page.Hits()) != 0 {
+			t.Fatalf("hits = %+v, want empty", page.Hits())
+		}
+	})
 }
 
 func foldASCIIForTest(value string) string {

--- a/infrastructure/sqlite/search_projection_session_query.go
+++ b/infrastructure/sqlite/search_projection_session_query.go
@@ -18,43 +18,32 @@ import (
 // "ready" instead of failing to build.
 var _ queryservice.ProjectionSessionSearch = (*EventDatasource)(nil)
 
-// SearchSessionHits returns session-tier matches from the bounded search
-// projection. When the projection is not complete, the method returns an empty
-// page without error so callers fall through to event-only results.
-func (d *EventDatasource) SearchSessionHits(
+// SearchSessionPage returns session-tier matches and the readiness that
+// explains an empty page from one read-only transaction. Early exits
+// (empty query, --kind, later pages) never open the store and report
+// not_applicable so callers do not invent a readiness they did not observe.
+func (d *EventDatasource) SearchSessionPage(
 	ctx context.Context,
 	criteria apptypes.EventSearchCriteria,
 	excludeSessionIDs []types.SessionID,
-) ([]apptypes.SearchSessionHit, error) {
+) (apptypes.SearchSessionPage, error) {
 	if criteria.Limit() <= 0 {
-		return nil, xerrors.New("limit must be greater than or equal to 1")
+		return apptypes.SearchSessionPage{}, xerrors.New("limit must be greater than or equal to 1")
 	}
 	queryValue := strings.TrimSpace(criteria.Query())
-	if queryValue == "" {
-		return []apptypes.SearchSessionHit{}, nil
-	}
-	// Kind cannot be applied to session summaries/keywords. Fail closed rather
-	// than return unfiltered session rows for a filter the user set.
-	if strings.TrimSpace(criteria.Kind().String()) != "" {
-		return []apptypes.SearchSessionHit{}, nil
-	}
-	// The session group points at trails the event tier could not reach; it is
-	// not a paginated list. Repeating it under every page anchor or offset would
-	// show the same sessions again on page two, so it belongs to the first page
-	// only.
-	if criteria.Offset() > 0 || !criteria.PageAnchor().IsZero() {
-		return []apptypes.SearchSessionHit{}, nil
+	if queryValue == "" || strings.TrimSpace(criteria.Kind().String()) != "" || criteria.Offset() > 0 || !criteria.PageAnchor().IsZero() {
+		return apptypes.SearchSessionPageOf(nil, apptypes.SearchSessionTierNotApplicable), nil
 	}
 
 	db, err := d.db.open(ctx)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to open DB for projection session search: %w", err)
+		return apptypes.SearchSessionPage{}, xerrors.Errorf("failed to open DB for projection session search: %w", err)
 	}
 	defer d.db.release(db)
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, xerrors.Errorf("failed to begin projection session search: %w", err)
+		return apptypes.SearchSessionPage{}, xerrors.Errorf("failed to begin projection session search: %w", err)
 	}
 	defer func() {
 		_ = tx.Rollback()
@@ -62,48 +51,23 @@ func (d *EventDatasource) SearchSessionHits(
 
 	ready, err := searchProjectionReadReady(ctx, tx)
 	if err != nil {
-		return nil, err
+		return apptypes.SearchSessionPage{}, err
 	}
 	if !ready {
 		if commitErr := tx.Commit(); commitErr != nil {
-			return nil, xerrors.Errorf("failed to finish empty projection session search: %w", commitErr)
+			return apptypes.SearchSessionPage{}, xerrors.Errorf("failed to finish empty projection session search: %w", commitErr)
 		}
-		return []apptypes.SearchSessionHit{}, nil
+		return apptypes.SearchSessionPageOf(nil, apptypes.SearchSessionTierNotReady), nil
 	}
 
 	hits, err := queryProjectionSessionHits(ctx, tx, criteria, queryValue, excludeSessionIDs)
 	if err != nil {
-		return nil, err
+		return apptypes.SearchSessionPage{}, err
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, xerrors.Errorf("failed to finish projection session search: %w", err)
+		return apptypes.SearchSessionPage{}, xerrors.Errorf("failed to finish projection session search: %w", err)
 	}
-	return hits, nil
-}
-
-// SearchSessionProjectionReady reports whether session-tier search may be
-// consulted. It is separate from SearchSessionHits because an empty result is
-// valid both for a ready projection with no match and for an incomplete one.
-func (d *EventDatasource) SearchSessionProjectionReady(ctx context.Context) (bool, error) {
-	db, err := d.db.open(ctx)
-	if err != nil {
-		return false, xerrors.Errorf("failed to open DB for projection session readiness: %w", err)
-	}
-	defer d.db.release(db)
-
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
-	if err != nil {
-		return false, xerrors.Errorf("failed to begin projection session readiness: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	ready, err := searchProjectionReadReady(ctx, tx)
-	if err != nil {
-		return false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return false, xerrors.Errorf("failed to finish projection session readiness: %w", err)
-	}
-	return ready, nil
+	return apptypes.SearchSessionPageOf(hits, apptypes.SearchSessionTierReady), nil
 }
 
 func queryProjectionSessionHits(
@@ -231,5 +195,3 @@ func appendSessionSearchFilters(
 	}
 	return args
 }
-
-var _ queryservice.ProjectionSessionSearchQuery = (*EventDatasource)(nil)

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -254,24 +254,14 @@ func (c *RootCLI) searchProjectionSessions(
 	if c.projectionSessionSearch == nil {
 		return []apptypes.SearchSessionHit{}, notices, nil
 	}
-	hits, err := c.projectionSessionSearch.SearchSessionHits(ctx, criteria, exclude)
+	page, err := c.projectionSessionSearch.SearchSessionPage(ctx, criteria, exclude)
 	if err != nil {
 		return nil, notices, xerrors.Errorf("search projection session hits: %w", err)
 	}
-	// An empty page means "nothing matched" or "the projection was never
-	// consulted", and the query service reports both the same way. Only this
-	// branch can use the answer, so readiness is asked for only here.
-	if len(hits) == 0 {
-		ready, readinessErr := c.projectionSessionSearch.SearchSessionProjectionReady(ctx)
-		// Readiness is advisory. The events were already found and printed, so a
-		// readiness failure must not turn a successful search into an error — but
-		// it must not silently pass for a ready projection either, because that is
-		// the ambiguity this whole path exists to remove.
-		if readinessErr == nil {
-			notices.projectionNotReady = !ready
-		} else {
-			notices.readinessUnknown = true
-		}
+	hits := page.Hits()
+	// State is the snapshot that produced Hits. Do not re-ask readiness.
+	if page.State() == apptypes.SearchSessionTierNotReady {
+		notices.projectionNotReady = true
 	}
 	if strings.TrimSpace(criteria.Kind().String()) == "" {
 		return hits, notices, nil
@@ -286,11 +276,17 @@ func (c *RootCLI) searchProjectionSessions(
 	// asked. That is also why the notice reports presence rather than a count:
 	// an accurate count would require re-running the event search as well, and
 	// the number is not what tells the user what to do.
-	probeHits, err := c.projectionSessionSearch.SearchSessionHits(ctx, criteria.WithoutKind(), nil)
+	//
+	// --kind itself is not_applicable, so readiness comes from this probe's
+	// snapshot rather than a third transaction.
+	probe, err := c.projectionSessionSearch.SearchSessionPage(ctx, criteria.WithoutKind(), nil)
 	if err != nil {
 		return nil, notices, xerrors.Errorf("probe projection session hits: %w", err)
 	}
-	notices.kindSuppressed = len(probeHits) > 0
+	notices.kindSuppressed = probe.State() == apptypes.SearchSessionTierReady && len(probe.Hits()) > 0
+	if probe.State() == apptypes.SearchSessionTierNotReady {
+		notices.projectionNotReady = true
+	}
 	return hits, notices, nil
 }
 

--- a/presentation/cli/search_session_projection_ready_test.go
+++ b/presentation/cli/search_session_projection_ready_test.go
@@ -116,20 +116,24 @@ func TestRootCLI_SearchJSONFieldsReportsSessionProjectionNotReadyOnlyForEmptyHit
 	}
 }
 
-func TestRootCLI_SearchReadinessErrorReportsUnknownReadiness(t *testing.T) {
+func TestRootCLI_SearchSessionPageErrorFailsSearch(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
 	stub := &projectionSessionSearchStub{readyErr: errors.New("readiness unavailable")}
-	out, stderr := executeSearchWithSessionStub(t, []string{"search", "--db-path", "/tmp/test-traceary.db", "needle"}, &eventUsecaseStub{}, stub)
-	ready := true
-	want, _ := executeSearchWithSessionStub(t, []string{"search", "--db-path", "/tmp/test-traceary.db", "needle"}, &eventUsecaseStub{}, &projectionSessionSearchStub{ready: &ready})
-	if diff := cmp.Diff(want, out); diff != "" {
-		t.Fatalf("stdout changed on readiness error (-want +got):\n%s", diff)
+	out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
+	root := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(&eventUsecaseStub{}),
+		cli.WithProjectionSessionSearch(stub),
+	).Command()
+	root.SetOut(out)
+	root.SetErr(errOut)
+	root.SetArgs([]string{"search", "--db-path", "/tmp/test-traceary.db", "needle"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want session-page failure")
 	}
-	if !strings.Contains(string(stderr), "could not determine whether the search projection is ready") {
-		t.Fatalf("readiness error must report unknown readiness: %q", stderr)
-	}
-	if !strings.Contains(string(stderr), "traceary store search-projection status") {
-		t.Fatalf("readiness error notice must point to status: %q", stderr)
+	if !strings.Contains(err.Error(), "readiness unavailable") {
+		t.Fatalf("Execute() error = %v, want readiness unavailable", err)
 	}
 }
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -91,34 +91,30 @@ type projectionSessionSearchStub struct {
 	excludes [][]types.SessionID
 }
 
-func (s *projectionSessionSearchStub) SearchSessionProjectionReady(context.Context) (bool, error) {
-	if s.readyErr != nil {
-		return false, s.readyErr
-	}
-	if s.ready == nil {
-		return true, nil
-	}
-	return *s.ready, nil
-}
-
-func (s *projectionSessionSearchStub) SearchSessionHits(
+func (s *projectionSessionSearchStub) SearchSessionPage(
 	_ context.Context,
 	criteria apptypes.EventSearchCriteria,
 	exclude []types.SessionID,
-) ([]apptypes.SearchSessionHit, error) {
+) (apptypes.SearchSessionPage, error) {
 	if s == nil {
-		return nil, nil
+		return apptypes.SearchSessionPageOf(nil, apptypes.SearchSessionTierNotApplicable), nil
 	}
 	s.calls++
 	s.criteria = append(s.criteria, criteria)
 	s.excludes = append(s.excludes, exclude)
 	if s.err != nil {
-		return nil, s.err
+		return apptypes.SearchSessionPage{}, s.err
 	}
-	if criteria.Kind().String() != "" {
-		return nil, nil
+	if criteria.Kind().String() != "" || strings.TrimSpace(criteria.Query()) == "" || criteria.Offset() > 0 || !criteria.PageAnchor().IsZero() {
+		return apptypes.SearchSessionPageOf(nil, apptypes.SearchSessionTierNotApplicable), nil
 	}
-	return s.hits, nil
+	if s.readyErr != nil {
+		return apptypes.SearchSessionPage{}, s.readyErr
+	}
+	if s.ready != nil && !*s.ready {
+		return apptypes.SearchSessionPageOf(nil, apptypes.SearchSessionTierNotReady), nil
+	}
+	return apptypes.SearchSessionPageOf(s.hits, apptypes.SearchSessionTierReady), nil
 }
 
 func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error) {


### PR DESCRIPTION
## Summary

Closes #1822

Leaves parent #1905 open.

Session-tier search asked for hits in one read transaction and readiness in another. A generation completing or a rebuild starting between them made `session_projection_not_ready` (and the CLI stderr notice) contradict the page.

## Design note

- **Requirement:** hits and the reason for an empty page must come from one snapshot. Empty query, `--kind`, and later pages must not pretend the tier was consulted.
- **Port:** `ProjectionSessionSearch` is now `SearchSessionPage` only. `ProjectionSessionSearchQuery` and `ProjectionSessionSearchReadiness` are gone.
- **States:** `ready` (consulted), `not_ready` (refused in that tx), `not_applicable` (never opened the store).
- **CLI:** `traceary search` uses `page.State()` for the not-ready notice. `--kind` takes readiness from the kind-less probe's page, not a third transaction.
- MCP `search` is already retired; the remaining consumer is the CLI.

## Tests

- `TestSearchSessionPageReportsStateFromTheSameSnapshot` — real EventDatasource: ready+hits, ready+empty, empty query `not_applicable`, idle generation `not_ready`.
- Existing kind/offset paths assert `not_applicable`.
- CLI stub implements `SearchSessionPage`; not-ready notice still appears; page errors fail the search.

```
go test ./infrastructure/sqlite/ ./presentation/cli/ -count=1 -run 'TestSearchSessionPageReportsStateFromTheSameSnapshot|TestSearchProjectionReadPath|TestRootCLI_Search'
```