### PR TITLE
fix: supersede earlier Kimi transcript when a turn grows

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **成長する Kimi turn は最終 transcript 1 行を残す (#1697)** — 同じ wire turn ID で fingerprint が変わったあとの Stop は長い本文を先に書き、marker の前の event id を消す。delete 失敗と 2 フィールドの `#1681` marker は fail-open（新しい行は残し、古い行は残す）。scratch: `hook kimi stop` のあと、同じ turn の長い payload では `kind=transcript` が 1 行になり、追記テキストを含む。
 - **spool と generic な Kimi transcript 記録が turn guard を継承する (#1696)** — `hook transcript kimi` と `command=transcript` の spool replay は、`hook kimi stop` と同じ (session, wire turn, fingerprint) ガードを通る。live store（`mode=ro`、2026-08-15）: `source_hook=stop` / `kind=transcript` / `agent=kimi` は 249,042 件（`client` は `hook`）。`hook_deliveries` に Kimi の `stop` 行はないので spool と live はそこでは分けられない。fail-open と成長 turn の記録は変えない。
 
 ## [v0.37.0] - 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Growing Kimi turns leave one final transcript row (#1697)** — a later Stop for the same wire turn ID with a new fingerprint appends the longer body, then deletes the previous transcript id from the marker. Delete failure and two-field `#1681` markers fail open (the new row stays; the old row is left). Scratch: `hook kimi stop` then a longer same-turn payload leaves one `kind=transcript` row that contains the appended text.
 - **Spooled and generic Kimi transcript recording inherit the turn guard (#1696)** — `hook transcript kimi` and spool replay of `command=transcript` now go through the same per-(session, wire turn, fingerprint) guard as `hook kimi stop`. Live store (`mode=ro`, 2026-08-15): 249,042 `source_hook=stop` / `kind=transcript` / `agent=kimi` rows (`client` is `hook`). `hook_deliveries` has no Kimi `stop` rows, so spool vs live cannot be split there. Fail-open and growing-turn recording are unchanged.
 
 ## [v0.37.0] - 2026-08-15

--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -19,6 +19,11 @@ type EventUsecase interface {
 	// to re-implement that policy in the presentation layer.
 	Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error)
 
+	// DeleteTranscript removes one previously logged transcript event.
+	// Missing or non-transcript ids return nil so a failed supersede can
+	// fail open without aborting the newer write.
+	DeleteTranscript(ctx context.Context, eventID types.EventID) error
+
 	// Audit records a command execution audit event. The AuditInput value
 	// object carries the command, attribution, exit code, and structural
 	// failure flag; auditCfg carries the redaction policy.

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -121,6 +121,20 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 	return event, nil
 }
 
+func (u *eventUsecase) DeleteTranscript(ctx context.Context, eventID types.EventID) error {
+	if u.eventRepo == nil {
+		return xerrors.Errorf("event repository is not configured")
+	}
+	parsed, err := types.EventIDFrom(eventID.String())
+	if err != nil {
+		return xerrors.Errorf("failed to resolve event ID: %w", err)
+	}
+	if err := u.eventRepo.DeleteTranscript(ctx, parsed); err != nil {
+		return xerrors.Errorf("failed to delete transcript event: %w", err)
+	}
+	return nil
+}
+
 func (u *eventUsecase) Audit(ctx context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	if u.eventRepo == nil {
 		return nil, nil, xerrors.Errorf("event repository is not configured")

--- a/application/usecase/record_command_audit_test.go
+++ b/application/usecase/record_command_audit_test.go
@@ -34,6 +34,10 @@ func (s *commandAuditSaverStub) SaveWithAudit(
 	return s.err
 }
 
+func (s *commandAuditSaverStub) DeleteTranscript(_ context.Context, _ types.EventID) error {
+	return nil
+}
+
 func TestEventUsecase_Audit(t *testing.T) {
 	t.Parallel()
 

--- a/application/usecase/record_log_test.go
+++ b/application/usecase/record_log_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 type eventRepositoryStub struct {
-	savedEvent *model.Event
-	err        error
+	savedEvent          *model.Event
+	err                 error
+	deletedTranscriptID types.EventID
+	deleteTranscriptErr error
 }
 
 func (s *eventRepositoryStub) Save(_ context.Context, event *model.Event) error {
@@ -26,6 +28,11 @@ func (s *eventRepositoryStub) Save(_ context.Context, event *model.Event) error 
 func (s *eventRepositoryStub) SaveWithAudit(_ context.Context, event *model.Event, _ *model.CommandAudit) error {
 	s.savedEvent = event
 	return s.err
+}
+
+func (s *eventRepositoryStub) DeleteTranscript(_ context.Context, eventID types.EventID) error {
+	s.deletedTranscriptID = eventID
+	return s.deleteTranscriptErr
 }
 
 func TestEventUsecase_Log(t *testing.T) {
@@ -287,4 +294,32 @@ func TestEventUsecase_Log_LeavesSourceHookEmptyWithoutContext(t *testing.T) {
 	if got.SourceHook() != "" {
 		t.Errorf("SourceHook() = %q, want empty for non-hook ctx", got.SourceHook())
 	}
+}
+
+func TestEventUsecase_DeleteTranscript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("forwards a resolved id to the repository", func(t *testing.T) {
+		t.Parallel()
+		stub := &eventRepositoryStub{}
+		sut := usecase.NewEventUsecase(stub, nil)
+		if err := sut.DeleteTranscript(context.Background(), types.EventID("evt-1")); err != nil {
+			t.Fatalf("DeleteTranscript() error = %v", err)
+		}
+		if stub.deletedTranscriptID.String() != "evt-1" {
+			t.Fatalf("deleted id = %q, want evt-1", stub.deletedTranscriptID)
+		}
+	})
+
+	t.Run("rejects an empty id", func(t *testing.T) {
+		t.Parallel()
+		stub := &eventRepositoryStub{}
+		sut := usecase.NewEventUsecase(stub, nil)
+		if err := sut.DeleteTranscript(context.Background(), types.EventID("")); err == nil {
+			t.Fatal("DeleteTranscript() error = nil, want error")
+		}
+		if stub.deletedTranscriptID != "" {
+			t.Fatalf("repository should not be called for an empty id")
+		}
+	})
 }

--- a/domain/model/event_repository.go
+++ b/domain/model/event_repository.go
@@ -1,6 +1,10 @@
 package model
 
-import "context"
+import (
+	"context"
+
+	"github.com/duck8823/traceary/domain/types"
+)
 
 // EventRepository persists Event aggregates.
 type EventRepository interface {
@@ -8,4 +12,7 @@ type EventRepository interface {
 	Save(ctx context.Context, event *Event) error
 	// SaveWithAudit persists an event together with its command audit.
 	SaveWithAudit(ctx context.Context, event *Event, audit *CommandAudit) error
+	// DeleteTranscript removes one transcript event by id. It is a no-op
+	// for a missing id or a non-transcript row (returns nil, 0 deleted).
+	DeleteTranscript(ctx context.Context, eventID types.EventID) error
 }

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -21,6 +21,9 @@ import (
 //go:embed sql/insert_event.sql
 var insertEventQuery string
 
+//go:embed sql/delete_transcript_event.sql
+var deleteTranscriptEventQuery string
+
 //go:embed sql/insert_command_audit.sql
 var insertCommandAuditQuery string
 
@@ -84,6 +87,29 @@ func (d *EventDatasource) Save(ctx context.Context, event *model.Event) error {
 		return err
 	}
 	return saveEventTransaction(ctx, db, event, nil, codecMetadata, nil, storePath)
+}
+
+// DeleteTranscript removes one transcript event. Missing or non-transcript
+// ids succeed so a supersede can fail open.
+func (d *EventDatasource) DeleteTranscript(ctx context.Context, eventID types.EventID) error {
+	parsed, err := types.EventIDFrom(eventID.String())
+	if err != nil {
+		return xerrors.Errorf("event ID must not be empty: %w", err)
+	}
+	storePath := d.db.Path()
+	db, err := d.db.openAt(ctx, storePath)
+	if err != nil {
+		return xerrors.Errorf("failed to open DB for transcript delete: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+	if _, err := db.ExecContext(ctx, deleteTranscriptEventQuery, parsed.String()); err != nil {
+		return xerrors.Errorf("failed to delete transcript event: %w", err)
+	}
+	return nil
 }
 
 // SaveWithAudit persists an event together with its command audit.

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -509,6 +509,86 @@ func newEventForSQLiteTest(
 	)
 }
 
+func TestDatasource_DeleteTranscript(t *testing.T) {
+	t.Parallel()
+
+	migrations := fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
+    created_at TEXT NOT NULL,
+    source_hook TEXT
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';
+`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    command_wrapper TEXT NOT NULL DEFAULT '',
+    command_name TEXT NOT NULL DEFAULT 'unknown',
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    input_original_bytes INTEGER NOT NULL DEFAULT 0,
+    output_original_bytes INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0,
+    failure_reason TEXT NOT NULL DEFAULT 'unknown'
+);`),
+		},
+	}
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	transcript := newEventForSQLiteTest(t, "evt-transcript", "hook", "kimi", "session-1", "ws", "short", time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC))
+	transcript = model.EventOf(transcript.EventID(), types.EventKindTranscript, transcript.Client(), transcript.Agent(), transcript.SessionID(), transcript.Workspace(), transcript.Body(), transcript.CreatedAt())
+	note := newEventForSQLiteTest(t, "evt-note", "cli", "kimi", "session-1", "ws", "keep me", time.Date(2026, 8, 15, 12, 1, 0, 0, time.UTC))
+	if err := sut.Save(context.Background(), transcript); err != nil {
+		t.Fatalf("Save(transcript) error = %v", err)
+	}
+	if err := sut.Save(context.Background(), note); err != nil {
+		t.Fatalf("Save(note) error = %v", err)
+	}
+
+	if err := sut.DeleteTranscript(context.Background(), transcript.EventID()); err != nil {
+		t.Fatalf("DeleteTranscript(transcript) error = %v", err)
+	}
+	if err := sut.DeleteTranscript(context.Background(), note.EventID()); err != nil {
+		t.Fatalf("DeleteTranscript(note) error = %v", err)
+	}
+	if err := sut.DeleteTranscript(context.Background(), types.EventID("missing")); err != nil {
+		t.Fatalf("DeleteTranscript(missing) error = %v", err)
+	}
+
+	got, err := sut.ListRecent(context.Background(), 10, 0, types.EventKind(""), types.Client(""), types.Agent(""), types.SessionID(""), types.Workspace(""), false, time.Time{}, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListRecent() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(got))
+	}
+	if got[0].EventID().String() != "evt-note" {
+		t.Fatalf("remaining id = %q, want evt-note", got[0].EventID())
+	}
+}
+
 func TestDatasource_ListWindow_ReturnsAllEventsAcrossBatches(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/sql/delete_transcript_event.sql
+++ b/infrastructure/sqlite/sql/delete_transcript_event.sql
@@ -1,0 +1,3 @@
+DELETE FROM events
+WHERE id = ?
+  AND kind = 'transcript';

--- a/presentation/cli/doctor_metadata_only_internal_test.go
+++ b/presentation/cli/doctor_metadata_only_internal_test.go
@@ -22,6 +22,9 @@ type hydrateCallTrackingEventUC struct {
 func (u *hydrateCallTrackingEventUC) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace, apptypes.LogRedaction) (*model.Event, error) {
 	return nil, nil
 }
+func (u *hydrateCallTrackingEventUC) DeleteTranscript(context.Context, types.EventID) error {
+	return nil
+}
 func (u *hydrateCallTrackingEventUC) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	return nil, nil, nil
 }

--- a/presentation/cli/hook_kimi.go
+++ b/presentation/cli/hook_kimi.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/types"
 )
 
 const kimiHookClient = "kimi"
@@ -275,11 +276,11 @@ func (c *RootCLI) runHookKimiStop(ctx context.Context, input io.Reader, dbPath s
 // through closes that window: the fingerprint and the persisted body are
 // now guaranteed to describe the same content (#1681 HIGH finding).
 //
-// This deliberately does not delete or supersede the earlier, shorter row
-// that a growing turn leaves behind — that needs a delete port this hook
-// does not have. Recording each growth snapshot still collapses ~24
-// same-turn firings to roughly 2-3 rows (turn ID unchanged, fingerprint
-// growing), a ~95% reduction with zero content loss.
+// When the same turn ID later arrives with a different fingerprint, the
+// new row is written first and the previous transcript id from the marker
+// is deleted (#1697). Delete failure leaves both rows (fail-open). A
+// two-field #1681 marker has no event id, so growth still records the
+// longer body but cannot supersede.
 //
 // The check-then-record-then-mark sequence runs inside
 // withKimiTranscriptTurnStateLock so two racing firings for the same
@@ -311,12 +312,14 @@ func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbP
 	blocks, turnID, turnResolved := extractKimiTranscriptTurn(payload)
 	turnID = strings.TrimSpace(turnID)
 	if !turnResolved || sessionID == "" || turnID == "" {
-		return c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, nil)
+		recorded, _, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, nil)
+		return recorded, err
 	}
 	fingerprint, fingerprintErr := kimiTranscriptBlocksFingerprint(blocks)
 	if fingerprintErr != nil {
 		slog.Debug("Kimi transcript fingerprint unavailable; recording unguarded", "session_id", sessionID, "turn_id", turnID, "error", fingerprintErr)
-		return c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
+		recorded, _, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
+		return recorded, err
 	}
 
 	var recorded bool
