### PR TITLE
fix: inherit Kimi turn guard on spool and hook transcript (#1696)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Fixed
+- **spool と generic な Kimi transcript 記録が turn guard を継承する (#1696)** — `hook transcript kimi` と `command=transcript` の spool replay は、`hook kimi stop` と同じ (session, wire turn, fingerprint) ガードを通る。live store（`mode=ro`、2026-08-15）: `source_hook=stop` / `kind=transcript` / `agent=kimi` は 249,042 件（`client` は `hook`）。`hook_deliveries` に Kimi の `stop` 行はないので spool と live はそこでは分けられない。fail-open と成長 turn の記録は変えない。
+
 ## [v0.37.0] - 2026-08-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Fixed
+- **Spooled and generic Kimi transcript recording inherit the turn guard (#1696)** — `hook transcript kimi` and spool replay of `command=transcript` now go through the same per-(session, wire turn, fingerprint) guard as `hook kimi stop`. Live store (`mode=ro`, 2026-08-15): 249,042 `source_hook=stop` / `kind=transcript` / `agent=kimi` rows (`client` is `hook`). `hook_deliveries` has no Kimi `stop` rows, so spool vs live cannot be split there. Fail-open and growing-turn recording are unchanged.
+
 ## [v0.37.0] - 2026-08-15
 
 ### Changed

--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -13,6 +13,23 @@ import (
 // ResolveDBPath exposes resolveDBPath for tests.
 var ResolveDBPath = resolveDBPath
 
+// PersistTestHookSpoolRecord writes a replayable spool record for tests.
+func PersistTestHookSpoolRecord(command, client, payload string) (string, error) {
+	return persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       command,
+		Client:        client,
+		Payload:       payload,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	})
+}
+
+// DrainTestHookSpoolRecords replays pending spool records through the
+// production drain path.
+func (c *RootCLI) DrainTestHookSpoolRecords(ctx context.Context, limit int) (replayed, failed int) {
+	return c.drainHookSpoolRecords(ctx, limit)
+}
+
 // ExpectedCodexPluginHookCount exposes the current packaged hook cardinality
 // so black-box doctor tests cannot silently drift from the production contract.
 var ExpectedCodexPluginHookCount = expectedCodexPluginHookCount

--- a/presentation/cli/hook_kimi.go
+++ b/presentation/cli/hook_kimi.go
@@ -244,7 +244,9 @@ func (c *RootCLI) runHookKimiStop(ctx context.Context, input io.Reader, dbPath s
 }
 
 // runHookKimiTranscript wraps the shared transcript recorder with a
-// per-(session, wire turn ID, content fingerprint) idempotency guard. Kimi's
+// per-(session, wire turn ID, content fingerprint) idempotency guard.
+// Native Stop calls it directly; generic `hook transcript kimi` and spool
+// replay of command=transcript reach it through runHookTranscript (#1696). Kimi's
 // Stop hook fires roughly two dozen times per completed turn, with
 // redeliveries observed as little as ~0.14s apart — including effectively
 // concurrent firings. Extraction itself is correct (it already resolves only

--- a/presentation/cli/hook_kimi_transcript_idempotency_test.go
+++ b/presentation/cli/hook_kimi_transcript_idempotency_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -471,6 +472,104 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 			t.Fatalf("transcript body = %q, want it to contain the wire log text", retryEvent.logCalls[0].message)
 		}
 	})
