### PR TITLE
docs: keep --recent-age; measure which cutoff binds (#1755)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Changed
+- **`--recent-age` は残す。bind する条件を測定して書いた (#1755)** — retention は `max(age, byte)`。密な scratch では byte（2026-06-20）が 30 日に勝つ。静かな scratch では byte cutoff が空で age が勝つ。容量圧のあるストアではこのフラグは不要。静かなストアではまだ使える。削除には admin の deprecation window が要る。`docs/research/search-projection-recent-age.ja.md` を参照。
+
 ### Fixed
 - **index-family 予算判定はファミリ合計に fallback する (#1835)** — `-1` は不明のままです。3 秒 split が切れても `physical_bytes` が取れるとき、`store search-projection status` はその合計に対する粗い 0/1 を出します。cutover も同じ fallback を persist するので、doctor は complete 世代の判定を見られます。理由のない `-1` はテスト失敗です。`docs/research/search-projection-budget-verdict.ja.md` を参照。
 - **recent-cutoff 導出は 2 秒タイムアウトではなく行数上限 (#1807)** — newest-first prefilter は最大 20,000 行なので、大きいストアでも cutoff が残ります。walk ceiling に届かない sample は age-only に戻さず、sample 内の最古 timestamp を残します。cancel と query error はこれまでどおり degrade です。新しいフラグはありません。`docs/research/search-projection-recent-cutoff.ja.md` を参照。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Changed
+- **`--recent-age` is kept; the committed measurement names when it binds (#1755)** — retention is `max(age, byte)`. Dense scratch: byte (2026-06-20) wins over 30d. Quiet scratch: empty byte cutoff, age wins. Capacity-pressure stores do not need the flag; quiet stores still can. Removal needs the admin deprecation window. See `docs/research/search-projection-recent-age.md`.
+
 ### Fixed
 - **Index-family budget verdict falls back to the family total (#1835)** — `-1` stays unknown. When the 3s split times out but `physical_bytes` is available, `store search-projection status` reports a coarse 0/1 against that total. Cutover persists the same fallback so doctor still sees a complete-generation verdict. A silent `-1` without `physical_evidence.reason` is a test failure. See `docs/research/search-projection-budget-verdict.md`.
 - **Recent-cutoff derivation is row-capped, not 2s-timed (#1807)** — the newest-first prefilter walks at most 20,000 rows so a large store still gets a cutoff. A sample that never crosses the walk ceiling keeps the oldest sampled timestamp instead of falling back to age-only. Cancel and query errors still degrade. No new flag. See `docs/research/search-projection-recent-cutoff.md`.

--- a/application/usecase/search_projection_plan.go
+++ b/application/usecase/search_projection_plan.go
@@ -11,6 +11,25 @@ import (
 
 const projectionIntegerBytes int64 = 8
 
+// RecentRetentionCutoff is max(now-age, byteCutoff). An empty or unparseable
+// RecentCutoffNorm leaves the age cutoff. Age binds on a quiet corpus whose
+// newest-first walk never crosses the byte ceiling; the byte cutoff binds on
+// any store that fills the recent window inside the age window (#1755).
+func RecentRetentionCutoff(now time.Time, age time.Duration, recentCutoffNorm string) time.Time {
+	cutoff := now.Add(-age)
+	if recentCutoffNorm == "" {
+		return cutoff
+	}
+	byteCutoff, err := time.Parse(time.RFC3339Nano, recentCutoffNorm)
+	if err != nil {
+		return cutoff
+	}
+	if byteCutoff.After(cutoff) {
+		return byteCutoff
+	}
+	return cutoff
+}
+
 // PlanProjectionBatch is pure: the same snapshot and budget produce the same plan.
 func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProjectionBudget) (apptypes.ProjectionBatchPlan, error) {
 	p := apptypes.ProjectionBatchPlan{GenerationID: s.Generation.GenerationID, Phase: s.Phase, ExpectedRevision: s.Generation.SourceRevision, ExpectedCheckpoint: s.Generation.Checkpoint, NextCheckpoint: s.Generation.Checkpoint, AllowRevisionDrift: s.CleanupAll, ContinueState: "rebuilding"}
@@ -124,13 +143,7 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 		if created, err := time.Parse(time.RFC3339Nano, d.CreatedAt); err == nil {
 			// Keep created_at_norm > max(ageCutoff, byteCutoff). Strict greater
 			// errs under budget when timestamps tie (#1679 D4).
-			cutoff := s.Now.Add(-b.RecentAge)
-			if s.RecentCutoffNorm != "" {
-				if byteCutoff, parseErr := time.Parse(time.RFC3339Nano, s.RecentCutoffNorm); parseErr == nil && byteCutoff.After(cutoff) {
-					cutoff = byteCutoff
-				}
-			}
-			w.RetainRecent = created.After(cutoff)
+			w.RetainRecent = created.After(RecentRetentionCutoff(s.Now, b.RecentAge, s.RecentCutoffNorm))
 		}
 		base, ok := summaries[d.SessionID]
 		if !ok {

--- a/application/usecase/search_projection_recent_age_binding_test.go
+++ b/application/usecase/search_projection_recent_age_binding_test.go
@@ -1,0 +1,113 @@
+package usecase_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+)
+
+func TestRecentAgeBindingOnScratchCorpora(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+	age := 30 * 24 * time.Hour
+	ageCutoff := now.Add(-age)
+	const nano = "2006-01-02T15:04:05.000000000Z"
+	tests := []struct {
+		name        string
+		byteCutoff  string
+		wantBinding string
+		docs        []struct {
+			id      string
+			created string
+			retain  bool
+		}
+	}{
+		{
+			name:        "dense ingest: byte cutoff is newer than 30d age",
+			byteCutoff:  "2026-06-20T00:00:00.000000000Z",
+			wantBinding: "byte",
+			docs: []struct {
+				id, created string
+				retain      bool
+			}{
+				{"inside-both", "2026-06-25T00:00:00.000000000Z", true},
+				{"age-only", "2026-06-10T00:00:00.000000000Z", false},
+				{"outside-both", "2026-05-20T00:00:00.000000000Z", false},
+			},
+		},
+		{
+			name:        "quiet store: walk never crosses the byte ceiling",
+			byteCutoff:  "",
+			wantBinding: "age",
+			docs: []struct {
+				id, created string
+				retain      bool
+			}{
+				{"inside-age", "2026-06-15T00:00:00.000000000Z", true},
+				{"outside-age", "2026-05-20T00:00:00.000000000Z", false},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotCutoff := usecase.RecentRetentionCutoff(now, age, tt.byteCutoff)
+			byteTime, byteErr := time.Parse(time.RFC3339Nano, tt.byteCutoff)
+			switch tt.wantBinding {
+			case "byte":
+				if byteErr != nil {
+					t.Fatal(byteErr)
+				}
+				if !gotCutoff.Equal(byteTime) {
+					t.Fatalf("cutoff=%s, want byte %s", gotCutoff.Format(nano), byteTime.Format(nano))
+				}
+			case "age":
+				if !gotCutoff.Equal(ageCutoff) {
+					t.Fatalf("cutoff=%s, want age %s", gotCutoff.Format(nano), ageCutoff.Format(nano))
+				}
+			default:
+				t.Fatalf("unknown binding %q", tt.wantBinding)
+			}
+			s := apptypes.ProjectionSnapshot{
+				Generation:               apptypes.SearchProjectionGeneration{GenerationID: "g"},
+				Phase:                    "source",
+				Now:                      now,
+				RecentCutoffNorm:         tt.byteCutoff,
+				RecentSourceCeilingBytes: 1 << 20,
+			}
+			b := apptypes.SearchProjectionBudget{
+				Rows: 16, WallTime: time.Second, LockTime: time.Second,
+				StoredBytes: 10_000, DecodedBytes: 10_000, WriteBytes: 10_000,
+				RecentAge: age, IndexFamilyBytes: 64 << 20,
+			}
+			for i, d := range tt.docs {
+				s.Documents = append(s.Documents, apptypes.ProjectionDocument{
+					Sequence: int64(i + 1), EventID: d.id, SessionID: "s",
+					CreatedAt: d.created, Text: "body", StoredBytes: 4, DecodedBytes: 4,
+				})
+			}
+			plan, err := usecase.PlanProjectionBatch(s, b)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(plan.Writes) != len(tt.docs) {
+				t.Fatalf("writes=%d, want %d", len(plan.Writes), len(tt.docs))
+			}
+			got := map[string]bool{}
+			for _, w := range plan.Writes {
+				got[w.Document.EventID] = w.RetainRecent
+			}
+			want := map[string]bool{}
+			for _, d := range tt.docs {
+				want[d.id] = d.retain
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("RetainRecent (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/docs/research/search-projection-recent-age.ja.md
+++ b/docs/research/search-projection-recent-age.ja.md
@@ -1,0 +1,22 @@
+# `--recent-age` の bind 測定 (#1755)
+
+[English](./search-projection-recent-age.md)
+
+recent ティアのどちらが bind するかの scratch サイズ測定です。live の約 36 GiB ストアではありません。
+
+## 決定
+
+**`--recent-age` は残します。** 第 3 のフラグは足しません。削除するなら admin の 1 minor deprecation window が要ります。
+
+retention は `created_at > max(now − age, byteCutoff)` です（`RecentRetentionCutoff` / `PlanProjectionBatch`）。
+
+## scratch コーパス（`TestRecentAgeBindingOnScratchCorpora`）
+
+`now = 2026-06-30T00:00:00Z`、age = 30 日（age cutoff = 2026-05-31）。
+
+| 形 | `RecentCutoffNorm` | bind | 残る行 |
+|---|---|---|---|
+| 密な ingest | 2026-06-20 | **byte** | 2026-06-25 残す; 2026-06-10 捨てる（age だけなら残る）; 2026-05-20 捨てる |
+| 静かなストア | 空（walk が交差しない） | **age** | 2026-06-15 残す; 2026-05-20 捨てる |
+
+容量圧があるストアでは byte cutoff のほうが新しいので、30 日フラグは窓を縮めません。age が bind するのは recent ティアがもともと小さいときだけです。`--recent-age` を触るのは、index-family 予算以外の理由で静かなストアの古い行を落とす場合です。

--- a/docs/research/search-projection-recent-age.md
+++ b/docs/research/search-projection-recent-age.md
@@ -1,0 +1,22 @@
+# `--recent-age` binding measurement (#1755)
+
+[日本語](./search-projection-recent-age.ja.md)
+
+Scratch-sized measurement of which recent-tier cutoff binds. Not the live ~36 GiB store.
+
+## Decision
+
+**Keep `--recent-age`.** Do not add a third flag. Removal would need the admin one-minor deprecation window.
+
+Retention is `created_at > max(now − age, byteCutoff)` (`RecentRetentionCutoff` / `PlanProjectionBatch`).
+
+## Scratch corpora (`TestRecentAgeBindingOnScratchCorpora`)
+
+`now = 2026-06-30T00:00:00Z`, age = 30 days (age cutoff = 2026-05-31).
+
+| shape | `RecentCutoffNorm` | binds | retained |
+|---|---|---|---|
+| dense ingest | 2026-06-20 | **byte** | 2026-06-25 yes; 2026-06-10 no (age-only); 2026-05-20 no |
+| quiet store | empty (walk never crossed) | **age** | 2026-06-15 yes; 2026-05-20 no |
+
+On a store with capacity pressure the byte cutoff is newer, so the 30-day flag does not shrink the window. Age binds only when the recent tier is already small. Touch `--recent-age` to drop old rows on a quiet store for a reason other than the index-family budget.

--- a/docs/search-projection-rebuild.ja.md
+++ b/docs/search-projection-rebuild.ja.md
@@ -202,6 +202,23 @@ complete した世代（無ければ上限付きの復号スキャン）で動�
 **世代をまたいだ合計**もこの予算では上限されません。前世代は完全に常駐したままです。
 それが再構築中も検索に答えられる理由であり、回収されるのは終端の cleanup フェーズです。
 
+`--recent-age`（既定 30 日）は残します。retention は
+`created_at > max(ageCutoff, byteCutoff)` です。scratch 測定
+（`TestRecentAgeBindingOnScratchCorpora`）:
+
+| コーパス | byte cutoff | どちらが bind するか |
+|---|---|---|
+| 密な ingest（30 日以内に byte ceiling を超える） | 2026-06-20 | **byte** |
+| 静かなストア（walk が ceiling に届かない） | 空 | **age** |
+
+容量圧があるストアでは byte cutoff のほうが新しいので、`--recent-age` は窓を
+さらに縮めません。age が bind するのは recent ティアがもともと小さいときだけです。
+operator が `--recent-age` を触るのは、index-family 予算以外の理由で静かなストアの
+古い行を落とす場合です。フラグ削除は admin の deprecation window が要ります
+（N で notice、N+1 で削除）。
+[search-projection-recent-age.ja.md](research/search-projection-recent-age.ja.md)
+を参照してください。
+
 source フェーズのカットオフは**構築コストの上限であり、強制機構ではありません**。
 最新 20,000 行を走査します（壁時計タイムアウトではありません）。その単位は保存エンベロープのバイト数であり、
 projection がインデックスする単位ではありません。`thinking` ブロックは走査には

--- a/docs/search-projection-rebuild.md
+++ b/docs/search-projection-rebuild.md
@@ -251,6 +251,22 @@ What is also **not** bounded by this budget is the sum across generations. The
 previous generation stays fully resident — that is what keeps search answerable during
 the rebuild — and is reclaimed only in the terminal cleanup phase.
 
+`--recent-age` (default 30 days) is kept. Retention is
+`created_at > max(ageCutoff, byteCutoff)`. Scratch measurement
+(`TestRecentAgeBindingOnScratchCorpora`):
+
+| corpus | byte cutoff | which binds |
+|---|---|---|
+| dense ingest (byte ceiling crossed inside 30d) | 2026-06-20 | **byte** |
+| quiet store (walk never crosses the ceiling) | empty | **age** |
+
+On a store with capacity pressure the byte cutoff is newer, so `--recent-age`
+does not shrink the window further. Age only binds when the recent tier is
+already small. Operators would touch `--recent-age` to drop old rows on a
+quiet store for reasons other than the index-family budget. Removing the flag
+needs the admin deprecation window (notice in N, removal in N+1). See
+[search-projection-recent-age](research/search-projection-recent-age.md).
+
 The source-phase cutoff is a **build-cost bound, not an enforcement mechanism**. It
 walks the newest 20,000 source rows (not a wall-clock timeout) over stored envelope
 bytes, which is not the unit the


### PR DESCRIPTION
## Summary

#1755 asked whether `--recent-age` can be removed. Scratch measurement on two corpus shapes, then keep-or-remove.

**Keep the flag.** Retention is `created_at > max(ageCutoff, byteCutoff)`.

| corpus | byte cutoff | binds |
|---|---|---|
| dense ingest | 2026-06-20 | **byte** |
| quiet store | empty | **age** |

On a store with capacity pressure the byte cutoff is newer, so 30d does not shrink the window. Age binds when the recent tier is already small. Removing the flag would need the admin one-minor deprecation window. No third flag.

`TestRecentAgeBindingOnScratchCorpora` drives `PlanProjectionBatch`.

## Test plan

- [x] `TestRecentAgeBindingOnScratchCorpora`
- [x] lint + docs i18n

Closes #1755
Leaves parent #1905 open
