### PR TITLE
fix: Log returns the canonical id on exact redelivery

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **Log は insert と exact redelivery を報告し、既存の正規 id を返す (#1710)** — `EventUsecase.Log` / `Audit` は `EventWriteResult` を返す。共有の `saveEventTransaction` が persist 結果を in-memory の event に載せるので、redelivery は捨てた構築 id ではなく既存行の id を返す。scratch: 同じ `event_id:` delivery の `Log` 2 回で `events` は 1 行、2 回目の id は 1 回目と一致する。
 - **成長する Kimi turn は最終 transcript 1 行を残す (#1697)** — 同じ wire turn ID で fingerprint が変わったあとの Stop は長い本文を先に書き、marker の前の event id を消す。delete 失敗と 2 フィールドの `#1681` marker は fail-open（新しい行は残し、古い行は残す）。scratch: `hook kimi stop` のあと、同じ turn の長い payload では `kind=transcript` が 1 行になり、追記テキストを含む。
 - **spool と generic な Kimi transcript 記録が turn guard を継承する (#1696)** — `hook transcript kimi` と `command=transcript` の spool replay は、`hook kimi stop` と同じ (session, wire turn, fingerprint) ガードを通る。live store（`mode=ro`、2026-08-15）: `source_hook=stop` / `kind=transcript` / `agent=kimi` は 249,042 件（`client` は `hook`）。`hook_deliveries` に Kimi の `stop` 行はないので spool と live はそこでは分けられない。fail-open と成長 turn の記録は変えない。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Log reports insert vs exact redelivery and returns the canonical id (#1710)** — `EventUsecase.Log` / `Audit` return `EventWriteResult`. Shared `saveEventTransaction` stamps the persist outcome on the in-memory event so a redelivered hook gets the existing row's id, not the discarded constructed one. Scratch: two `Log` calls with the same `event_id:` delivery leave one `events` row and the second result's id equals the first.
 - **Growing Kimi turns leave one final transcript row (#1697)** — a later Stop for the same wire turn ID with a new fingerprint appends the longer body, then deletes the previous transcript id from the marker. Delete failure and two-field `#1681` markers fail open (the new row stays; the old row is left). Scratch: `hook kimi stop` then a longer same-turn payload leaves one `kind=transcript` row that contains the appended text.
 - **Spooled and generic Kimi transcript recording inherit the turn guard (#1696)** — `hook transcript kimi` and spool replay of `command=transcript` now go through the same per-(session, wire turn, fingerprint) guard as `hook kimi stop`. Live store (`mode=ro`, 2026-08-15): 249,042 `source_hook=stop` / `kind=transcript` / `agent=kimi` rows (`client` is `hook`). `hook_deliveries` has no Kimi `stop` rows, so spool vs live cannot be split there. Fail-open and growing-turn recording are unchanged.
 

--- a/application/types/event_write_result.go
+++ b/application/types/event_write_result.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// EventWriteResult is the application-layer outcome of Log / Audit.
+// Event is the constructed write with the store's canonical id. Inserted
+// is false when an exact hook redelivery reused an existing row (#1710).
+type EventWriteResult struct {
+	event    *model.Event
+	inserted bool
+}
+
+// EventWriteResultOf pairs a persisted (or reused) event with whether
+// this call inserted it.
+func EventWriteResultOf(event *model.Event, inserted bool) EventWriteResult {
+	return EventWriteResult{event: event, inserted: inserted}
+}
+
+// Event returns the write, or nil when the call failed before constructing one.
+func (r EventWriteResult) Event() *model.Event { return r.event }
+
+// Inserted reports whether a new events row was written.
+func (r EventWriteResult) Inserted() bool { return r.inserted }
+
+// EventID is the store's canonical id, or empty when Event is nil.
+func (r EventWriteResult) EventID() domtypes.EventID {
+	if r.event == nil {
+		return ""
+	}
+	return r.event.EventID()
+}

--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -17,7 +17,9 @@ type EventUsecase interface {
 	// the implementation applies built-in redactors + the caller's
 	// extra patterns before persisting so no log-ingest surface has
 	// to re-implement that policy in the presentation layer.
-	Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error)
+	// The write result reports whether a row was inserted. On an exact
+	// hook redelivery Event() carries the canonical existing id.
+	Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (apptypes.EventWriteResult, error)
 
 	// DeleteTranscript removes one previously logged transcript event.
 	// Missing or non-transcript ids return nil so a failed supersede can
@@ -26,8 +28,9 @@ type EventUsecase interface {
 
 	// Audit records a command execution audit event. The AuditInput value
 	// object carries the command, attribution, exit code, and structural
-	// failure flag; auditCfg carries the redaction policy.
-	Audit(ctx context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error)
+	// failure flag; auditCfg carries the redaction policy. The write
+	// result reports insert vs exact redelivery, same as Log.
+	Audit(ctx context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (apptypes.EventWriteResult, *model.CommandAudit, error)
 
 	// Search performs full-text search across events.
 	Search(ctx context.Context, criteria apptypes.EventSearchCriteria) ([]*model.Event, error)

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -48,22 +48,22 @@ func NewEventUsecase(
 	}
 }
 
-func (u *eventUsecase) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error) {
+func (u *eventUsecase) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (apptypes.EventWriteResult, error) {
 	if u.eventRepo == nil {
-		return nil, xerrors.Errorf("event repository is not configured")
+		return apptypes.EventWriteResult{}, xerrors.Errorf("event repository is not configured")
 	}
 
 	if _, err := types.AgentFrom(agent.String()); err != nil {
-		return nil, xerrors.Errorf("failed to resolve agent: %w", err)
+		return apptypes.EventWriteResult{}, xerrors.Errorf("failed to resolve agent: %w", err)
 	}
 	if _, err := types.SessionIDFrom(sessionID.String()); err != nil {
-		return nil, xerrors.Errorf("failed to resolve session ID: %w", err)
+		return apptypes.EventWriteResult{}, xerrors.Errorf("failed to resolve session ID: %w", err)
 	}
 	resolvedKind := types.EventKindNote
 	if strings.TrimSpace(kind.String()) != "" {
 		resolved, err := types.EventKindFrom(kind.String())
 		if err != nil {
-			return nil, xerrors.Errorf("failed to resolve event kind: %w", err)
+			return apptypes.EventWriteResult{}, xerrors.Errorf("failed to resolve event kind: %w", err)
 		}
 		resolvedKind = resolved
 	}
@@ -84,7 +84,7 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 	if resolvedKind == types.EventKindTranscript {
 		rules, err := redaction.CompileRules(logCfg.ExtraRedactPatterns(), logCfg.StructuredRules())
 		if err != nil {
-			return nil, xerrors.Errorf("failed to compile redaction rules for transcript: %w", err)
+			return apptypes.EventWriteResult{}, xerrors.Errorf("failed to compile redaction rules for transcript: %w", err)
 		}
 		if redactedBody, ok := redactStructuredBodyBlocks(message, rules); ok {
 			message = redactedBody
@@ -95,7 +95,7 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 
 	eventID, err := newEventID()
 	if err != nil {
-		return nil, xerrors.Errorf("failed to generate event ID: %w", err)
+		return apptypes.EventWriteResult{}, xerrors.Errorf("failed to generate event ID: %w", err)
 	}
 
 	event, err := model.NewEvent(
@@ -108,17 +108,17 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 		message,
 	)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to build log event: %w", err)
+		return apptypes.EventWriteResult{}, xerrors.Errorf("failed to build log event: %w", err)
 	}
 	event.SetSourceHook(apptypes.SourceHookFromContext(ctx))
 	if err := attachHookDelivery(ctx, event); err != nil {
-		return nil, xerrors.Errorf("failed to attach log delivery evidence: %w", err)
+		return apptypes.EventWriteResult{}, xerrors.Errorf("failed to attach log delivery evidence: %w", err)
 	}
 	if err := u.eventRepo.Save(ctx, event); err != nil {
-		return nil, xerrors.Errorf("failed to save log event: %w", err)
+		return apptypes.EventWriteResult{}, xerrors.Errorf("failed to save log event: %w", err)
 	}
 
-	return event, nil
+	return apptypes.EventWriteResultOf(event, event.PersistInserted()), nil
 }
 
 func (u *eventUsecase) DeleteTranscript(ctx context.Context, eventID types.EventID) error {
@@ -135,34 +135,34 @@ func (u *eventUsecase) DeleteTranscript(ctx context.Context, eventID types.Event
 	return nil
 }
 
-func (u *eventUsecase) Audit(ctx context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+func (u *eventUsecase) Audit(ctx context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (apptypes.EventWriteResult, *model.CommandAudit, error) {
 	if u.eventRepo == nil {
-		return nil, nil, xerrors.Errorf("event repository is not configured")
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("event repository is not configured")
 	}
 
 	if _, err := types.AgentFrom(in.Agent.String()); err != nil {
-		return nil, nil, xerrors.Errorf("failed to resolve agent: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to resolve agent: %w", err)
 	}
 	if _, err := types.SessionIDFrom(in.SessionID.String()); err != nil {
-		return nil, nil, xerrors.Errorf("failed to resolve session ID: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to resolve session ID: %w", err)
 	}
 	eventID, err := newEventID()
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to generate event ID: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to generate event ID: %w", err)
 	}
 
 	maxInputBytes, err := resolveAuditPayloadLimit(auditCfg.MaxInputBytes(), maxAuditInputLength)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to resolve input limit: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to resolve input limit: %w", err)
 	}
 	maxOutputBytes, err := resolveAuditPayloadLimit(auditCfg.MaxOutputBytes(), maxAuditOutputLength)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to resolve output limit: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to resolve output limit: %w", err)
 	}
 
 	rules, err := redaction.CompileRules(auditCfg.ExtraRedactPatterns(), auditCfg.StructuredRules())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to compile redaction rules: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to compile redaction rules: %w", err)
 	}
 
 	normalizedCommand := in.Command
@@ -187,12 +187,12 @@ func (u *eventUsecase) Audit(ctx context.Context, in apptypes.AuditInput, auditC
 		outputPayload.Truncated,
 	)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to build command audit: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to build command audit: %w", err)
 	}
 	commandAudit.SetOriginalPayloadBytes(inputPayload.OriginalBytes, outputPayload.OriginalBytes)
 	commandAudit.SetRedaction(inputRedacted, outputRedacted)
 	if err := commandAudit.ClassifyOutcome(in.ExitCode, in.FailureReason, in.Failed); err != nil {
-		return nil, nil, xerrors.Errorf("failed to classify command audit outcome: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to classify command audit outcome: %w", err)
 	}
 
 	// command_executed no longer persists a composed body; command_audits is
@@ -208,18 +208,21 @@ func (u *eventUsecase) Audit(ctx context.Context, in apptypes.AuditInput, auditC
 		"",
 	)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to build audit event: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to build audit event: %w", err)
 	}
 	event.SetSourceHook(apptypes.SourceHookFromContext(ctx))
 	if err := attachHookDelivery(ctx, event, commandAuditDeliveryFields(commandAudit)...); err != nil {
-		return nil, nil, xerrors.Errorf("failed to attach audit delivery evidence: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to attach audit delivery evidence: %w", err)
 	}
 
 	if err := u.eventRepo.SaveWithAudit(ctx, event, commandAudit); err != nil {
-		return nil, nil, xerrors.Errorf("failed to save audit event: %w", err)
+		return apptypes.EventWriteResult{}, nil, xerrors.Errorf("failed to save audit event: %w", err)
+	}
+	if !event.PersistInserted() {
+		commandAudit.RebindEventID(event.EventID())
 	}
 
-	return event, commandAudit, nil
+	return apptypes.EventWriteResultOf(event, event.PersistInserted()), commandAudit, nil
 }
 
 func (u *eventUsecase) Search(ctx context.Context, criteria apptypes.EventSearchCriteria) ([]*model.Event, error) {

--- a/application/usecase/record_command_audit_test.go
+++ b/application/usecase/record_command_audit_test.go
@@ -47,7 +47,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 		stub := &commandAuditSaverStub{}
 		sut := usecase.NewEventUsecase(stub, nil)
 
-		event, commandAudit, err := sut.Audit(context.Background(),
+		wrote, commandAudit, err := sut.Audit(context.Background(),
 			apptypes.AuditInput{
 				Command:   "go test ./...",
 				Input:     "stdin",
@@ -64,6 +64,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Audit() error = %v", err)
 		}
+		event := wrote.Event()
 		if event == nil || commandAudit == nil {
 			t.Fatalf("Audit() returned nil values")
 		}
@@ -137,7 +138,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 		longInput := "input-head-" + strings.Repeat("i", 70*1024) + "-input-tail"
 		longOutput := "output-head-" + strings.Repeat("o", 70*1024) + "-output-tail"
 
-		event, commandAudit, err := sut.Audit(context.Background(),
+		wrote, commandAudit, err := sut.Audit(context.Background(),
 			apptypes.AuditInput{
 				Command:   "go test ./...",
 				Input:     longInput,
@@ -154,6 +155,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Audit() error = %v", err)
 		}
+		event := wrote.Event()
 		if !commandAudit.InputTruncated() {
 			t.Fatalf("InputTruncated() = false, want true")
 		}

--- a/application/usecase/record_log_test.go
+++ b/application/usecase/record_log_test.go
@@ -35,6 +35,23 @@ func (s *eventRepositoryStub) DeleteTranscript(_ context.Context, eventID types.
 	return s.deleteTranscriptErr
 }
 
+func loggedEvent(t *testing.T, wrote apptypes.EventWriteResult, err error) *model.Event {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Log() error = %v", err)
+	}
+	if wrote.Event() == nil {
+		t.Fatal("Log() event is nil")
+	}
+	return wrote.Event()
+}
+
+func mustLog(t *testing.T, fn func() (apptypes.EventWriteResult, error)) *model.Event {
+	t.Helper()
+	wrote, err := fn()
+	return loggedEvent(t, wrote, err)
+}
+
 func TestEventUsecase_Log(t *testing.T) {
 	t.Parallel()
 
@@ -44,21 +61,17 @@ func TestEventUsecase_Log(t *testing.T) {
 		stub := &eventRepositoryStub{}
 		sut := usecase.NewEventUsecase(stub, nil)
 
-		got, err := sut.Log(context.Background(),
-			"  hello traceary  ",
-			types.EventKind(""),
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace("duck8823/traceary"),
-			apptypes.LogRedaction{},
-		)
-		if err != nil {
-			t.Fatalf("Log() error = %v", err)
-		}
-		if got == nil {
-			t.Fatalf("Log() event is nil")
-		}
+		got := mustLog(t, func() (apptypes.EventWriteResult, error) {
+			return sut.Log(context.Background(),
+				"  hello traceary  ",
+				types.EventKind(""),
+				types.Client("cli"),
+				types.Agent("codex"),
+				types.SessionID("session-1"),
+				types.Workspace("duck8823/traceary"),
+				apptypes.LogRedaction{},
+			)
+		})
 		if stub.savedEvent == nil {
 			t.Fatalf("Save() event is nil")
 		}
@@ -91,18 +104,17 @@ func TestEventUsecase_Log(t *testing.T) {
 		stub := &eventRepositoryStub{}
 		sut := usecase.NewEventUsecase(stub, nil)
 
-		got, err := sut.Log(context.Background(),
-			"compact summary text",
-			types.EventKind("compact_summary"),
-			types.Client("hook"),
-			types.Agent("claude"),
-			types.SessionID("session-1"),
-			types.Workspace("duck8823/traceary"),
-			apptypes.LogRedaction{},
-		)
-		if err != nil {
-			t.Fatalf("Log() error = %v", err)
-		}
+		got := mustLog(t, func() (apptypes.EventWriteResult, error) {
+			return sut.Log(context.Background(),
+				"compact summary text",
+				types.EventKind("compact_summary"),
+				types.Client("hook"),
+				types.Agent("claude"),
+				types.SessionID("session-1"),
+				types.Workspace("duck8823/traceary"),
+				apptypes.LogRedaction{},
+			)
+		})
 		if diff := cmp.Diff("compact_summary", got.Kind().String()); diff != "" {
 			t.Fatalf("Kind() mismatch (-want +got):\n%s", diff)
 		}
@@ -114,18 +126,17 @@ func TestEventUsecase_Log(t *testing.T) {
 		stub := &eventRepositoryStub{}
 		sut := usecase.NewEventUsecase(stub, nil)
 
-		got, err := sut.Log(context.Background(),
-			"hello",
-			types.EventKind(""),
-			types.Client("cli"),
-			types.Agent("manual"),
-			types.SessionID("session-1"),
-			types.Workspace(""),
-			apptypes.LogRedaction{},
-		)
-		if err != nil {
-			t.Fatalf("Log() error = %v", err)
-		}
+		got := mustLog(t, func() (apptypes.EventWriteResult, error) {
+			return sut.Log(context.Background(),
+				"hello",
+				types.EventKind(""),
+				types.Client("cli"),
+				types.Agent("manual"),
+				types.SessionID("session-1"),
+				types.Workspace(""),
+				apptypes.LogRedaction{},
+			)
+		})
 		if diff := cmp.Diff("note", got.Kind().String()); diff != "" {
 			t.Fatalf("Kind() mismatch (-want +got):\n%s", diff)
 		}
@@ -160,18 +171,17 @@ func TestEventUsecase_Log(t *testing.T) {
 		cfg := apptypes.NewLogRedactionBuilder().
 			ExtraRedactPatterns([]string{`my_custom_secret=\S+`}).
 			Build()
-		got, err := sut.Log(context.Background(),
-			"Authorization: Bearer abc.DEF-123 and my_custom_secret=s3cr3tValue42 follows",
-			types.EventKindTranscript,
-			types.Client("hook"),
-			types.Agent("claude"),
-			types.SessionID("session-1"),
-			types.Workspace("duck8823/traceary"),
-			cfg,
-		)
-		if err != nil {
-			t.Fatalf("Log() error = %v", err)
-		}
+		got := mustLog(t, func() (apptypes.EventWriteResult, error) {
+			return sut.Log(context.Background(),
+				"Authorization: Bearer abc.DEF-123 and my_custom_secret=s3cr3tValue42 follows",
+				types.EventKindTranscript,
+				types.Client("hook"),
+				types.Agent("claude"),
+				types.SessionID("session-1"),
+				types.Workspace("duck8823/traceary"),
+				cfg,
+			)
+		})
 		body := got.Body()
 		if strings.Contains(body, "s3cr3tValue42") {
 			t.Errorf("transcript body leaked operator extra pattern: %q", body)
@@ -196,18 +206,17 @@ func TestEventUsecase_Log(t *testing.T) {
 		// Prompt and compact_summary bodies intentionally keep operator
 		// intent verbatim; the kind-aware gate inside EventUsecase.Log
 		// must not apply redaction to those kinds.
-		got, err := sut.Log(context.Background(),
-			"my_custom_secret=keepme",
-			types.EventKindPrompt,
-			types.Client("hook"),
-			types.Agent("claude"),
-			types.SessionID("session-1"),
-			types.Workspace("duck8823/traceary"),
-			cfg,
-		)
-		if err != nil {
-			t.Fatalf("Log() error = %v", err)
-		}
+		got := mustLog(t, func() (apptypes.EventWriteResult, error) {
+			return sut.Log(context.Background(),
+				"my_custom_secret=keepme",
+				types.EventKindPrompt,
+				types.Client("hook"),
+				types.Agent("claude"),
+				types.SessionID("session-1"),
+				types.Workspace("duck8823/traceary"),
+				cfg,
+			)
+		})
 		if diff := cmp.Diff("my_custom_secret=keepme", got.Body()); diff != "" {
 			t.Fatalf("Body() mismatch (-want +got):\n%s", diff)
 		}
@@ -249,18 +258,17 @@ func TestEventUsecase_Log_StampsSourceHookFromContext(t *testing.T) {
 	sut := usecase.NewEventUsecase(stub, nil)
 
 	ctx := apptypes.WithSourceHook(context.Background(), "stop")
-	got, err := sut.Log(ctx,
-		"transcript body",
-		types.EventKindTranscript,
-		types.Client("hook"),
-		types.Agent("claude"),
-		types.SessionID("session-1"),
-		types.Workspace("github.com/example/repo"),
-		apptypes.LogRedaction{},
-	)
-	if err != nil {
-		t.Fatalf("Log() error = %v", err)
-	}
+	got := mustLog(t, func() (apptypes.EventWriteResult, error) {
+		return sut.Log(ctx,
+			"transcript body",
+			types.EventKindTranscript,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("session-1"),
+			types.Workspace("github.com/example/repo"),
+			apptypes.LogRedaction{},
+		)
+	})
 	if got.SourceHook() != "stop" {
 		t.Errorf("returned event SourceHook() = %q, want %q", got.SourceHook(), "stop")
 	}
@@ -279,18 +287,17 @@ func TestEventUsecase_Log_LeavesSourceHookEmptyWithoutContext(t *testing.T) {
 	stub := &eventRepositoryStub{}
 	sut := usecase.NewEventUsecase(stub, nil)
 
-	got, err := sut.Log(context.Background(),
-		"manual note",
-		types.EventKindNote,
-		types.Client("cli"),
-		types.Agent("manual"),
-		types.SessionID("session-1"),
-		types.Workspace("github.com/example/repo"),
-		apptypes.LogRedaction{},
-	)
-	if err != nil {
-		t.Fatalf("Log() error = %v", err)
-	}
+	got := mustLog(t, func() (apptypes.EventWriteResult, error) {
+		return sut.Log(context.Background(),
+			"manual note",
+			types.EventKindNote,
+			types.Client("cli"),
+			types.Agent("manual"),
+			types.SessionID("session-1"),
+			types.Workspace("github.com/example/repo"),
+			apptypes.LogRedaction{},
+		)
+	})
 	if got.SourceHook() != "" {
 		t.Errorf("SourceHook() = %q, want empty for non-hook ctx", got.SourceHook())
 	}

--- a/domain/model/command_audit.go
+++ b/domain/model/command_audit.go
@@ -90,6 +90,17 @@ func CommandAuditOf(
 // EventID returns the linked event ID.
 func (a *CommandAudit) EventID() types.EventID { return a.eventID }
 
+// RebindEventID points this in-memory audit at the canonical persisted
+// event after an exact redelivery discarded the constructed event id.
+func (a *CommandAudit) RebindEventID(eventID types.EventID) {
+	if a == nil {
+		return
+	}
+	if parsed, err := types.EventIDFrom(eventID.String()); err == nil {
+		a.eventID = parsed
+	}
+}
+
 // Command returns the executed command.
 func (a *CommandAudit) Command() string { return a.command }
 

--- a/domain/model/event.go
+++ b/domain/model/event.go
@@ -26,6 +26,12 @@ type Event struct {
 	// commandAudit is optional read-side enrichment joined from command_audits.
 	// Write paths keep the audit as a separate aggregate (SaveWithAudit).
 	commandAudit types.Optional[*CommandAudit]
+	// persistKnown / persistInserted are write-side outcome from
+	// saveEventTransaction. They are not stored; readers reconstructing
+	// EventOf leave persistKnown false, which PersistInserted treats as
+	// inserted so stubs and read models stay insert-shaped.
+	persistKnown    bool
+	persistInserted bool
 }
 
 // NewEvent creates a new Event.
@@ -199,6 +205,32 @@ func (e *Event) SetDeliveryEvidence(evidence HookDeliveryEvidence) {
 // DeliveryEvidence returns optional stable hook delivery evidence.
 func (e *Event) DeliveryEvidence() types.Optional[HookDeliveryEvidence] {
 	return e.deliveryEvidence
+}
+
+// RecordPersistOutcome records whether Save inserted a new row and, on an
+// exact redelivery, replaces this in-memory event's ID with the canonical
+// existing id. The constructed ID never named a row in that case (#1710).
+func (e *Event) RecordPersistOutcome(inserted bool, persistedID types.EventID) {
+	if e == nil {
+		return
+	}
+	e.persistKnown = true
+	e.persistInserted = inserted
+	if !inserted {
+		if trimmed, err := types.EventIDFrom(persistedID.String()); err == nil {
+			e.eventID = trimmed
+		}
+	}
+}
+
+// PersistInserted reports whether the last Save inserted this event. When
+// Save has not recorded an outcome (test stubs, reconstructed rows), this
+// is true so callers treat the event as newly written.
+func (e *Event) PersistInserted() bool {
+	if e == nil || !e.persistKnown {
+		return true
+	}
+	return e.persistInserted
 }
 
 // AttachCommandAudit attaches a hydrated command audit for read-side consumers.

--- a/domain/model/event_persist_result.go
+++ b/domain/model/event_persist_result.go
@@ -1,0 +1,33 @@
+package model
+
+import "github.com/duck8823/traceary/domain/types"
+
+// EventPersistResult is the write-side outcome of Save / SaveWithAudit /
+// SaveBoundary. Inserted is false on an exact hook redelivery.
+type EventPersistResult struct {
+	inserted    bool
+	persistedID types.EventID
+}
+
+// EventPersistResultOf reports whether a row was inserted and which event
+// id is now the store's canonical identity for that delivery.
+func EventPersistResultOf(inserted bool, persistedID types.EventID) EventPersistResult {
+	return EventPersistResult{inserted: inserted, persistedID: persistedID}
+}
+
+// Inserted reports whether a new events row was written.
+func (r EventPersistResult) Inserted() bool { return r.inserted }
+
+// PersistedID is the store's event id: the constructed id on insert, or
+// the existing row's id on exact redelivery.
+func (r EventPersistResult) PersistedID() types.EventID { return r.persistedID }
+
+// ApplyEventPersistResult stamps the persist outcome onto the in-memory
+// event so callers of Save do not have to change their error-only
+// signatures to learn insert vs redelivery.
+func ApplyEventPersistResult(event *Event, result EventPersistResult) {
+	if event == nil {
+		return
+	}
+	event.RecordPersistOutcome(result.Inserted(), result.PersistedID())
+}

--- a/infrastructure/sqlite/event_delivery_store.go
+++ b/infrastructure/sqlite/event_delivery_store.go
@@ -46,7 +46,7 @@ func saveEventTransaction(
 			return xerrors.Errorf("failed to begin event delivery transaction: %w", err)
 		}
 
-		inserted, published, persistErr := persistEventDelivery(ctx, tx, event, audit, codecMetadata)
+		inserted, persistedID, published, persistErr := persistEventDelivery(ctx, tx, event, audit, codecMetadata)
 		if persistErr == nil && inserted && afterInsert != nil {
 			persistErr = afterInsert(ctx, tx)
 		}
@@ -83,6 +83,7 @@ func saveEventTransaction(
 		if published != nil {
 			publishAttestationAnchorAfterCommit(storePath, *published)
 		}
+		model.ApplyEventPersistResult(event, model.EventPersistResultOf(inserted, types.EventID(persistedID)))
 		return nil
 	}
 	return xerrors.Errorf("hook delivery identity remained unstable after %d attempts", maxDeliveryDecisionAttempts)
@@ -94,9 +95,9 @@ func persistEventDelivery(
 	event *model.Event,
 	audit *model.CommandAudit,
 	codecMetadata bool,
-) (bool, *attestation.AnchorRecord, error) {
+) (bool, string, *attestation.AnchorRecord, error) {
 	if event == nil {
-		return false, nil, xerrors.Errorf("event must not be nil")
+		return false, "", nil, xerrors.Errorf("event must not be nil")
 	}
 
 	evidence, hasDelivery := event.DeliveryEvidence().Value()
@@ -104,21 +105,21 @@ func persistEventDelivery(
 	if hasDelivery {
 		existing, found, err := findHookDeliveryByFingerprint(ctx, tx, event.SessionID(), evidence)
 		if err != nil {
-			return false, nil, err
+			return false, "", nil, err
 		}
 		if found {
 			if err := insertHookDeliveryAttempt(ctx, tx, event, existing.deliveryRecordID, "exact_redelivery"); err != nil {
-				return false, nil, err
+				return false, "", nil, err
 			}
 			if err := insertWorkspaceObservation(ctx, tx, event, existing.observedEventID, existing.deliveryRecordID, "supplemental", "runtime", diagnosticReason(existing.identityStatus), evidence.AttributionFingerprint()); err != nil {
-				return false, nil, err
+				return false, "", nil, err
 			}
-			return false, nil, nil
+			return false, existing.observedEventID, nil, nil
 		}
 
 		_, acceptedFound, err := findAcceptedHookDelivery(ctx, tx, event.SessionID(), evidence.ReportedID())
 		if err != nil {
-			return false, nil, err
+			return false, "", nil, err
 		}
 		identityStatus = "accepted"
 		if acceptedFound {
@@ -126,21 +127,21 @@ func persistEventDelivery(
 		}
 		if err := insertHookDelivery(ctx, tx, event, evidence, identityStatus); err != nil {
 			if isSQLiteUniqueOrPKConflict(err) {
-				return false, nil, errHookDeliveryIdentityRace
+				return false, "", nil, errHookDeliveryIdentityRace
 			}
-			return false, nil, err
+			return false, "", nil, err
 		}
 		if err := insertHookDeliveryAttempt(ctx, tx, event, evidence.DeliveryRecordID(), identityStatus); err != nil {
-			return false, nil, err
+			return false, "", nil, err
 		}
 	}
 
 	if err := insertEventAndAudit(ctx, tx, event, audit, codecMetadata); err != nil {
-		return false, nil, err
+		return false, "", nil, err
 	}
 	published, err := appendAttestationLink(ctx, tx, event, audit)
 	if err != nil {
-		return false, nil, err
+		return false, "", nil, err
 	}
 
 	deliveryRecordID := ""
@@ -150,9 +151,9 @@ func persistEventDelivery(
 		attributionFingerprint = evidence.AttributionFingerprint()
 	}
 	if err := insertWorkspaceObservation(ctx, tx, event, event.EventID().String(), deliveryRecordID, "primary", "runtime", diagnosticReason(identityStatus), attributionFingerprint); err != nil {
-		return false, nil, err
+		return false, "", nil, err
 	}
-	return true, published, nil
+	return true, event.EventID().String(), published, nil
 }
 
 func insertHookDeliveryAttempt(ctx context.Context, tx *sql.Tx, event *model.Event, deliveryRecordID, outcome string) error {

--- a/infrastructure/sqlite/hook_delivery_store_test.go
+++ b/infrastructure/sqlite/hook_delivery_store_test.go
@@ -310,10 +310,16 @@ func TestSessionDatasource_HookBoundaryRedeliveryIsIdempotent(t *testing.T) {
 	sessions := usecase.NewSessionUsecase(eventDS, sessionDS, sessionDS, eventDS)
 	startCtx := apptypes.WithSourceHook(ctx, "session_start")
 	startCtx = apptypes.WithHookDelivery(startCtx, apptypes.HookDeliveryInputOf("session_id:session-1", "/repo"))
+	var startIDs []types.EventID
 	for i := 0; i < 2; i++ {
-		if _, err := sessions.Start(startCtx, types.Client("hook"), types.Agent("codex"), types.SessionID("session-1"), types.Workspace("/repo"), ""); err != nil {
+		started, err := sessions.Start(startCtx, types.Client("hook"), types.Agent("codex"), types.SessionID("session-1"), types.Workspace("/repo"), "")
+		if err != nil {
 			t.Fatalf("Start(attempt %d) error = %v", i+1, err)
 		}
+		startIDs = append(startIDs, started.EventID())
+	}
+	if startIDs[0] == "" || startIDs[0] != startIDs[1] {
+		t.Fatalf("Start ids = %q / %q, want the same canonical id", startIDs[0], startIDs[1])
 	}
 
 	endCtx := apptypes.WithSourceHook(ctx, "session_end")
@@ -484,6 +490,46 @@ func TestSessionDatasource_HookBoundaryWithoutNativeIDUsesLifecycleGuard(t *test
 	assertSQLiteCount(t, dbPath, "hook_deliveries", 0)
 }
 
+func TestEventUsecase_Log_ExactRedeliveryReturnsCanonicalEventID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	eventDS, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	events := usecase.NewEventUsecase(eventDS, eventDS)
+	deliveryCtx := apptypes.WithSourceHook(ctx, "user_prompt_submit")
+	deliveryCtx = apptypes.WithHookDelivery(deliveryCtx, apptypes.HookDeliveryInputOf("event_id:prompt-1", "/repo"))
+
+	first, err := events.Log(deliveryCtx, "same prompt body", types.EventKindPrompt, types.Client("hook"), types.Agent("codex"), types.SessionID("session-log"), types.Workspace("/repo"), apptypes.LogRedaction{})
+	if err != nil {
+		t.Fatalf("Log(first) error = %v", err)
+	}
+	if !first.Inserted() {
+		t.Fatal("Log(first).Inserted() = false, want true")
+	}
+	if first.Event() == nil || first.EventID().String() == "" {
+		t.Fatal("Log(first) returned an empty event id")
+	}
+
+	retry, err := events.Log(deliveryCtx, "same prompt body", types.EventKindPrompt, types.Client("hook"), types.Agent("codex"), types.SessionID("session-log"), types.Workspace("/repo"), apptypes.LogRedaction{})
+	if err != nil {
+		t.Fatalf("Log(retry) error = %v", err)
+	}
+	if retry.Inserted() {
+		t.Fatal("Log(retry).Inserted() = true, want false for exact redelivery")
+	}
+	if retry.EventID() != first.EventID() {
+		t.Fatalf("Log(retry) id = %q, want canonical %q", retry.EventID(), first.EventID())
+	}
+
+	assertSQLiteCount(t, dbPath, "events", 1)
+	assertSQLiteCount(t, dbPath, "hook_deliveries", 1)
+	assertSQLiteCountWhere(t, dbPath, "hook_delivery_attempts", "outcome = 'exact_redelivery'", 1)
+}
+
 func TestEventDatasource_HookAuditUsesFullSemanticDeliveryFingerprint(t *testing.T) {
 	t.Parallel()
 
@@ -497,9 +543,9 @@ func TestEventDatasource_HookAuditUsesFullSemanticDeliveryFingerprint(t *testing
 	deliveryCtx := apptypes.WithSourceHook(ctx, "post_tool_use")
 	deliveryCtx = apptypes.WithHookDelivery(deliveryCtx, apptypes.HookDeliveryInputOf("tool_use_id:tool-1", "/repo"))
 
-	audit := func(failed bool) {
+	audit := func(failed bool) apptypes.EventWriteResult {
 		t.Helper()
-		if _, _, err := events.Audit(deliveryCtx, apptypes.AuditInput{
+		wrote, _, err := events.Audit(deliveryCtx, apptypes.AuditInput{
 			Command:   "go test ./...",
 			Output:    "same output",
 			Client:    types.Client("hook"),
@@ -508,13 +554,21 @@ func TestEventDatasource_HookAuditUsesFullSemanticDeliveryFingerprint(t *testing
 			Workspace: types.Workspace("/repo"),
 			ExitCode:  types.None[int](),
 			Failed:    failed,
-		}, apptypes.NewAuditRedactionBuilder().Build()); err != nil {
+		}, apptypes.NewAuditRedactionBuilder().Build())
+		if err != nil {
 			t.Fatalf("Audit(failed=%t) error = %v", failed, err)
 		}
+		return wrote
 	}
 
-	audit(false)
-	audit(false)
+	first := audit(false)
+	retry := audit(false)
+	if !first.Inserted() || retry.Inserted() {
+		t.Fatalf("Audit insert/redelivery = %t/%t, want true/false", first.Inserted(), retry.Inserted())
+	}
+	if retry.EventID() != first.EventID() {
+		t.Fatalf("Audit(retry) id = %q, want canonical %q", retry.EventID(), first.EventID())
+	}
 	assertSQLiteCount(t, dbPath, "events", 1)
 	assertSQLiteCount(t, dbPath, "command_audits", 1)
 

--- a/presentation/cli/audit.go
+++ b/presentation/cli/audit.go
@@ -205,7 +205,7 @@ func (c *RootCLI) runAudit(ctx context.Context, output io.Writer, input auditCom
 		ExtraRedactPatterns(c.extraRedactPatterns).
 		StructuredRules(c.structuredRedactRules).
 		Build()
-	event, commandAudit, err := c.event.Audit(ctx,
+	wrote, commandAudit, err := c.event.Audit(ctx,
 		apptypes.AuditInput{
 			Command:       input.command,
 			Input:         input.input,
@@ -224,6 +224,7 @@ func (c *RootCLI) runAudit(ctx context.Context, output io.Writer, input auditCom
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to record command audit", "監査ログ記録に失敗しました"), err)
 	}
+	event := wrote.Event()
 	if input.asJSON {
 		eventDetails, err := apptypes.EventDetailsOf(event, types.Some(commandAudit))
 		if err != nil {

--- a/presentation/cli/doctor_metadata_only_internal_test.go
+++ b/presentation/cli/doctor_metadata_only_internal_test.go
@@ -19,14 +19,14 @@ type hydrateCallTrackingEventUC struct {
 	hydrateCalls int
 }
 
-func (u *hydrateCallTrackingEventUC) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace, apptypes.LogRedaction) (*model.Event, error) {
-	return nil, nil
+func (u *hydrateCallTrackingEventUC) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace, apptypes.LogRedaction) (apptypes.EventWriteResult, error) {
+	return apptypes.EventWriteResult{}, nil
 }
 func (u *hydrateCallTrackingEventUC) DeleteTranscript(context.Context, types.EventID) error {
 	return nil
 }
-func (u *hydrateCallTrackingEventUC) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
-	return nil, nil, nil
+func (u *hydrateCallTrackingEventUC) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (apptypes.EventWriteResult, *model.CommandAudit, error) {
+	return apptypes.EventWriteResult{}, nil, nil
 }
 func (u *hydrateCallTrackingEventUC) Search(context.Context, apptypes.EventSearchCriteria) ([]*model.Event, error) {
 	return nil, nil

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -659,10 +659,11 @@ func (c *RootCLI) runHookCompact(
 				kind = types.EventKind("")
 			}
 		}
-		logged, err := c.event.Log(ctx, body, kind, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
+		wrote, err := c.event.Log(ctx, body, kind, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
 		if err != nil {
 			return xerrors.Errorf("failed to record compact hook event: %w", err)
 		}
+		logged := wrote.Event()
 		// Non-empty compact_summary is the sole discriminator — no
 		// minimum-length heuristic. Marker-only hosts create no refinement.
 		if logged != nil && strings.TrimSpace(compactSummary) != "" {
@@ -734,12 +735,9 @@ func (c *RootCLI) runHookCompact(
 // The warn lines are the observability. sessions.summary is not written
 // (#1706); list / handoff read session_refinements.
 //
-// coversTo names the event event.Log just returned. No host's compact
-// payload carries a field on the proven delivery-ID allowlist, so a compact
-// event never takes the exact-redelivery branch and always inserts. Should a
-// host add one, Log would hand back an event it did not persist and Refine
-// would reject the unknown covers_to before writing — the warn below, and
-// then the gc fallback. See #1710.
+// coversTo names the event Log returned. On exact redelivery that id is
+// the canonical existing row (#1710), so Refine can cover a persisted
+// event. Hosts without a proven delivery ID still insert.
 func (c *RootCLI) applyPostCompactDigest(
 	ctx context.Context,
 	sessionID types.SessionID,
@@ -1005,12 +1003,12 @@ func (c *RootCLI) runHookTranscriptWithBlocks(
 	if err := c.storeManagement.Initialize(ctx); err != nil {
 		return false, "", xerrors.Errorf("failed to initialize store: %w", err)
 	}
-	event, err := c.event.Log(ctx, body, types.EventKindTranscript, types.Client("hook"), agent, sessionID, workspace, logCfg)
+	wrote, err := c.event.Log(ctx, body, types.EventKindTranscript, types.Client("hook"), agent, sessionID, workspace, logCfg)
 	if err != nil {
 		return false, "", xerrors.Errorf("failed to record hook transcript: %w", err)
 	}
 	eventID := ""
-	if event != nil {
+	if event := wrote.Event(); event != nil {
 		eventID = event.EventID().String()
 	}
 	return true, eventID, nil

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1243,16 +1243,16 @@ func (s *spoolCodexUsageStub) CaptureHeadless(_ context.Context, input usecase.C
 	return usecase.CodexUsageCaptureResult{}, s.err
 }
 
-func (s *spoolEventUsecaseStub) Log(_ context.Context, message string, _ types.EventKind, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace, _ apptypes.LogRedaction) (*model.Event, error) {
+func (s *spoolEventUsecaseStub) Log(_ context.Context, message string, _ types.EventKind, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace, _ apptypes.LogRedaction) (apptypes.EventWriteResult, error) {
 	s.logCalls++
 	s.lastMessage = message
-	return nil, s.logErr
+	return apptypes.EventWriteResult{}, s.logErr
 }
 func (s *spoolEventUsecaseStub) DeleteTranscript(context.Context, types.EventID) error {
 	return nil
 }
-func (s *spoolEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
-	return nil, nil, nil
+func (s *spoolEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (apptypes.EventWriteResult, *model.CommandAudit, error) {
+	return apptypes.EventWriteResult{}, nil, nil
 }
 func (s *spoolEventUsecaseStub) Search(context.Context, apptypes.EventSearchCriteria) ([]*model.Event, error) {
 	return nil, nil

--- a/presentation/cli/log.go
+++ b/presentation/cli/log.go
@@ -120,10 +120,11 @@ func (c *RootCLI) runLog(ctx context.Context, output io.Writer, input logCommand
 		ExtraRedactPatterns(c.extraRedactPatterns).
 		StructuredRules(c.structuredRedactRules).
 		Build()
-	event, err := c.event.Log(ctx, message, kind, client, agent, sessionID, workspace, logCfg)
+	wrote, err := c.event.Log(ctx, message, kind, client, agent, sessionID, workspace, logCfg)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to record log", "ログ記録に失敗しました"), err)
 	}
+	event := wrote.Event()
 	if input.asJSON {
 		if err := writeEventJSON(output, event); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print record result", "ログ記録結果の出力に失敗しました"), err)

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -24,16 +24,16 @@ type tailEventUsecaseStub struct {
 	onListWindow        func(callIndex int, criteria apptypes.EventListCriteria)
 }
 
-func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace, apptypes.LogRedaction) (*model.Event, error) {
-	return nil, nil
+func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace, apptypes.LogRedaction) (apptypes.EventWriteResult, error) {
+	return apptypes.EventWriteResult{}, nil
 }
 
 func (s *tailEventUsecaseStub) DeleteTranscript(context.Context, types.EventID) error {
 	return nil
 }
 
-func (s *tailEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
-	return nil, nil, nil
+func (s *tailEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (apptypes.EventWriteResult, *model.CommandAudit, error) {
+	return apptypes.EventWriteResult{}, nil, nil
 }
 
 func (s *tailEventUsecaseStub) Search(context.Context, apptypes.EventSearchCriteria) ([]*model.Event, error) {

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -122,7 +122,7 @@ func (s *projectionSessionSearchStub) SearchSessionPage(
 	return apptypes.SearchSessionPageOf(s.hits, apptypes.SearchSessionTierReady), nil
 }
 
-func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error) {
+func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (apptypes.EventWriteResult, error) {
 	s.logMu.Lock()
 	defer s.logMu.Unlock()
 	s.logCall.message = message
@@ -138,13 +138,13 @@ func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.E
 	s.logCall.id = id
 	s.logCalls = append(s.logCalls, s.logCall)
 	if s.logEvent != nil || s.logErr != nil {
-		return s.logEvent, s.logErr
+		return apptypes.EventWriteResultOf(s.logEvent, true), s.logErr
 	}
 	event, err := model.NewEvent(id, kind, client, agent, sessionID, workspace, message)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to build stub log event: %w", err)
+		return apptypes.EventWriteResult{}, xerrors.Errorf("failed to build stub log event: %w", err)
 	}
-	return event, nil
+	return apptypes.EventWriteResultOf(event, true), nil
 }
 
 func (s *eventUsecaseStub) DeleteTranscript(_ context.Context, eventID types.EventID) error {
@@ -164,7 +164,7 @@ func (s *eventUsecaseStub) DeleteTranscript(_ context.Context, eventID types.Eve
 	s.logCalls = kept
 	return nil
 }
-func (s *eventUsecaseStub) Audit(_ context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+func (s *eventUsecaseStub) Audit(_ context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (apptypes.EventWriteResult, *model.CommandAudit, error) {
 	s.auditCall.command = in.Command
 	s.auditCall.input = in.Input
 	s.auditCall.output = in.Output
@@ -176,7 +176,7 @@ func (s *eventUsecaseStub) Audit(_ context.Context, in apptypes.AuditInput, audi
 	s.auditCall.failed = in.Failed
 	s.auditCall.failureReason = in.FailureReason
 	s.auditCall.auditCfg = auditCfg
-	return s.auditEvent, s.auditAudit, s.auditErr
+	return apptypes.EventWriteResultOf(s.auditEvent, true), s.auditAudit, s.auditErr
 }
 func (s *eventUsecaseStub) Search(_ context.Context, criteria apptypes.EventSearchCriteria) ([]*model.Event, error) {
 	s.searchCalls++


### PR DESCRIPTION
## Summary
- `EventUsecase.Log` and `Audit` now return `EventWriteResult` so a caller can tell an insert from an exact hook redelivery without reading infrastructure.
- Shared `saveEventTransaction` stamps the persist outcome on the in-memory event and rebinds the discarded constructed id to the existing row.
- Session Start/End reuse that same stamp, so a redelivered boundary returns the first event's id.
- Removed the #1672 hazard comment on `applyPostCompactDigest`.

Closes #1710
Leaves parent #1906 open

## Test plan
- [x] `go test ./...`
- [x] `go tool golangci-lint run`
- [x] `TestEventUsecase_Log_ExactRedeliveryReturnsCanonicalEventID` drives real `EventUsecase.Log` on scratch SQLite with the same `event_id:` delivery twice
- [x] Audit exact redelivery returns the first id; session Start redelivery returns the same id