@@ -327,14 +330,16 @@ func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbP
 			// does not re-request for an already-persisted turn.
 			return nil
 		}
+		eventID := ""
 		var err error
-		recorded, err = c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
+		recorded, eventID, err = c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
 		if err != nil {
 			recordErr = err
 			return err
 		}
 		if recorded {
-			markKimiTranscriptTurnRecorded(sessionID, turnID, fingerprint)
+			c.supersedePreviousKimiTranscriptIfGrown(ctx, sessionID, turnID, fingerprint, eventID)
+			markKimiTranscriptTurnRecorded(sessionID, turnID, fingerprint, eventID)
 		}
 		return nil
 	})
@@ -360,9 +365,34 @@ func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbP
 		// withKimiTranscriptTurnStateLock, so writing one here would race
 		// the very lock this falls back from.
 		slog.Debug("Kimi transcript turn lock unavailable; recording unguarded", "session_id", sessionID, "turn_id", turnID, "error", lockErr)
-		return c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
+		unguarded, _, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
+		return unguarded, err
 	}
 	return recorded, lockErr
+}
+
+// supersedePreviousKimiTranscriptIfGrown deletes the earlier transcript for
+// the same turn when this firing persisted a different fingerprint. Missing
+// event ids (legacy two-field markers) and delete errors leave the previous
+// row in place so a hook never drops the newer write (#1697).
+func (c *RootCLI) supersedePreviousKimiTranscriptIfGrown(
+	ctx context.Context,
+	sessionID, turnID, fingerprint, newEventID string,
+) {
+	if c.event == nil || newEventID == "" {
+		return
+	}
+	prevTurn, prevFingerprint, prevEventID, ok := loadKimiTranscriptTurnMarker(sessionID)
+	if !ok || prevTurn != turnID || prevFingerprint == fingerprint || prevEventID == "" {
+		return
+	}
+	if err := c.event.DeleteTranscript(ctx, types.EventID(prevEventID)); err != nil {
+		slog.Debug("failed to supersede previous growing Kimi transcript; leaving both rows",
+			"session_id", sessionID,
+			"turn_id", turnID,
+			"previous_event_id", prevEventID,
+			"error", err)
+	}
 }
 
 func (c *RootCLI) captureKimiUsage(

--- a/presentation/cli/hook_kimi_transcript.go
+++ b/presentation/cli/hook_kimi_transcript.go
@@ -287,22 +287,25 @@ const kimiTranscriptTurnMarkerSeparator = "\t"
 
 // encodeKimiTranscriptTurnMarker renders the marker file content for a
 // recorded (turn ID, content fingerprint) pair.
-func encodeKimiTranscriptTurnMarker(turnID, fingerprint string) []byte {
-	return []byte(turnID + kimiTranscriptTurnMarkerSeparator + fingerprint)
+func encodeKimiTranscriptTurnMarker(turnID, fingerprint, eventID string) []byte {
+	return []byte(turnID + kimiTranscriptTurnMarkerSeparator + fingerprint + kimiTranscriptTurnMarkerSeparator + eventID)
 }
 
 // decodeKimiTranscriptTurnMarker parses a marker file's content into its
-// (turn ID, fingerprint) pair. It returns ok=false for anything that is not
-// exactly two nonempty tab-separated fields — including a marker written by
-// the pre-fingerprint format (turn ID only, no separator), which must never
-// be mistaken for a match against a real fingerprint.
-func decodeKimiTranscriptTurnMarker(data []byte) (turnID, fingerprint string, ok bool) {
+// (turn ID, fingerprint, event ID) triple. Two-field markers from #1681
+// still match for idempotency; their event ID is empty so a later growth
+// cannot supersede. Pre-fingerprint single-field markers still fail closed
+// for matching (ok=false).
+func decodeKimiTranscriptTurnMarker(data []byte) (turnID, fingerprint, eventID string, ok bool) {
 	trimmed := strings.TrimSpace(string(data))
-	parts := strings.SplitN(trimmed, kimiTranscriptTurnMarkerSeparator, 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", false
+	parts := strings.Split(trimmed, kimiTranscriptTurnMarkerSeparator)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", false
 	}
-	return parts[0], parts[1], true
+	if len(parts) >= 3 {
+		eventID = parts[2]
+	}
+	return parts[0], parts[1], eventID, true
 }
 
 // kimiTranscriptTurnStatePath returns the marker file path recording the
@@ -400,33 +403,46 @@ func kimiTranscriptTurnAlreadyRecorded(sessionID, turnID, fingerprint string) bo
 		}
 		return false
 	}
-	recordedTurnID, recordedFingerprint, ok := decodeKimiTranscriptTurnMarker(data)
+	recordedTurnID, recordedFingerprint, _, ok := decodeKimiTranscriptTurnMarker(data)
 	if !ok {
 		return false
 	}
 	return recordedTurnID == turnID && recordedFingerprint == fingerprint
 }
 