+}
+
+// TestRootCLI_HookTranscriptAndSpoolInheritKimiTurnGuard is #1696: the
+// generic hook transcript command and spool replay of command=transcript
+// must use the same (session, wire turn, fingerprint) guard as Stop.
+func TestRootCLI_HookTranscriptAndSpoolInheritKimiTurnGuard(t *testing.T) {
+	const sessionID = "session_00000000-0000-4000-8000-000000000001"
+
+	setup := func(t *testing.T, key string) (string, *eventUsecaseStub, *sessionUsecaseStub) {
+		t.Helper()
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", key)
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"inherited guard reply"}}}`,
+		})
+		return readKimiFixture(t, "stop.json"), &eventUsecaseStub{}, &sessionUsecaseStub{}
+	}
+
+	t.Run("generic hook transcript kimi does not re-record an already recorded turn", func(t *testing.T) {
+		payload, eventStub, sessionStub := setup(t, "kimi-turn-inherit-generic")
+		runKimiHook(t, "stop", payload, eventStub, sessionStub)
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("Stop log calls = %d, want 1", got)
+		}
+		runHookTranscriptCommand(t, "kimi", payload, eventStub, sessionStub)
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("after hook transcript kimi: log calls = %d, want 1 (guard must inherit)", got)
+		}
+	})
+
+	t.Run("spool replay of command=transcript does not re-record an already recorded turn", func(t *testing.T) {
+		payload, eventStub, sessionStub := setup(t, "kimi-turn-inherit-spool")
+		root := runKimiHookRoot(t, "stop", payload, eventStub, sessionStub)
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("Stop log calls = %d, want 1", got)
+		}
+		if _, err := cli.PersistTestHookSpoolRecord("transcript", "kimi", payload); err != nil {
+			t.Fatalf("persist spool transcript: %v", err)
+		}
+		replayed, failed := root.DrainTestHookSpoolRecords(context.Background(), 5)
+		if replayed != 1 || failed != 0 {
+			t.Fatalf("drain transcript spool: replayed=%d failed=%d, want 1/0", replayed, failed)
+		}
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("after transcript spool replay: log calls = %d, want 1 (guard must inherit)", got)
+		}
+	})
+}
+
+func runHookTranscriptCommand(
+	t *testing.T,
+	client string,
+	payload string,
+	eventStub *eventUsecaseStub,
+	sessionStub *sessionUsecaseStub,
+) {
+	t.Helper()
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(payload))
+	rootCmd.SetArgs([]string{"hook", "transcript", client})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(hook transcript %s) error = %v", client, err)
+	}
+}
+
+func runKimiHookRoot(
+	t *testing.T,
+	event string,
+	payload string,
+	eventStub *eventUsecaseStub,
+	sessionStub *sessionUsecaseStub,
+) *cli.RootCLI {
+	t.Helper()
+	root := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSession(sessionStub),
+	)
+	rootCmd := root.Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(payload))
+	rootCmd.SetArgs([]string{"hook", "kimi", event})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(hook kimi %s) error = %v", event, err)
+	}
+	return root
 }
 
 // appendKimiWireRow appends one more row to an already-seeded session's

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -861,10 +861,13 @@ var resolveHookTranscriptSessionIDFunc = resolveHookSessionID
 // capture is a nice-to-have, not a requirement for sessions to close
 // cleanly.
 //
-// This is a thin wrapper around runHookTranscriptWithBlocks that always
-// uses the client's registered extractor; every caller except Kimi's
-// idempotency guard (hook_kimi.go) goes through here and is unaffected by
-// that guard's pre-extracted-blocks path.
+// runHookTranscript is the single transcript-recording entry used by
+// generic `hook transcript <client>` and by spool replay of
+// command=transcript. Clients with a turn guard (today: Kimi) are
+// dispatched to that guard so those paths inherit the same fail-open
+// idempotency as the native Stop command (#1696). Other clients still
+// extract through the registered extractor inside
+// runHookTranscriptWithBlocks.
 //
 // Like runHookTranscriptWithBlocks, recorded is true only when a row was
 // actually persisted. Callers that gate follow-up work on a successful write
@@ -876,7 +879,25 @@ func (c *RootCLI) runHookTranscript(
 	client string,
 	dbPath string,
 ) (bool, error) {
+	if recorder, ok := transcriptTurnRecorderFor(client); ok {
+		payload, err := readHookPayload(input)
+		if err != nil {
+			return false, err
+		}
+		return recorder(c, ctx, payload, dbPath)
+	}
 	return c.runHookTranscriptWithBlocks(ctx, input, client, dbPath, nil)
+}
+
+// transcriptTurnRecorderFor returns the per-client turn guard that must wrap
+// persist, if any. The Kimi recorder is the only registration: its turn
+// identity lives in the session wire log, not in the hook envelope. Adding
+// another client means adding a resolver here, not wrapping each caller.
+func transcriptTurnRecorderFor(client string) (func(*RootCLI, context.Context, []byte, string) (bool, error), bool) {
+	if client == kimiHookClient {
+		return (*RootCLI).runHookKimiTranscript, true
+	}
+	return nil, false
 }
 
 // runHookTranscriptWithBlocks is the shared implementation behind


### PR DESCRIPTION
## Summary

#1696: the Kimi turn guard lived only in `runHookKimiTranscript` (`hook kimi stop`). Generic `hook transcript kimi` and spool replay of `command=transcript` went through `runHookTranscript` unguarded.

`runHookTranscript` now dispatches `client=kimi` to that same guard. Native Stop still calls `runHookKimiTranscript` directly (no nested lock). Fail-open and growing-turn recording are unchanged (#1697 is separate).

Live store (`sqlite3` `mode=ro`, 2026-08-15): 249,042 Kimi stop transcripts (`client=hook`, `agent=kimi`). Same-body extras exist historically (#1681). `hook_deliveries` has no Kimi `stop` rows, so spool vs live cannot be split. Measurement is on the issue.

## Test plan

- [x] `TestRootCLI_HookTranscriptAndSpoolInheritKimiTurnGuard`
- [x] existing `TestRootCLI_HookKimiStop_TranscriptTurnIdempotency`
- [x] `go tool golangci-lint run ./presentation/cli/`

Closes #1696
Leaves parent #1906 open
