### PR TITLE
docs: keep session-tier LIKE; measure porter FTS cost (#1756)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Changed
+- **session ティア検索は exact-keyword + LIKE のまま (#1756)** — unicode61+porter の FTS は測定したうえで足しません。`LIKE '%deploy%'` はすでに `deployed` に当たります。scratch（要約 2,009 件）: ラベル付き集合の LIKE recall は 1.00。比較 FTS は 290,816 バイトで family は 352,256 バイトです。予算外の第 2 index は足しません。`docs/research/search-projection-session-tier-index.ja.md` を参照。
 - **`--recent-age` は残す。bind する条件を測定して書いた (#1755)** — retention は `max(age, byte)`。密な scratch では byte（2026-06-20）が 30 日に勝つ。静かな scratch では byte cutoff が空で age が勝つ。容量圧のあるストアではこのフラグは不要。静かなストアではまだ使える。削除には admin の deprecation window が要る。`docs/research/search-projection-recent-age.ja.md` を参照。
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Changed
+- **Session-tier search stays exact-keyword + LIKE (#1756)** — a unicode61+porter FTS was measured and not added. `LIKE '%deploy%'` already matches `deployed`. Scratch (2,009 summaries): LIKE recall 1.00 on the labeled set; compare FTS costs 290,816 bytes against a 352,256-byte family. No second, unbudgeted index. See `docs/research/search-projection-session-tier-index.md`.
 - **`--recent-age` is kept; the committed measurement names when it binds (#1755)** — retention is `max(age, byte)`. Dense scratch: byte (2026-06-20) wins over 30d. Quiet scratch: empty byte cutoff, age wins. Capacity-pressure stores do not need the flag; quiet stores still can. Removal needs the admin deprecation window. See `docs/research/search-projection-recent-age.md`.
 
 ### Fixed

--- a/docs/research/search-projection-session-tier-index.ja.md
+++ b/docs/research/search-projection-session-tier-index.ja.md
@@ -1,0 +1,45 @@
+# session ティアの index 対 LIKE（#1756）
+
+[English](./search-projection-session-tier-index.md)
+
+session ティアに unicode61+porter の FTS5 が要るかの scratch 測定です。live の約 36 GiB store は対象外です。
+
+## 決定
+
+**exact-keyword + `LIKE` を残します。** session ティアの FTS は足しません。予算外の第 2 index も、新しいフラグも足しません。
+
+`SearchSessionPage` はこれまでどおり `search_projection_session_keywords` の exact match、または `summary_text LIKE '%q%' ESCAPE '\'` です。
+
+## 理由
+
+1. Issue の stemming 例は LIKE の取りこぼしではありません。`LIKE '%deploy%'` は `deployed` に当たります。
+2. 比較用 index は `--index-family-bytes` を消費します。この scratch では 290,816 バイトで、残りの family（352,256）と同じ桁です。1464 MiB 天井ではその分 recent 窓が縮みます。
+3. ラベル付き relevant 集合では LIKE の recall は porter FTS より悪くありません。FTS が勝つのは精度（`undeploy` は substring の余分）とダイアクリティカル（`cafe` ↔ `café`）です。family 予算の index を払う理由には足りません。
+
+## scratch コーパス（`TestSessionTierKeepsLikePathAndMeasuresPorterFTS`）
+
+session 要約 2,009 件（ラベル 9 + filler 2,000）。クエリ集合は既存の session-tier テストと Issue の品質ケースです。porter FTS は比較テーブル（`search_projection_session_compare_fts`）として作り、捨てます。スキーマに `search_projection_session_*fts*` は残りません。
+
+| クエリ | LIKE hits | LIKE recall | LIKE p50 | LIKE p95 | FTS hits | FTS recall | FTS p50 | FTS p95 |
+|---|---|---|---|---|---|---|---|---|
+| unique-session-marker | sess-unique | 1.00 | 2.54 ms | 2.73 ms | sess-unique | 1.00 | 62 µs | 68 µs |
+| filter-needle | sess-filter | 1.00 | 2.44 ms | 2.52 ms | sess-filter | 1.00 | 9 µs | 10 µs |
+| subsecond-marker | sess-subsecond | 1.00 | 2.51 ms | 2.68 ms | sess-subsecond | 1.00 | 9 µs | 9 µs |
+| deploy | deployed, deploy, DEPLOY, **undeploy** | 1.00 | 2.42 ms | 2.53 ms | deployed, deploy, DEPLOY | 1.00 | 9 µs | 10 µs |
+| Deploy | deploy と同じ | 1.00 | 2.44 ms | 2.77 ms | deploy と同じ（undeploy なし） | 1.00 | 9 µs | 9 µs |
+| cafe | cafe のみ | 1.00 | 2.41 ms | 2.75 ms | cafe + café | 1.00 | 8 µs | 9 µs |
+| café | café のみ | 1.00 | 2.40 ms | 2.63 ms | café + cafe | 1.00 | 9 µs | 11 µs |
+
+`deploy` の relevant は `{deployed, deploy, DEPLOY}` です。LIKE の extra は `undeploy`（substring）です。`cafe` / `café` の shipped path は keyword と同じ ASCII fold だけです。
+
+| 時点 | dbstat |
+|---|---|
+| 比較 FTS 前の family | 352,256 |
+| 比較 porter FTS（shadow 含む） | **290,816** |
+| drop 後の family | 352,256 |
+
+1464 MiB 天井ではこの 290,816 バイトは family が recent 窓に回せない分です。多年の session ティアでは index は小さくならず大きくなります。ここでの LIKE レイテンシは 2,009 行の走査であり 36 GiB store ではありません。その走査を買うために予算外 index は足しません。
+
+## 約束
+
+session ティアは exact-keyword + LIKE のままです。後の minor で index を足すなら `--index-family-bytes` に含めます。

--- a/docs/research/search-projection-session-tier-index.md
+++ b/docs/research/search-projection-session-tier-index.md
@@ -1,0 +1,45 @@
+# Session-tier index vs LIKE (#1756)
+
+[日本語](./search-projection-session-tier-index.ja.md)
+
+Scratch-sized measurement of whether the session tier needs a unicode61+porter FTS5 index. Not the live ~36 GiB store.
+
+## Decision
+
+**Keep exact-keyword + `LIKE`.** Do not add a session-tier FTS. No second, unbudgeted index. No new flag.
+
+`SearchSessionPage` stays on `search_projection_session_keywords` exact match or `summary_text LIKE '%q%' ESCAPE '\'`.
+
+## Why
+
+1. The issue's stemming example is not a LIKE miss: `LIKE '%deploy%'` matches `deployed`.
+2. The comparison index charges `--index-family-bytes`. On this scratch it is 290,816 bytes — the same order as the rest of the family (352,256). Those bytes would come out of the recent window at the 1464 MiB ceiling.
+3. LIKE recall is not worse than porter FTS on the labeled relevant sets. FTS wins precision (`undeploy` is a substring extra) and folds diacritics (`cafe` ↔ `café`). That is not enough to pay a family-budget index.
+
+## Scratch corpus (`TestSessionTierKeepsLikePathAndMeasuresPorterFTS`)
+
+2,009 session summaries (9 labeled + 2,000 fillers). Query set from existing session-tier tests plus the issue's quality cases. Porter FTS is a comparison table (`search_projection_session_compare_fts`), then dropped. Schema does not grow `search_projection_session_*fts*`.
+
+| query | LIKE hits | LIKE recall | LIKE p50 | LIKE p95 | FTS hits | FTS recall | FTS p50 | FTS p95 |
+|---|---|---|---|---|---|---|---|---|
+| unique-session-marker | sess-unique | 1.00 | 2.54 ms | 2.73 ms | sess-unique | 1.00 | 62 µs | 68 µs |
+| filter-needle | sess-filter | 1.00 | 2.44 ms | 2.52 ms | sess-filter | 1.00 | 9 µs | 10 µs |
+| subsecond-marker | sess-subsecond | 1.00 | 2.51 ms | 2.68 ms | sess-subsecond | 1.00 | 9 µs | 9 µs |
+| deploy | deployed, deploy, DEPLOY, **undeploy** | 1.00 | 2.42 ms | 2.53 ms | deployed, deploy, DEPLOY | 1.00 | 9 µs | 10 µs |
+| Deploy | same as deploy | 1.00 | 2.44 ms | 2.77 ms | same as deploy (no undeploy) | 1.00 | 9 µs | 9 µs |
+| cafe | cafe only | 1.00 | 2.41 ms | 2.75 ms | cafe + café | 1.00 | 8 µs | 9 µs |
+| café | café only | 1.00 | 2.40 ms | 2.63 ms | café + cafe | 1.00 | 9 µs | 11 µs |
+
+Relevant set for `deploy` is `{deployed, deploy, DEPLOY}`. LIKE extra is `undeploy` (substring). `cafe` / `café` are ASCII-fold only on the shipped path, same as keywords.
+
+| point | dbstat |
+|---|---|
+| family before compare FTS | 352,256 |
+| compare porter FTS (shadow included) | **290,816** |
+| family after drop | 352,256 |
+
+At the 1464 MiB ceiling those 290,816 bytes are recent-window bytes the family cannot keep. A multi-year session tier would make the index larger, not cheaper. LIKE latency here is a 2,009-row scan, not a 36 GiB store; the release still does not add an unbudgeted index to buy that scan.
+
+## Promise
+
+The session tier stays exact-keyword + LIKE. If a later minor adds an index, it counts against `--index-family-bytes`.

--- a/docs/search-projection-rebuild.ja.md
+++ b/docs/search-projection-rebuild.ja.md
@@ -219,6 +219,15 @@ operator が `--recent-age` を触るのは、index-family 予算以外の理由
 [search-projection-recent-age.ja.md](research/search-projection-recent-age.ja.md)
 を参照してください。
 
+session ティアは exact-keyword + `LIKE` のままです。unicode61+porter の FTS は
+測定したうえで足しません（`TestSessionTierKeepsLikePathAndMeasuresPorterFTS`）。
+`LIKE '%deploy%'` はすでに `deployed` に当たります。比較 index は短い要約
+2,009 件で 290,816 バイト、family は 352,256 バイトで、recent 窓を決めるのと
+同じ予算です。ラベル付き集合では LIKE の recall は悪くなく、FTS が勝つのは
+substring の精度とダイアクリティカルだけです。予算外の第 2 index は足しません。
+[search-projection-session-tier-index.ja.md](research/search-projection-session-tier-index.ja.md)
+を参照してください。
+
 source フェーズのカットオフは**構築コストの上限であり、強制機構ではありません**。
 最新 20,000 行を走査します（壁時計タイムアウトではありません）。その単位は保存エンベロープのバイト数であり、
 projection がインデックスする単位ではありません。`thinking` ブロックは走査には

--- a/docs/search-projection-rebuild.md
+++ b/docs/search-projection-rebuild.md
@@ -267,6 +267,15 @@ quiet store for reasons other than the index-family budget. Removing the flag
 needs the admin deprecation window (notice in N, removal in N+1). See
 [search-projection-recent-age](research/search-projection-recent-age.md).
 
+The session tier stays exact-keyword + `LIKE`. A unicode61+porter FTS was
+measured and not added (`TestSessionTierKeepsLikePathAndMeasuresPorterFTS`).
+`LIKE '%deploy%'` already matches `deployed`. The comparison index cost
+290,816 bytes on 2,009 short summaries against a 352,256-byte family — the
+same budget that sizes the recent window. LIKE recall is not worse on the
+labeled set; FTS only wins substring precision and diacritic folding. No
+second, unbudgeted index. See
+[search-projection-session-tier-index](research/search-projection-session-tier-index.md).
+
 The source-phase cutoff is a **build-cost bound, not an enforcement mechanism**. It
 walks the newest 20,000 source rows (not a wall-clock timeout) over stored envelope
 bytes, which is not the unit the

--- a/infrastructure/sqlite/search_projection_session_query.go
+++ b/infrastructure/sqlite/search_projection_session_query.go
@@ -97,6 +97,9 @@ func queryProjectionSessionHits(
 		         )
 		         OR sum.summary_text LIKE ? ESCAPE '\'
 		       )`)
+	// Exact keyword + LIKE is the shipped session-tier match (#1756).
+	// A porter FTS was measured and not added: LIKE already matches
+	// stemming-as-substring, and the index would charge the family budget.
 	keyword := foldSearchASCII(queryValue)
 	likeQuery := "%" + escapeLikeQuery(queryValue) + "%"
 	args := []any{keyword, likeQuery}

--- a/infrastructure/sqlite/search_projection_session_tier_index_test.go
+++ b/infrastructure/sqlite/search_projection_session_tier_index_test.go
@@ -1,0 +1,339 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const sessionTierCompareFTS = "search_projection_session_compare_fts"
+
+const sessionTierFamilyBytesSQL = `
+SELECT COALESCE(SUM(pgsize), 0)
+  FROM dbstat
+ WHERE name IN (
+         SELECT name
+           FROM sqlite_schema
+          WHERE name GLOB 'search_projection_*'
+             OR tbl_name GLOB 'search_projection_*'
+             OR name GLOB 'literal_search_*'
+             OR tbl_name GLOB 'literal_search_*'
+       )`
+
+// TestSessionTierKeepsLikePathAndMeasuresPorterFTS is the #1756 scratch
+// measurement. SearchSessionPage stays on exact-keyword + LIKE. The porter
+// FTS is created only for the comparison, then dropped.
+func TestSessionTierKeepsLikePathAndMeasuresPorterFTS(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 6, 19, 10, 0, 0, 0, time.UTC)
+	labeled := []projectionSessionSeed{
+		{sessionID: "sess-unique", summary: "discussed unique-session-marker during planning", eventCount: 12, startedAt: base, workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-filter", summary: "filter-needle older summary", eventCount: 4, startedAt: base.Add(time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-subsecond", summary: "planning notes with subsecond-marker", eventCount: 3, startedAt: base.Add(2 * time.Second), workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-deployed", summary: "the service was deployed to staging", eventCount: 8, startedAt: base.Add(3 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-deploy", summary: "deploy the service tonight", eventCount: 5, startedAt: base.Add(4 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-case", summary: "Discussed DEPLOY pipeline", eventCount: 2, startedAt: base.Add(5 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-undeploy", summary: "we will undeploy later", eventCount: 1, startedAt: base.Add(6 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-cafe-ascii", summary: "cafe rollout notes", eventCount: 2, startedAt: base.Add(7 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-cafe-accent", summary: "café rollout notes", eventCount: 2, startedAt: base.Add(8 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
+	}
+	seedCompleteProjection(t, dbPath, "gen-1756", nil, labeled, nil)
+
+	const fillers = 2000
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		tx, err := db.Begin()
+		if err != nil {
+			t.Fatalf("begin filler insert: %v", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		for i := 0; i < fillers; i++ {
+			id := fmt.Sprintf("sess-fill-%04d", i)
+			started := base.Add(time.Duration(i+10) * time.Minute).UTC().Format(time.RFC3339Nano)
+			if _, err := tx.Exec(`
+				INSERT OR REPLACE INTO sessions(session_id, started_at, client, agent, workspace)
+				VALUES (?, ?, 'cli', 'codex', ?)`, id, started, workspace.String()); err != nil {
+				t.Fatalf("insert filler session %s: %v", id, err)
+			}
+			summary := fmt.Sprintf("session filler notes %d about planning and review", i)
+			if _, err := tx.Exec(`
+				INSERT INTO search_projection_session_summaries(
+					generation_id, session_id, event_count, summary_text, projection_version, summary_version
+				) VALUES ('gen-1756', ?, 1, ?, 1, 1)`, id, summary); err != nil {
+				t.Fatalf("insert filler summary %s: %v", id, err)
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit fillers: %v", err)
+		}
+	})
+
+	queries := []struct {
+		name     string
+		query    string
+		relevant []string
+	}{
+		{name: "unique-session-marker", query: "unique-session-marker", relevant: []string{"sess-unique"}},
+		{name: "filter-needle", query: "filter-needle", relevant: []string{"sess-filter"}},
+		{name: "subsecond-marker", query: "subsecond-marker", relevant: []string{"sess-subsecond"}},
+		{name: "deploy-stem", query: "deploy", relevant: []string{"sess-deployed", "sess-deploy", "sess-case"}},
+		{name: "deploy-case", query: "Deploy", relevant: []string{"sess-deployed", "sess-deploy", "sess-case"}},
+		{name: "cafe-ascii", query: "cafe", relevant: []string{"sess-cafe-ascii"}},
+		{name: "cafe-accent", query: "café", relevant: []string{"sess-cafe-accent"}},
+	}
+
+	likeByQuery := map[string]sessionTierPathStats{}
+	for _, q := range queries {
+		criteria := apptypes.NewEventSearchCriteriaBuilder(50).
+			Query(q.query).
+			Workspace(workspace).
+			Build()
+		hits, err := sut.SearchSessionPage(ctx, criteria, nil)
+		if err != nil {
+			t.Fatalf("SearchSessionPage(%q) error = %v", q.query, err)
+		}
+		if hits.State() != apptypes.SearchSessionTierReady {
+			t.Fatalf("SearchSessionPage(%q) state = %q, want ready", q.query, hits.State())
+		}
+		got := sessionHitIDs(hits.Hits())
+		samples := make([]time.Duration, 0, 20)
+		for i := 0; i < 20; i++ {
+			start := time.Now()
+			page, err := sut.SearchSessionPage(ctx, criteria, nil)
+			elapsed := time.Since(start)
+			if err != nil {
+				t.Fatalf("SearchSessionPage(%q) timed error = %v", q.query, err)
+			}
+			if page.State() != apptypes.SearchSessionTierReady {
+				t.Fatalf("SearchSessionPage(%q) timed state = %q", q.query, page.State())
+			}
+			samples = append(samples, elapsed)
+		}
+		likeByQuery[q.name] = measurePath(got, q.relevant, samples)
+	}
+
+	deployLike := likeByQuery["deploy-stem"]
+	if !containsAll(deployLike.hits, []string{"sess-deployed", "sess-deploy", "sess-case"}) {
+		t.Fatalf("LIKE deploy hits = %v, want stemming-as-substring of deployed/deploy/DEPLOY", deployLike.hits)
+	}
+	if deployLike.recall != 1 {
+		t.Fatalf("LIKE deploy recall = %v, want 1 (stemming is not a LIKE miss)", deployLike.recall)
+	}
+
+	var familyBefore, compareFTS, familyAfterDrop int64
+	ftsByQuery := map[string]sessionTierPathStats{}
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if err := db.QueryRow(sessionTierFamilyBytesSQL).Scan(&familyBefore); err != nil {
+			t.Fatalf("family before: %v", err)
+		}
+		if _, err := db.Exec(`
+			CREATE VIRTUAL TABLE ` + sessionTierCompareFTS + ` USING fts5(
+				session_id UNINDEXED,
+				summary_text,
+				tokenize = 'porter unicode61'
+			)`); err != nil {
+			t.Fatalf("create compare FTS: %v", err)
+		}
+		if _, err := db.Exec(`
+			INSERT INTO ` + sessionTierCompareFTS + `(session_id, summary_text)
+			SELECT session_id, summary_text
+			  FROM search_projection_session_summaries
+			 WHERE generation_id = 'gen-1756'`); err != nil {
+			t.Fatalf("populate compare FTS: %v", err)
+		}
+		if err := db.QueryRow(`
+			SELECT COALESCE(SUM(pgsize),0)
+			  FROM dbstat
+			 WHERE name IN (
+			         SELECT name FROM sqlite_schema
+			          WHERE name GLOB '` + sessionTierCompareFTS + `*'
+			             OR tbl_name GLOB '` + sessionTierCompareFTS + `*'
+			       )`).Scan(&compareFTS); err != nil {
+			t.Fatalf("compare FTS dbstat: %v", err)
+		}
+		if compareFTS <= 0 {
+			t.Fatalf("compare FTS dbstat = %d, want a positive family charge", compareFTS)
+		}
+
+		for _, q := range queries {
+			phrase := sessionTierFTSPhrase(q.query)
+			got := queryCompareFTS(t, db, phrase)
+			samples := make([]time.Duration, 0, 20)
+			for i := 0; i < 20; i++ {
+				start := time.Now()
+				_ = queryCompareFTS(t, db, phrase)
+				samples = append(samples, time.Since(start))
+			}
+			ftsByQuery[q.name] = measurePath(got, q.relevant, samples)
+		}
+
+		if _, err := db.Exec(`DROP TABLE ` + sessionTierCompareFTS); err != nil {
+			t.Fatalf("drop compare FTS: %v", err)
+		}
+		if err := db.QueryRow(sessionTierFamilyBytesSQL).Scan(&familyAfterDrop); err != nil {
+			t.Fatalf("family after drop: %v", err)
+		}
+		var leftover int
+		if err := db.QueryRow(`
+			SELECT COUNT(*) FROM sqlite_master
+			 WHERE name LIKE 'search_projection_session_%fts%'
+			    OR name LIKE 'search_projection_session%fts%'`).Scan(&leftover); err != nil {
+			t.Fatalf("schema leftover: %v", err)
+		}
+		if leftover != 0 {
+			t.Fatalf("schema grew a session-tier FTS (%d leftover names)", leftover)
+		}
+	})
+	if familyAfterDrop != familyBefore {
+		t.Fatalf("family after drop = %d, before = %d", familyAfterDrop, familyBefore)
+	}
+
+	const ceiling = 1464 << 20
+	t.Logf("session-tier #1756 family_before=%d compare_fts=%d family_after_drop=%d ceiling=%d recent_bytes_displaced=%d",
+		familyBefore, compareFTS, familyAfterDrop, ceiling, compareFTS)
+	for _, q := range queries {
+		like := likeByQuery[q.name]
+		fts := ftsByQuery[q.name]
+		t.Logf("query=%s like_hits=%v like_recall=%.2f like_p50=%s like_p95=%s like_extra=%v fts_hits=%v fts_recall=%.2f fts_p50=%s fts_p95=%s fts_extra=%v fts_missing=%v",
+			q.name, like.hits, like.recall, like.p50, like.p95, like.extra,
+			fts.hits, fts.recall, fts.p50, fts.p95, fts.extra, fts.missing)
+	}
+
+	// Cafe ASCII is a LIKE hit; accented café is a LIKE hit for the accented
+	// query. Searching "cafe" is not required to match "café" — ASCII fold
+	// only, same as the keyword path.
+	if !containsAll(likeByQuery["cafe-ascii"].hits, []string{"sess-cafe-ascii"}) {
+		t.Fatalf("LIKE cafe hits = %v, want sess-cafe-ascii", likeByQuery["cafe-ascii"].hits)
+	}
+	if !containsAll(likeByQuery["cafe-accent"].hits, []string{"sess-cafe-accent"}) {
+		t.Fatalf("LIKE café hits = %v, want sess-cafe-accent", likeByQuery["cafe-accent"].hits)
+	}
+}
+
+func sessionTierFTSPhrase(query string) string {
+	folded := strings.Map(func(r rune) rune {
+		if r >= 'A' && r <= 'Z' {
+			return r + ('a' - 'A')
+		}
+		return r
+	}, strings.TrimSpace(query))
+	return `"` + strings.ReplaceAll(folded, `"`, `""`) + `"`
+}
+
+func queryCompareFTS(t *testing.T, db *sql.DB, phrase string) []string {
+	t.Helper()
+	rows, err := db.Query(`SELECT session_id FROM `+sessionTierCompareFTS+` WHERE `+sessionTierCompareFTS+` MATCH ?`, phrase)
+	if err != nil {
+		t.Fatalf("compare FTS MATCH %s: %v", phrase, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan compare FTS: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate compare FTS: %v", err)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+type sessionTierPathStats struct {
+	hits    []string
+	recall  float64
+	p50     time.Duration
+	p95     time.Duration
+	extra   []string
+	missing []string
+}
+
+func measurePath(got, relevant []string, samples []time.Duration) sessionTierPathStats {
+	sorted := append([]string(nil), got...)
+	sort.Strings(sorted)
+	relevantSet := map[string]struct{}{}
+	for _, id := range relevant {
+		relevantSet[id] = struct{}{}
+	}
+	gotSet := map[string]struct{}{}
+	for _, id := range sorted {
+		gotSet[id] = struct{}{}
+	}
+	var extra, missing []string
+	hitRelevant := 0
+	for _, id := range relevant {
+		if _, ok := gotSet[id]; ok {
+			hitRelevant++
+		} else {
+			missing = append(missing, id)
+		}
+	}
+	for _, id := range sorted {
+		if _, ok := relevantSet[id]; !ok {
+			extra = append(extra, id)
+		}
+	}
+	recall := 0.0
+	if len(relevant) > 0 {
+		recall = float64(hitRelevant) / float64(len(relevant))
+	}
+	return sessionTierPathStats{
+		hits:    sorted,
+		recall:  recall,
+		p50:     durationPercentile(samples, 0.50),
+		p95:     durationPercentile(samples, 0.95),
+		extra:   extra,
+		missing: missing,
+	}
+}
+
+func durationPercentile(samples []time.Duration, p float64) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	idx := int(math.Ceil(p*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func containsAll(got, want []string) bool {
+	set := map[string]struct{}{}
+	for _, id := range got {
+		set[id] = struct{}{}
+	}
+	for _, id := range want {
+		if _, ok := set[id]; !ok {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

#1756 asked whether the session tier needs a real index before #1679's LIKE deferral becomes permanent. Scratch measurement, then keep-or-add.

**Keep exact-keyword + `LIKE`.** No session-tier FTS. No second, unbudgeted index. No new flag.

| path | deploy recall | extra | family charge |
|---|---|---|---|
| shipped LIKE | 1.00 (`deployed` is a substring) | `undeploy` | 0 |
| compare porter FTS | 1.00 | none (diacritics fold) | **290,816** vs family 352,256 |

Stemming is not a LIKE miss. The comparison index is the same order as the rest of the scratch family; those bytes would come out of the recent window at 1464 MiB. `TestSessionTierKeepsLikePathAndMeasuresPorterFTS` drives `SearchSessionPage` and drops the compare table.

## Test plan

- [x] `TestSessionTierKeepsLikePathAndMeasuresPorterFTS`
- [x] related session-page tests
- [x] lint + docs i18n

Closes #1756
Leaves parent #1905 open