-// markKimiTranscriptTurnRecorded persists (turnID, fingerprint) as the last
-// recorded transcript turn for sessionID. Callers MUST call this only after
-// confirming a row was actually persisted (runHookTranscriptWithBlocks
-// returned recorded=true) — never merely because the recorder returned a
-// nil error, since it fails soft (nil error, nothing written) on several
-// unrelated conditions. Marking on a skip would silently drop every later
-// redelivery of a turn that was never actually stored (#1681 CRITICAL
-// finding). Failures to write the marker file itself are logged and
-// swallowed: losing the marker only risks one extra duplicate on the next
-// Stop firing, never a lost turn, and a hook must never fail the host's
-// turn over housekeeping state. Callers must hold
-// withKimiTranscriptTurnStateLock for correctness under concurrent
-// firings.
-func markKimiTranscriptTurnRecorded(sessionID, turnID, fingerprint string) {
+func loadKimiTranscriptTurnMarker(sessionID string) (turnID, fingerprint, eventID string, ok bool) {
+	path, err := kimiTranscriptTurnStatePath(sessionID)
+	if err != nil {
+		return "", "", "", false
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed name under the hook state directory
+	if err != nil {
+		return "", "", "", false
+	}
+	return decodeKimiTranscriptTurnMarker(data)
+}
+
+// markKimiTranscriptTurnRecorded persists (turnID, fingerprint, eventID)
+// as the last recorded transcript turn for sessionID. Callers MUST call
+// this only after confirming a row was actually persisted
+// (runHookTranscriptWithBlocks returned recorded=true) — never merely
+// because the recorder returned a nil error, since it fails soft (nil
+// error, nothing written) on several unrelated conditions. Marking on a
+// skip would silently drop every later redelivery of a turn that was never
+// actually stored (#1681 CRITICAL finding). The event ID is required so a
+// later same-turn growth can delete the previous row (#1697). Failures to
+// write the marker file itself are logged and swallowed: losing the marker
+// only risks one extra duplicate on the next Stop firing, never a lost
+// turn, and a hook must never fail the host's turn over housekeeping
+// state. Callers must hold withKimiTranscriptTurnStateLock for correctness
+// under concurrent firings.
+func markKimiTranscriptTurnRecorded(sessionID, turnID, fingerprint, eventID string) {
 	path, err := kimiTranscriptTurnStatePath(sessionID)
 	if err != nil {
 		slog.Debug("failed to resolve Kimi transcript turn state path", "session_id", sessionID, "error", err)
 		return
 	}
-	if err := os.WriteFile(path, encodeKimiTranscriptTurnMarker(turnID, fingerprint), 0o600); err != nil {
+	if err := os.WriteFile(path, encodeKimiTranscriptTurnMarker(turnID, fingerprint, eventID), 0o600); err != nil {
 		slog.Debug("failed to write Kimi transcript turn state", "path", path, "error", err)
 	}
 }

--- a/presentation/cli/hook_kimi_transcript_idempotency_test.go
+++ b/presentation/cli/hook_kimi_transcript_idempotency_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
@@ -11,8 +12,12 @@ import (
 	"testing"
 
 	"github.com/gofrs/flock"
+	_ "modernc.org/sqlite"
 
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/types"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
 	cli "github.com/duck8823/traceary/presentation/cli"
 )
 
@@ -127,17 +132,13 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 		}
 	})
 
