### PR TITLE
fix: walk every timeline summary candidate without a depth cap

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **timeline の summary candidate walk を exact かつ cheap にする (#1746)** — kind ごとの ranked id は上限なし（`json_group_array`）。Go は decode 後の最初の非 blank を残すので、圧縮された blank が 4 件あっても同じ kind の後続 prompt を隠しません。`body_codec` の schema check は candidate ごとではなく `ListTimelineBlocks` あたり 1 回です。
 - **search projection status の generation 付き field を 1 snapshot にする (#1839)** — `recent_documents` / `summary_sessions` / `keyword_rows` / `fingerprint_rows`、rebuild 側の `recent_source_bytes` と exclusions は、1 つの read-only transaction の中で `active_generation_id` / `generation_id` を 1 度だけ解決します。dbstat の `physical_bytes` はその transaction の外です。
 - **`traceary search --kind` の session-tier 読みは 1 snapshot (#1859)** — #1822 のあと残っていた 2 回呼び出しは、`--kind` が `SearchSessionPage` を 2 回叩いていたことです。kind 付きの呼び出しは常に `not_applicable` で store を開かないので、CLI は kind なし probe だけにします。cutover 後に kind-suppression と not-ready が食い違うことはありません。
 - **session-tier の hits と readiness を同じ snapshot から返す (#1822)** — `SearchSessionPage` が 1 つの read transaction で hits と `ready` / `not_ready` / `not_applicable` を返します。空クエリ、`--kind`、2 ページ目以降は store を開かず `not_applicable` です。`SearchSessionProjectionReady` は廃止し、空ページと後から読んだ generation の readiness を組み合わせられないようにします。`traceary search` の session notice もこの page を使います。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Timeline summary walk is exact and cheap (#1746)** — ranked candidate ids per kind are unbounded (`json_group_array`). Go keeps the first non-blank after decode, so four compressed blanks no longer hide a later prompt of the same kind. The body_codec schema check is once per `ListTimelineBlocks`, not once per candidate.
 - **Search projection status snapshots generation-scoped fields (#1839)** — `recent_documents`, `summary_sessions`, `keyword_rows`, `fingerprint_rows`, rebuild-scoped `recent_source_bytes`, and exclusions resolve `active_generation_id` / `generation_id` once inside one read-only transaction. The dbstat `physical_bytes` walk stays outside that transaction.
 - **`traceary search --kind` uses one session-tier snapshot (#1859)** — after #1822 the leftover two-call path was `--kind` asking `SearchSessionPage` twice. The kind-set call is always `not_applicable` and does not open the store, so the CLI now makes only the kind-less probe. Kind-suppression and not-ready cannot disagree after a cutover.
 - **Session-tier hits and readiness share one snapshot (#1822)** — `SearchSessionPage` returns hits plus `ready` / `not_ready` / `not_applicable` from a single read transaction. Empty query, `--kind`, and later pages report `not_applicable` without opening the store. `SearchSessionProjectionReady` is gone so callers cannot pair an empty page with a later generation's readiness. `traceary search` uses that page for the session notice.

--- a/infrastructure/sqlite/codec_aware_body_sql_test.go
+++ b/infrastructure/sqlite/codec_aware_body_sql_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -541,6 +542,78 @@ func TestTimelineSummary_BlankCandidateDoesNotStealTheSummary(t *testing.T) {
 				t.Fatalf("timeline summary source mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestTimelineSummary_WalksPastTheFormerCandidateCap(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, backfill, path := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+	events := NewEventDatasource(NewDatabase(path, preparedMigrations(t)))
+
+	// Depth 3 used to fall through to the next kind. Four compressed blanks
+	// ahead of the real prompt is past that cap.
+	for i := 0; i < 4; i++ {
+		insertPlaintextEventAt(t, db, eventSeed{
+			ID: fmt.Sprintf("timeline-blank-%d", i), Kind: "prompt", Body: strings.Repeat(" ", 4096),
+		}, fmt.Sprintf("2026-08-09T00:00:0%dZ", i))
+	}
+	insertPlaintextEventAt(t, db, eventSeed{
+		ID: "timeline-real-beyond-cap", Kind: "prompt", Body: "fourth blank then this",
+	}, "2026-08-09T00:00:04Z")
+	runPayloadBackfill(ctx, t, backfill)
+	for i := 0; i < 4; i++ {
+		assertBodyCodec(t, db, fmt.Sprintf("timeline-blank-%d", i), payloadCodecZstd)
+	}
+
+	blocks, err := events.ListTimelineBlocks(ctx, types.Workspace(""), time.Time{}, time.Time{}, 900, 10)
+	if err != nil {
+		t.Fatalf("ListTimelineBlocks: %v", err)
+	}
+	if len(blocks) != 1 || len(blocks[0].WorkspaceBreakdown()) != 1 {
+		t.Fatalf("want one block with one workspace, got %d blocks", len(blocks))
+	}
+	got := blocks[0].WorkspaceBreakdown()[0]
+	if diff := cmp.Diff("fourth blank then this", got.Summary()); diff != "" {
+		t.Fatalf("timeline summary mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(apptypes.TimelineSummarySourcePrompt, got.SummarySource()); diff != "" {
+		t.Fatalf("timeline summary source mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTimelineSummary_QueryCountPerRowDoesNotRegress(t *testing.T) {
+	ctx := context.Background()
+	db, backfill, path := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+	events := NewEventDatasource(NewDatabase(path, preparedMigrations(t)))
+	insertPlaintextEventAt(t, db, eventSeed{
+		ID: "timeline-only-real", Kind: "prompt", Body: "the only prompt",
+	}, "2026-08-09T00:00:00Z")
+	runPayloadBackfill(ctx, t, backfill)
+
+	// Main hydrated one candidate as schema+body (2). The walk still decodes
+	// that one body; the schema check is once per ListTimelineBlocks.
+	counts := map[string]int{}
+	events.SetTimelinePayloadQueryHookForTest(func(kind string) { counts[kind]++ })
+	defer events.SetTimelinePayloadQueryHookForTest(nil)
+
+	blocks, err := events.ListTimelineBlocks(ctx, types.Workspace(""), time.Time{}, time.Time{}, 900, 10)
+	if err != nil {
+		t.Fatalf("ListTimelineBlocks: %v", err)
+	}
+	if len(blocks) != 1 || len(blocks[0].WorkspaceBreakdown()) != 1 {
+		t.Fatalf("want one block with one workspace, got %d blocks", len(blocks))
+	}
+	if diff := cmp.Diff("the only prompt", blocks[0].WorkspaceBreakdown()[0].Summary()); diff != "" {
+		t.Fatalf("timeline summary mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, counts["schema"]); diff != "" {
+		t.Fatalf("schema checks per list (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, counts["body"]); diff != "" {
+		t.Fatalf("body reads per row (-want +got):\n%s", diff)
 	}
 }
 

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"strings"
@@ -44,8 +45,9 @@ var listTimelineBlocksQuery string
 // EventDatasource is the SQLite-backed implementation of the event
 // repository and event query service.
 type EventDatasource struct {
-	db                *Database
-	onListWindowBatch func(batchIndex, batchSize int)
+	db                       *Database
+	onListWindowBatch        func(batchIndex, batchSize int)
+	timelinePayloadQueryHook func(kind string)
 }
 
 // NewEventDatasource creates a new EventDatasource bound to the given
@@ -514,6 +516,14 @@ func (d *EventDatasource) ListTimelineBlocks(
 		}
 	}()
 
+	hasCodec, err := eventHasCodecColumns(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if d.timelinePayloadQueryHook != nil {
+		d.timelinePayloadQueryHook("schema")
+	}
+
 	// The query returns one row per (block, workspace). We preserve the
 	// insertion order of both block_num values (ordered DESC by block_start
 	// in SQL) and their per-workspace rows (ordered DESC by ws_event_count,
@@ -531,20 +541,20 @@ func (d *EventDatasource) ListTimelineBlocks(
 
 	for rows.Next() {
 		var (
-			blockNum        int
-			blockStart      string
-			blockEnd        string
-			blockEventCount int
-			agents          string
-			workspace       string
-			wsEventCount    int
-			kinds           string
-			wsAgents        string
-			promptIDs       [timelineSummaryCandidates]string
-			compactIDs      [timelineSummaryCandidates]string
-			transcriptIDs   [timelineSummaryCandidates]string
+			blockNum          int
+			blockStart        string
+			blockEnd          string
+			blockEventCount   int
+			agents            string
+			workspace         string
+			wsEventCount      int
+			kinds             string
+			wsAgents          string
+			promptIDsJSON     string
+			compactIDsJSON    string
+			transcriptIDsJSON string
 		)
-		scanTargets := []any{
+		if err := rows.Scan(
 			&blockNum,
 			&blockStart,
 			&blockEnd,
@@ -554,24 +564,21 @@ func (d *EventDatasource) ListTimelineBlocks(
 			&wsEventCount,
 			&kinds,
 			&wsAgents,
-		}
-		for _, candidates := range []*[timelineSummaryCandidates]string{&promptIDs, &compactIDs, &transcriptIDs} {
-			for i := range candidates {
-				scanTargets = append(scanTargets, &candidates[i])
-			}
-		}
-		if err := rows.Scan(scanTargets...); err != nil {
+			&promptIDsJSON,
+			&compactIDsJSON,
+			&transcriptIDsJSON,
+		); err != nil {
 			return nil, xerrors.Errorf("failed to scan timeline block: %w", err)
 		}
-		firstPromptBody, err := firstNonBlankCandidate(ctx, db, promptIDs)
+		firstPromptBody, err := d.firstNonBlankCandidate(ctx, db, promptIDsJSON, hasCodec)
 		if err != nil {
 			return nil, err
 		}
-		compactSummaryBody, err := firstNonBlankCandidate(ctx, db, compactIDs)
+		compactSummaryBody, err := d.firstNonBlankCandidate(ctx, db, compactIDsJSON, hasCodec)
 		if err != nil {
 			return nil, err
 		}
-		firstTranscriptBody, err := firstNonBlankCandidate(ctx, db, transcriptIDs)
+		firstTranscriptBody, err := d.firstNonBlankCandidate(ctx, db, transcriptIDsJSON, hasCodec)
 		if err != nil {
 			return nil, err
 		}
@@ -627,26 +634,24 @@ func (d *EventDatasource) ListTimelineBlocks(
 	return blocks, nil
 }
 
-// timelineSummaryCandidates is how deep list_timeline_blocks.sql ranks summary
-// candidates per kind. SQL cannot judge whether an encoded body is blank, so it
-// hands over the leading candidates and Go decides after decoding. Depth 3 also
-// covers the blanks SQLite's TRIM misses (tabs, newlines) in plaintext rows.
-//
-// The depth is a cap, not a guarantee: a kind whose first three candidates are
-// all blank falls through to the next kind rather than to its own fourth
-// candidate, and only the first non-blank one is decoded, so the usual cost is
-// one hydration per kind. Making it exact needs an unbounded candidate list or
-// a blankness signal that survives encoding — tracked separately (#1746).
-const timelineSummaryCandidates = 3
-
-// firstNonBlankCandidate decodes candidates in rank order and returns the first
-// whose plaintext is not blank. An empty id marks the end of the ranked list.
-func firstNonBlankCandidate(ctx context.Context, db *sql.DB, ids [timelineSummaryCandidates]string) (string, error) {
+// firstNonBlankCandidate decodes ranked candidate ids in order and returns the
+// first whose plaintext is not blank. The list is unbounded (#1746): a kind
+// does not fall through to the next kind while it still has later candidates.
+// hasCodec is resolved once per ListTimelineBlocks so N candidates cost one
+// schema check plus N body reads, not 2N.
+func (d *EventDatasource) firstNonBlankCandidate(ctx context.Context, db *sql.DB, idsJSON string, hasCodec bool) (string, error) {
+	ids, err := decodeTimelineCandidateIDs(idsJSON)
+	if err != nil {
+		return "", err
+	}
 	for _, id := range ids {
 		if id == "" {
-			return "", nil
+			continue
 		}
-		plain, err := loadEventPlaintext(ctx, db, id)
+		if d.timelinePayloadQueryHook != nil {
+			d.timelinePayloadQueryHook("body")
+		}
+		plain, err := decodeEventPlaintext(ctx, db, id, hasCodec)
 		if err != nil {
 			return "", err
 		}
@@ -655,6 +660,18 @@ func firstNonBlankCandidate(ctx context.Context, db *sql.DB, ids [timelineSummar
 		}
 	}
 	return "", nil
+}
+
+func decodeTimelineCandidateIDs(idsJSON string) ([]string, error) {
+	trimmed := strings.TrimSpace(idsJSON)
+	if trimmed == "" || trimmed == "[]" {
+		return nil, nil
+	}
+	var ids []string
+	if err := json.Unmarshal([]byte(trimmed), &ids); err != nil {
+		return nil, xerrors.Errorf("decode timeline summary candidates: %w", err)
+	}
+	return ids, nil
 }
 
 // resolveWorkspaceSummary applies the fallback chain

--- a/infrastructure/sqlite/export_test.go
+++ b/infrastructure/sqlite/export_test.go
@@ -59,6 +59,12 @@ func (d *Database) SetStatusGenerationReadHookForTest(hook func()) {
 	d.afterStatusGenerationScopeRead = hook
 }
 
+// SetTimelinePayloadQueryHookForTest counts schema/body reads on the
+// timeline walk. Pass nil to clear.
+func (d *EventDatasource) SetTimelinePayloadQueryHookForTest(hook func(kind string)) {
+	d.timelinePayloadQueryHook = hook
+}
+
 // SetGarbageCollectionNowForTest fixes the timestamp persisted by gc discards.
 func (d *StoreManagementDatasource) SetGarbageCollectionNowForTest(now func() time.Time) {
 	d.now = now

--- a/infrastructure/sqlite/payload_hydration.go
+++ b/infrastructure/sqlite/payload_hydration.go
@@ -166,11 +166,23 @@ func hydrateCommandAudit(ctx context.Context, q queryRowContexter, audit *model.
 }
 
 func loadEventPlaintext(ctx context.Context, q queryRowContexter, eventID string) ([]byte, error) {
+	hasCodec, err := eventHasCodecColumns(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return decodeEventPlaintext(ctx, q, eventID, hasCodec)
+}
+
+func eventHasCodecColumns(ctx context.Context, q queryRowContexter) (bool, error) {
 	var has int
 	if err := q.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pragma_table_info('events') WHERE name='body_codec')`).Scan(&has); err != nil {
-		return nil, xerrors.Errorf("inspect event payload metadata: %w", err)
+		return false, xerrors.Errorf("inspect event payload metadata: %w", err)
 	}
-	if has == 0 {
+	return has != 0, nil
+}
+
+func decodeEventPlaintext(ctx context.Context, q queryRowContexter, eventID string, hasCodec bool) ([]byte, error) {
+	if !hasCodec {
 		var body []byte
 		var storedLength sql.NullInt64
 		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxDecodedPayloadBytes, eventID).Scan(&body, &storedLength); err != nil {

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -10,11 +10,12 @@
 --   ws_rows        : one row per (block, workspace) with counts / kinds /
 --                    summary candidate ids
 --
--- Summary candidates are returned as ids, never as bodies: an encoded body is
--- a BLOB this query cannot read, so Go decodes each candidate in rank order and
--- keeps the first non-blank one (#1685 D6). TRIM(body) != '' still drops blank
--- plaintext candidates for free; it cannot judge an encoded body, which is why
--- more than one candidate per kind is returned.
+-- Summary candidates are returned as ranked id lists, never as bodies: an
+-- encoded body is a BLOB this query cannot read, so Go decodes in rank order
+-- and keeps the first non-blank one (#1685 D6, #1746). TRIM(body) != '' still
+-- drops identity whitespace for free. Encoded blanks and tab/newline
+-- plaintext survive TRIM, so the list is unbounded — a depth cap would fall
+-- through to the next kind instead of the kind's own later candidate.
 --
 -- The final SELECT returns one row per (block, workspace) for the top N
 -- blocks; Go assembles per-block breakdown by grouping on block_num.
@@ -77,11 +78,12 @@ first_prompt AS (
   SELECT
     block_num,
     workspace,
-    MAX(CASE WHEN rn = 1 THEN id END) AS first_prompt_id_1,
-    MAX(CASE WHEN rn = 2 THEN id END) AS first_prompt_id_2,
-    MAX(CASE WHEN rn = 3 THEN id END) AS first_prompt_id_3
-  FROM prompt_ranked
-  WHERE rn <= 3
+    json_group_array(id) AS first_prompt_ids
+  FROM (
+    SELECT block_num, workspace, id
+    FROM prompt_ranked
+    ORDER BY block_num, workspace, rn
+  )
   GROUP BY block_num, workspace
 ),
 compact_ranked AS (
@@ -98,11 +100,12 @@ last_compact AS (
   SELECT
     block_num,
     workspace,
-    MAX(CASE WHEN rn = 1 THEN id END) AS compact_summary_id_1,
-    MAX(CASE WHEN rn = 2 THEN id END) AS compact_summary_id_2,
-    MAX(CASE WHEN rn = 3 THEN id END) AS compact_summary_id_3
-  FROM compact_ranked
-  WHERE rn <= 3
+    json_group_array(id) AS compact_summary_ids
+  FROM (
+    SELECT block_num, workspace, id
+    FROM compact_ranked
+    ORDER BY block_num, workspace, rn
+  )
   GROUP BY block_num, workspace
 ),
 transcript_ranked AS (
@@ -119,11 +122,12 @@ first_transcript AS (
   SELECT
     block_num,
     workspace,
-    MAX(CASE WHEN rn = 1 THEN id END) AS first_transcript_id_1,
-    MAX(CASE WHEN rn = 2 THEN id END) AS first_transcript_id_2,
-    MAX(CASE WHEN rn = 3 THEN id END) AS first_transcript_id_3
-  FROM transcript_ranked
-  WHERE rn <= 3
+    json_group_array(id) AS first_transcript_ids
+  FROM (
+    SELECT block_num, workspace, id
+    FROM transcript_ranked
+    ORDER BY block_num, workspace, rn
+  )
   GROUP BY block_num, workspace
 ),
 ws_rows AS (
@@ -133,15 +137,9 @@ ws_rows AS (
     COUNT(*) AS ws_event_count,
     GROUP_CONCAT(b.kind, '|') AS kinds,
     GROUP_CONCAT(DISTINCT b.agent) AS ws_agents,
-    MAX(fp.first_prompt_id_1) AS first_prompt_id_1,
-    MAX(fp.first_prompt_id_2) AS first_prompt_id_2,
-    MAX(fp.first_prompt_id_3) AS first_prompt_id_3,
-    MAX(lc.compact_summary_id_1) AS compact_summary_id_1,
-    MAX(lc.compact_summary_id_2) AS compact_summary_id_2,
-    MAX(lc.compact_summary_id_3) AS compact_summary_id_3,
-    MAX(ft.first_transcript_id_1) AS first_transcript_id_1,
-    MAX(ft.first_transcript_id_2) AS first_transcript_id_2,
-    MAX(ft.first_transcript_id_3) AS first_transcript_id_3
+    MAX(fp.first_prompt_ids) AS first_prompt_ids,
+    MAX(lc.compact_summary_ids) AS compact_summary_ids,
+    MAX(ft.first_transcript_ids) AS first_transcript_ids
   FROM blocks b
   LEFT JOIN first_prompt fp
     ON fp.block_num = b.block_num AND fp.workspace = b.workspace
@@ -163,15 +161,9 @@ SELECT
   wr.ws_event_count,
   wr.kinds,
   COALESCE(wr.ws_agents, '') AS ws_agents,
-  COALESCE(wr.first_prompt_id_1, '') AS first_prompt_id_1,
-  COALESCE(wr.first_prompt_id_2, '') AS first_prompt_id_2,
-  COALESCE(wr.first_prompt_id_3, '') AS first_prompt_id_3,
-  COALESCE(wr.compact_summary_id_1, '') AS compact_summary_id_1,
-  COALESCE(wr.compact_summary_id_2, '') AS compact_summary_id_2,
-  COALESCE(wr.compact_summary_id_3, '') AS compact_summary_id_3,
-  COALESCE(wr.first_transcript_id_1, '') AS first_transcript_id_1,
-  COALESCE(wr.first_transcript_id_2, '') AS first_transcript_id_2,
-  COALESCE(wr.first_transcript_id_3, '') AS first_transcript_id_3
+  COALESCE(wr.first_prompt_ids, '[]') AS first_prompt_ids,
+  COALESCE(wr.compact_summary_ids, '[]') AS compact_summary_ids,
+  COALESCE(wr.first_transcript_ids, '[]') AS first_transcript_ids
 FROM top_blocks tb
 JOIN ws_rows wr ON wr.block_num = tb.block_num
 ORDER BY tb.block_start DESC, wr.ws_event_count DESC, wr.workspace


### PR DESCRIPTION
## Summary

`list_timeline_blocks.sql` ranked at most three summary candidates per kind. Four compressed whitespace bodies of the same kind hid a later real summary.

This PR returns the unbounded ranked id list (`json_group_array`) and keeps the first non-blank decode. `TRIM(body) != ''` still drops identity whitespace in SQL. The `body_codec` schema check is once per `ListTimelineBlocks`, so a one-candidate row stays at one schema read plus one body read (not worse than main).

A durable blankness column is out of scope (write path + backfill).

## Test plan

- [x] `go test ./infrastructure/sqlite/ -run 'TestTimelineSummary|TestDatasource_ListTimelineBlocks'`
- [x] `go tool golangci-lint run ./infrastructure/sqlite/`
- [ ] CI

Closes #1746
Leaves parent #1905 open