-	t.Run("a turn that grows content between firings records a second event containing the new content", func(t *testing.T) {
+	t.Run("a turn that grows content between firings leaves one event containing the new content", func(t *testing.T) {
 		// Kimi's Stop hook is not a completed-turn boundary: it can re-fire
 		// while a turn is still streaming, so the SAME wire turn ID can gain
 		// blocks between firings (measured live: 2,053 of 52,475 consecutive
 		// same-session pairs grew, 153 of those gained the turn's only
-		// "text" block). Every other fixture in this suite seeds a turn
-		// that is already complete before the first Stop firing, which
-		// bakes the wrong "turn ID alone means unchanged" premise into the
-		// old guard. This reproduces the growth case directly: the first
-		// firing sees only a thinking block, then a text block is appended
-		// under the SAME turnId before the second firing.
+		// "text" block). #1697 records the grown body then deletes the
+		// previous same-turn row so the store keeps one final transcript.
 		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
 		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-growing")
 		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
@@ -169,11 +170,89 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 		)
 		runKimiHook(t, "stop", payload, eventStub, sessionStub)
 
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("remaining transcript rows after the turn grew = %d, want 1", got)
+		}
+		if !strings.Contains(eventStub.logCalls[0].message, "final answer text") {
+			t.Fatalf("remaining transcript body = %q, want it to contain the newly appended text block", eventStub.logCalls[0].message)
+		}
+		if len(eventStub.deleteTranscriptIDs) != 1 {
+			t.Fatalf("DeleteTranscript calls = %d, want 1", len(eventStub.deleteTranscriptIDs))
+		}
+	})
+
+	t.Run("a two-field legacy marker still records growth but cannot supersede", func(t *testing.T) {
+		stateDir := t.TempDir()
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-legacy-marker")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"think","think":"reasoning about the reply"}}}`,
+		})
+
+		eventStub := &eventUsecaseStub{}
+		payload := readKimiFixture(t, "stop.json")
+		runKimiHook(t, "stop", payload, eventStub, &sessionUsecaseStub{})
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log calls after the first firing = %d, want 1", got)
+		}
+		markerPath := kimiTranscriptMarkerPath(stateDir, sessionID)
+		data, err := os.ReadFile(markerPath)
+		if err != nil {
+			t.Fatalf("read marker: %v", err)
+		}
+		fields := strings.Split(strings.TrimSpace(string(data)), "\t")
+		if len(fields) < 2 {
+			t.Fatalf("marker fields = %v, want at least turn and fingerprint", fields)
+		}
+		if err := os.WriteFile(markerPath, []byte(fields[0]+"\t"+fields[1]+"\n"), 0o600); err != nil {
+			t.Fatalf("rewrite two-field marker: %v", err)
+		}
+
+		appendKimiWireRow(t, homeDir, sessionID,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"final answer text"}}}`,
+		)
+		runKimiHook(t, "stop", payload, eventStub, &sessionUsecaseStub{})
 		if got := len(eventStub.logCalls); got != 2 {
-			t.Fatalf("transcript log calls after the turn grew = %d, want 2 (turn ID unchanged but content grew must still record)", got)
+			t.Fatalf("remaining transcript rows after legacy-marker growth = %d, want 2", got)
+		}
+		if len(eventStub.deleteTranscriptIDs) != 0 {
+			t.Fatalf("DeleteTranscript calls = %d, want 0 for a two-field marker", len(eventStub.deleteTranscriptIDs))
+		}
+	})
+
+	t.Run("a failed supersede delete leaves both rows", func(t *testing.T) {
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-supersede-fail-open")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"think","think":"reasoning about the reply"}}}`,
+		})
+
+		eventStub := &eventUsecaseStub{}
+		payload := readKimiFixture(t, "stop.json")
+		runKimiHook(t, "stop", payload, eventStub, &sessionUsecaseStub{})
+		eventStub.deleteTranscriptErr = errors.New("simulated transcript delete failure")
+
+		appendKimiWireRow(t, homeDir, sessionID,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"final answer text"}}}`,
+		)
+		runKimiHook(t, "stop", payload, eventStub, &sessionUsecaseStub{})
+		if got := len(eventStub.logCalls); got != 2 {
+			t.Fatalf("remaining transcript rows after failed supersede = %d, want 2", got)
 		}
 		if !strings.Contains(eventStub.logCalls[1].message, "final answer text") {
-			t.Fatalf("second transcript body = %q, want it to contain the newly appended text block", eventStub.logCalls[1].message)
+			t.Fatalf("newer transcript body = %q, want it to contain the appended text", eventStub.logCalls[1].message)
 		}
 	})
 
@@ -524,6 +603,79 @@ func TestRootCLI_HookTranscriptAndSpoolInheritKimiTurnGuard(t *testing.T) {
 			t.Fatalf("after transcript spool replay: log calls = %d, want 1 (guard must inherit)", got)
 		}
 	})
+}
+
+func TestRootCLI_HookKimiStop_SupersedesGrowingTurnOnScratchStore(t *testing.T) {
+	const sessionID = "session_00000000-0000-4000-8000-000000000001"
+
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-supersede-scratch")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	seedKimiSession(t, homeDir, sessionID, []string{
+		`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+		`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"think","think":"reasoning about the reply"}}}`,
+	})
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	eventDS := sqliteinfra.NewEventDatasource(db)
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	eventUC := usecase.NewEventUsecase(eventDS, eventDS)
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	payload := readKimiFixture(t, "stop.json")
+	fire := func() {
+		t.Helper()
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(storeUC),
+			cli.WithEvent(eventUC),
+			cli.WithDatabasePathSetter(db.SetPath),
+		).Command()
+		rootCmd.SetIn(strings.NewReader(payload))
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"hook", "kimi", "stop", "--db-path", dbPath})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute(hook kimi stop) error = %v", err)
+		}
+	}
+
+	fire()
+	appendKimiWireRow(t, homeDir, sessionID,
+		`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"final answer text"}}}`,
+	)
+	fire()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = sqldb.Close() }()
+
+	var count int
+	if err := sqldb.QueryRow(`SELECT COUNT(*) FROM events WHERE kind = 'transcript'`).Scan(&count); err != nil {
+		t.Fatalf("count transcripts: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("transcript rows = %d, want 1 after stop then a longer same-turn payload", count)
+	}
+	listed, err := eventUC.List(ctx, apptypes.NewEventListCriteriaBuilder(10).Kind(types.EventKindTranscript).Build())
+	if err != nil {
+		t.Fatalf("List(transcript) error = %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("listed transcripts = %d, want 1", len(listed))
+	}
+	if !strings.Contains(listed[0].Body(), "final answer text") {
+		t.Fatalf("remaining transcript body = %q, want the appended text", listed[0].Body())
+	}
 }
 
 func runHookTranscriptCommand(

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -886,7 +886,8 @@ func (c *RootCLI) runHookTranscript(
 		}
 		return recorder(c, ctx, payload, dbPath)
 	}
-	return c.runHookTranscriptWithBlocks(ctx, input, client, dbPath, nil)
+	recorded, _, err := c.runHookTranscriptWithBlocks(ctx, input, client, dbPath, nil)
+	return recorded, err
 }
 
 // transcriptTurnRecorderFor returns the per-client turn guard that must wrap
@@ -924,12 +925,12 @@ func (c *RootCLI) runHookTranscriptWithBlocks(
 	client string,
 	dbPath string,
 	blocks []apptypes.EventBodyBlock,
-) (bool, error) {
+) (bool, string, error) {
 	if c.storeManagement == nil {
-		return false, xerrors.Errorf("initialize store usecase is not configured")
+		return false, "", xerrors.Errorf("initialize store usecase is not configured")
 	}
 	if c.event == nil {
-		return false, xerrors.Errorf("record log usecase is not configured")
+		return false, "", xerrors.Errorf("record log usecase is not configured")
 	}
 	// Tag for #672: transcript comes from Claude / Codex Stop or
 	// Gemini AfterAgent. Downstream readers can distinguish via
@@ -942,7 +943,7 @@ func (c *RootCLI) runHookTranscriptWithBlocks(
 
 	payload, err := readHookPayload(input)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	ctx = withResolvedHookDelivery(ctx, payload, client)
 	if len(blocks) == 0 {
@@ -952,11 +953,11 @@ func (c *RootCLI) runHookTranscriptWithBlocks(
 			// unsupported client never aborts the host's Stop / SessionEnd
 			// hook. New clients must register an extractor in
 			// `transcriptExtractorFor` before their hook is wired.
-			return false, nil
+			return false, "", nil
 		}
 		extracted, ok := extractor(payload)
 		if !ok || len(extracted) == 0 {
-			return false, nil
+			return false, "", nil
 		}
 		blocks = extracted
 	}
@@ -967,7 +968,7 @@ func (c *RootCLI) runHookTranscriptWithBlocks(
 	// through apptypes.ExtractPlainBody.
 	body, err := apptypes.MarshalEventBodyBlocks(blocks)
 	if err != nil {
-		return false, xerrors.Errorf("failed to serialize transcript blocks: %w", err)
+		return false, "", xerrors.Errorf("failed to serialize transcript blocks: %w", err)
 	}
 	// Transcript bodies can echo secrets the assistant saw earlier in
 	// the turn (API keys from .env, Bearer tokens from header dumps,
@@ -983,30 +984,34 @@ func (c *RootCLI) runHookTranscriptWithBlocks(
 
 	sessionID, err := resolveHookTranscriptSessionIDFunc(payload, client)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	if sessionID == "" {
-		return false, nil
+		return false, "", nil
 	}
 	workspace, err := resolveHookWorkspace(ctx, payload, client, true)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	agent, err := resolveHookAgent(client, payload)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	resolvedDBPath, err := resolveDBPath(dbPath)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	c.applyDatabasePath(resolvedDBPath)
 	if err := c.storeManagement.Initialize(ctx); err != nil {
-		return false, xerrors.Errorf("failed to initialize store: %w", err)
+		return false, "", xerrors.Errorf("failed to initialize store: %w", err)
 	}
-	if _, err := c.event.Log(ctx, body, types.EventKindTranscript, types.Client("hook"), agent, sessionID, workspace, logCfg); err != nil {
-		return false, xerrors.Errorf("failed to record hook transcript: %w", err)
+	event, err := c.event.Log(ctx, body, types.EventKindTranscript, types.Client("hook"), agent, sessionID, workspace, logCfg)
+	if err != nil {
+		return false, "", xerrors.Errorf("failed to record hook transcript: %w", err)
 	}
-
-	return true, nil
+	eventID := ""
+	if event != nil {
+		eventID = event.EventID().String()
+	}
+	return true, eventID, nil
 }

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1248,6 +1248,9 @@ func (s *spoolEventUsecaseStub) Log(_ context.Context, message string, _ types.E
 	s.lastMessage = message
 	return nil, s.logErr
 }
+func (s *spoolEventUsecaseStub) DeleteTranscript(context.Context, types.EventID) error {
+	return nil
+}
 func (s *spoolEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	return nil, nil, nil
 }

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -28,6 +28,10 @@ func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, typ
 	return nil, nil
 }
 
+func (s *tailEventUsecaseStub) DeleteTranscript(context.Context, types.EventID) error {
+	return nil
+}
+
 func (s *tailEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	return nil, nil, nil
 }
@@ -84,7 +88,7 @@ func (s *tailEventUsecaseStub) Timeline(context.Context, apptypes.TimelineCriter
 
 type tailStoreManagementStub struct{}
 
-func (tailStoreManagementStub) Initialize(context.Context) error { return nil }
+func (tailStoreManagementStub) Initialize(context.Context) error           { return nil }
 func (tailStoreManagementStub) InitializeAuthorized(context.Context) error { return nil }
 func (tailStoreManagementStub) PreviewOfflineMigrations(context.Context) ([]int64, error) {
 	return nil, nil

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ import (
 
 // eventUsecaseStub implements usecase.EventUsecase for testing.
 type eventLogCall struct {
+	id         types.EventID
 	message    string
 	kind       types.EventKind
 	client     types.Client
@@ -62,10 +64,13 @@ type eventUsecaseStub struct {
 	// (#1681); tests exercising that race invoke Log() from multiple
 	// goroutines and need this stub to record calls safely rather than
 	// racing on the slice append.
-	logMu     sync.Mutex
-	logCall   eventLogCall
-	logCalls  []eventLogCall
-	auditCall struct {
+	logMu               sync.Mutex
+	logSeq              int
+	logCall             eventLogCall
+	logCalls            []eventLogCall
+	deleteTranscriptErr error
+	deleteTranscriptIDs []types.EventID
+	auditCall           struct {
 		command       string
 		input         string
 		output        string
@@ -128,8 +133,36 @@ func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.E
 	s.logCall.workspace = workspace
 	s.logCall.logCfg = logCfg
 	s.logCall.sourceHook = apptypes.SourceHookFromContext(ctx)
+	s.logSeq++
+	id := types.EventID("stub-" + strconv.Itoa(s.logSeq))
+	s.logCall.id = id
 	s.logCalls = append(s.logCalls, s.logCall)
-	return s.logEvent, s.logErr
+	if s.logEvent != nil || s.logErr != nil {
+		return s.logEvent, s.logErr
+	}
+	event, err := model.NewEvent(id, kind, client, agent, sessionID, workspace, message)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to build stub log event: %w", err)
+	}
+	return event, nil
+}
+
+func (s *eventUsecaseStub) DeleteTranscript(_ context.Context, eventID types.EventID) error {
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
+	s.deleteTranscriptIDs = append(s.deleteTranscriptIDs, eventID)
+	if s.deleteTranscriptErr != nil {
+		return s.deleteTranscriptErr
+	}
+	kept := s.logCalls[:0]
+	for _, call := range s.logCalls {
+		if call.id == eventID {
+			continue
+		}
+		kept = append(kept, call)
+	}
+	s.logCalls = kept
+	return nil
 }
 func (s *eventUsecaseStub) Audit(_ context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	s.auditCall.command = in.Command


### PR DESCRIPTION
## Summary
- Growing Kimi turns now leave one final `kind=transcript` row: the new body is written first, then the previous event id from the turn marker is deleted.
- Two-field `#1681` markers and a failed delete fail open (the new row stays; the old row is left).
- Marker format is now `turnID\tfingerprint\teventID`.

Closes #1697
Leaves parent #1906 open

## Test plan
- [x] `go test ./...`
- [x] `go tool golangci-lint run`
- [x] `TestRootCLI_HookKimiStop_SupersedesGrowingTurnOnScratchStore` fires `hook kimi stop`, appends same-turn text, fires again, and asserts one decoded transcript row containing the appended text
- [x] Stub cases: growth supersedes, two-field marker cannot supersede, delete failure keeps both rows, unadvanced turn still collapses to one row