### PR TITLE
fix: make presentation/cli test seams race-free

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Fixed
+- **`go test ./presentation/cli/ -race` が export-test seam で data race を出さない (#1698)** — `Set*Func` seam は `atomic.Pointer` スロットなので、serial なテストが差し替えているあいだに parallel なテストが `resolveDBPath` / `userHomeDirFunc` を読んでも定義済みです。production はスロットを書きません。scratch: 並行差し替え対 `resolveDBPath` のテストと、`-race -count=1` を 2 回走らせて `DATA RACE` なし。
+
 ## [v0.38.0] - 2026-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Fixed
+- **`go test ./presentation/cli/ -race` no longer reports a data race on export-test seams (#1698)** — `Set*Func` seams are `atomic.Pointer` slots, so a serial test can replace them while a parallel test still reads `resolveDBPath` / `userHomeDirFunc`. Production never writes the slots. Scratch: a concurrent replace-vs-`resolveDBPath` test plus two `-race -count=1` package runs report no `DATA RACE`.
+
 ## [v0.38.0] - 2026-08-16
 
 ### Fixed

--- a/presentation/cli/context.go
+++ b/presentation/cli/context.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var detectRepoContextFunc = detectRepoContext
-
 func resolveWorkspaceValue(ctx context.Context, flagValue string) string {
 	if repo := resolveExplicitWorkspaceValue(flagValue); repo != "" {
 		return repo

--- a/presentation/cli/doctor_antigravity.go
+++ b/presentation/cli/doctor_antigravity.go
@@ -161,10 +161,7 @@ func buildAntigravityCapabilityCheck(state antigravityCapabilityState) doctorChe
 	}
 }
 
-// antigravityBundleExistsFunc reports whether an Antigravity app bundle exists
-// at the given path. It is a package-level var so tests can force a
-// deterministic installed/not-installed state regardless of the host machine.
-var antigravityBundleExistsFunc = func(path string) bool {
+func defaultAntigravityBundleExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }

--- a/presentation/cli/doctor_antigravity_cli_plugin_test.go
+++ b/presentation/cli/doctor_antigravity_cli_plugin_test.go
@@ -168,11 +168,11 @@ func TestBuildAntigravityCLIPluginCheck(t *testing.T) {
 
 func TestInspectAntigravityCLIPluginSkipsWhenHomeUnresolved(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
-	orig := userHomeDirFunc
-	t.Cleanup(func() { userHomeDirFunc = orig })
-	userHomeDirFunc = func() (string, error) {
+	orig := currentUserHomeDirFunc()
+	t.Cleanup(func() { storeUserHomeDirFunc(orig) })
+	storeUserHomeDirFunc(func() (string, error) {
 		return "", errors.New("no home")
-	}
+	})
 
 	check := inspectAntigravityCLIPlugin()
 	if check.Name != "antigravity-cli-plugin" {
@@ -193,9 +193,9 @@ func TestObserveAntigravityCLIPluginUsesCurrentSharedConfigPath(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "plugin.json"), healthyAntigravityPluginJSON)
 	writeFile(t, filepath.Join(dir, "hooks.json"), healthyAntigravityHooksJSON)
 
-	orig := userHomeDirFunc
-	t.Cleanup(func() { userHomeDirFunc = orig })
-	userHomeDirFunc = func() (string, error) { return home, nil }
+	orig := currentUserHomeDirFunc()
+	t.Cleanup(func() { storeUserHomeDirFunc(orig) })
+	storeUserHomeDirFunc(func() (string, error) { return home, nil })
 
 	observation := observeAntigravityCLIPlugin()
 	if observation.Shape != antigravityCLIPluginHealthy {
@@ -217,9 +217,9 @@ func TestObserveAntigravityCLIPluginDoesNotHideStaleTwin(t *testing.T) {
 	writeFile(t, filepath.Join(currentDir, "hooks.json"), healthyAntigravityHooksJSON)
 	writeFile(t, filepath.Join(legacyDir, "hooks", "hooks.json"), staleGeminiHooksJSON)
 
-	orig := userHomeDirFunc
-	t.Cleanup(func() { userHomeDirFunc = orig })
-	userHomeDirFunc = func() (string, error) { return home, nil }
+	orig := currentUserHomeDirFunc()
+	t.Cleanup(func() { storeUserHomeDirFunc(orig) })
+	storeUserHomeDirFunc(func() (string, error) { return home, nil })
 
 	observation := observeAntigravityCLIPlugin()
 	if observation.Shape != antigravityCLIPluginStaleGemini {

--- a/presentation/cli/doctor_antigravity_permissions_test.go
+++ b/presentation/cli/doctor_antigravity_permissions_test.go
@@ -275,9 +275,9 @@ func TestInspectAntigravityHeadlessPermissionsUsesOnlyCLIGlobalSettings(t *testi
 		}
 	}
 
-	originalHomeDirFunc := userHomeDirFunc
-	userHomeDirFunc = func() (string, error) { return home, nil }
-	t.Cleanup(func() { userHomeDirFunc = originalHomeDirFunc })
+	originalHomeDirFunc := currentUserHomeDirFunc()
+	storeUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(func() { storeUserHomeDirFunc(originalHomeDirFunc) })
 
 	got := inspectAntigravityHeadlessPermissions()
 	if got.Executable || len(got.Missing) != len(antigravityRequiredHookPermissions) {

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -457,13 +457,14 @@ func TestProbeGrokDoctorStateUserHookRoutes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			originalLookPath, originalOutput, originalHome := grokDoctorLookPath, grokDoctorOutput, userHomeDirFunc
+			originalLookPath, originalOutput, originalHome := grokDoctorLookPath, grokDoctorOutput, currentUserHomeDirFunc()
 			t.Cleanup(func() {
-				grokDoctorLookPath, grokDoctorOutput, userHomeDirFunc = originalLookPath, originalOutput, originalHome
+				grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput
+				storeUserHomeDirFunc(originalHome)
 			})
 
 			home := t.TempDir()
-			userHomeDirFunc = func() (string, error) { return home, nil }
+			storeUserHomeDirFunc(func() (string, error) { return home, nil })
 			grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
 
 			projectDir := t.TempDir()
@@ -575,13 +576,14 @@ func TestProbeGrokDoctorStateUserHookRoutes(t *testing.T) {
 
 func TestProbeGrokDoctorStateWarnsDuplicateWhenNativeCoverageIncomplete(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
-	originalLookPath, originalOutput, originalHome := grokDoctorLookPath, grokDoctorOutput, userHomeDirFunc
+	originalLookPath, originalOutput, originalHome := grokDoctorLookPath, grokDoctorOutput, currentUserHomeDirFunc()
 	t.Cleanup(func() {
-		grokDoctorLookPath, grokDoctorOutput, userHomeDirFunc = originalLookPath, originalOutput, originalHome
+		grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput
+		storeUserHomeDirFunc(originalHome)
 	})
 
 	home := t.TempDir()
-	userHomeDirFunc = func() (string, error) { return home, nil }
+	storeUserHomeDirFunc(func() (string, error) { return home, nil })
 	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
 
 	projectDir := t.TempDir()

--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -42,7 +42,7 @@ var ExpectedCodexPluginHookCount = expectedCodexPluginHookCount
 
 // SetUserHomeDirFunc replaces the home-directory lookup function for tests.
 func SetUserHomeDirFunc(f func() (string, error)) {
-	userHomeDirFunc = f
+	storeUserHomeDirFunc(f)
 	stateDir, configured := os.LookupEnv(hookStateDirEnvKey)
 	if configured && strings.TrimSpace(stateDir) != "" && stateDir != testDefaultHookStateDir {
 		return
@@ -64,7 +64,7 @@ func CallUserHomeDirFunc() (string, error) {
 
 // ResetUserHomeDirFunc restores the default home-directory lookup function for tests.
 func ResetUserHomeDirFunc() {
-	userHomeDirFunc = testDefaultUserHomeDirFunc
+	storeUserHomeDirFunc(testDefaultUserHomeDirFunc)
 	_ = os.Setenv(hookStateDirEnvKey, testDefaultHookStateDir)
 }
 
@@ -72,71 +72,68 @@ func ResetUserHomeDirFunc() {
 // probe for tests so the not_installed / installed capability path can be
 // exercised deterministically regardless of the host machine.
 func SetAntigravityBundleExistsFunc(f func(string) bool) {
-	antigravityBundleExistsFunc = f
+	storeAntigravityBundleExistsFunc(f)
 }
 
 // ResetAntigravityBundleExistsFunc restores the default Antigravity bundle
 // existence probe.
 func ResetAntigravityBundleExistsFunc() {
-	antigravityBundleExistsFunc = func(path string) bool {
-		_, err := os.Stat(path)
-		return err == nil
-	}
+	storeAntigravityBundleExistsFunc(defaultAntigravityBundleExists)
 }
 
 // SetGCNowFunc replaces the current-time function for tests.
 func SetGCNowFunc(f func() time.Time) {
-	gcNowFunc = f
+	storeGCNowFunc(f)
 }
 
 // ResetGCNowFunc restores the default current-time function for tests.
 func ResetGCNowFunc() {
-	gcNowFunc = time.Now
+	storeGCNowFunc(time.Now)
 }
 
 // SetTopNowFunc replaces the current-time function used by sessions / top
 // snapshot loading for tests.
 func SetTopNowFunc(f func() time.Time) {
-	topNowFunc = f
+	storeTopNowFunc(f)
 }
 
 // ResetTopNowFunc restores the default top current-time function for tests.
 func ResetTopNowFunc() {
-	topNowFunc = time.Now
+	storeTopNowFunc(time.Now)
 }
 
 // SetAntigravityPendingNowFunc replaces the current-time function used for
 // Antigravity pending-state TTL pruning for tests.
 func SetAntigravityPendingNowFunc(f func() time.Time) {
-	antigravityPendingNowFunc = f
+	storeAntigravityPendingNowFunc(f)
 }
 
 // ResetAntigravityPendingNowFunc restores the default current-time function
 // used for Antigravity pending-state TTL pruning.
 func ResetAntigravityPendingNowFunc() {
-	antigravityPendingNowFunc = time.Now
+	storeAntigravityPendingNowFunc(time.Now)
 }
 
 // SetAntigravityProcessCwdFunc replaces the process-cwd lookup used when
 // Antigravity payloads omit workspacePaths.
 func SetAntigravityProcessCwdFunc(f func(int) (string, error)) {
-	antigravityProcessCwdFunc = f
+	storeAntigravityProcessCwdFunc(f)
 }
 
 // ResetAntigravityProcessCwdFunc restores the default process-cwd lookup.
 func ResetAntigravityProcessCwdFunc() {
-	antigravityProcessCwdFunc = defaultAntigravityProcessCwd
+	storeAntigravityProcessCwdFunc(defaultAntigravityProcessCwd)
 }
 
 // SetAntigravityParentPIDFunc replaces the parent-PID seed used for workspace
 // fallback discovery.
 func SetAntigravityParentPIDFunc(f func() int) {
-	antigravityParentPIDFunc = f
+	storeAntigravityParentPIDFunc(f)
 }
 
 // ResetAntigravityParentPIDFunc restores the default parent-PID seed.
 func ResetAntigravityParentPIDFunc() {
-	antigravityParentPIDFunc = os.Getppid
+	storeAntigravityParentPIDFunc(os.Getppid)
 }
 
 // AntigravityWorkspaceCwd exposes antigravityWorkspaceCwd for tests.
@@ -157,33 +154,33 @@ func AntigravityPendingCommandPath(conversationID, stepIdx string) (string, erro
 // Kimi's idempotency guard (#1681), whose own turn-resolution check would
 // otherwise make that skip unreachable through payload manipulation alone.
 func SetResolveHookTranscriptSessionIDFunc(f func([]byte, string) (types.SessionID, error)) {
-	resolveHookTranscriptSessionIDFunc = f
+	storeResolveHookTranscriptSessionIDFunc(f)
 }
 
 // ResetResolveHookTranscriptSessionIDFunc restores the default session-ID
 // resolver for runHookTranscriptWithBlocks.
 func ResetResolveHookTranscriptSessionIDFunc() {
-	resolveHookTranscriptSessionIDFunc = resolveHookSessionID
+	storeResolveHookTranscriptSessionIDFunc(resolveHookSessionID)
 }
 
 // SetAfterInspectGrokTranscriptHook runs fn after inspectGrokTranscript has
 // classified the wire log. Tests use it to remove or rewrite updates.jsonl
 // so a second extract would fail-soft (#1713).
 func SetAfterInspectGrokTranscriptHook(fn func()) {
-	afterInspectGrokTranscriptHook = fn
+	storeAfterInspectGrokTranscriptHook(fn)
 }
 
 // ResetAfterInspectGrokTranscriptHook clears the post-inspect test hook.
 func ResetAfterInspectGrokTranscriptHook() {
-	afterInspectGrokTranscriptHook = nil
+	storeAfterInspectGrokTranscriptHook(nil)
 }
 
 // SetDetectRepoContextFunc replaces the work-context resolver for tests.
 func SetDetectRepoContextFunc(f func(context.Context) (string, error)) {
-	detectRepoContextFunc = f
+	storeDetectRepoContextFunc(f)
 }
 
 // ResetDetectRepoContextFunc restores the default work-context resolver for tests.
 func ResetDetectRepoContextFunc() {
-	detectRepoContextFunc = detectRepoContext
+	storeDetectRepoContextFunc(detectRepoContext)
 }

--- a/presentation/cli/gc.go
+++ b/presentation/cli/gc.go
@@ -1,7 +1,5 @@
 package cli
 
-import "time"
-
 const defaultRetentionDays = 90
 
-var gcNowFunc = time.Now
+

--- a/presentation/cli/hook_antigravity.go
+++ b/presentation/cli/hook_antigravity.go
@@ -441,13 +441,7 @@ func firstAntigravityWorkspacePath(payload []byte) string {
 	return ""
 }
 
-// antigravityProcessCwdFunc resolves the current working directory of a process
-// by PID. Tests replace it so host process lookups stay deterministic.
-var antigravityProcessCwdFunc = defaultAntigravityProcessCwd
 
-// antigravityParentPIDFunc returns the parent PID of the current process. Tests
-// can override it without depending on real process topology.
-var antigravityParentPIDFunc = os.Getppid
 
 // resolveAntigravityFallbackWorkspaceCwd walks the parent process chain and
 // returns the first cwd that looks like a user workspace rather than an
@@ -589,10 +583,6 @@ type antigravityPendingCommand struct {
 // otherwise leak the file forever. Writes opportunistically prune siblings
 // older than this so the antigravity-pending directory does not grow unbounded.
 const antigravityPendingStaleAfter = 24 * time.Hour
-
-// antigravityPendingNowFunc returns the current time used for pending-state TTL
-// pruning. It is a package var so tests can pin a deterministic clock.
-var antigravityPendingNowFunc = time.Now
 
 func antigravityPendingCommandPath(conversationID, stepIdx string) (string, error) {
 	stateDir, err := resolveHookStateDir()

--- a/presentation/cli/hook_grok.go
+++ b/presentation/cli/hook_grok.go
@@ -387,15 +387,4 @@ func inspectGrokTranscript(payload []byte) ([]apptypes.EventBodyBlock, grokTrans
 	return blocks, grokTranscriptReady
 }
 
-// afterInspectGrokTranscriptHook, when set, runs after inspectGrokTranscript
-// has classified the wire log (and, when ready, assembled the blocks). Tests
-// use it to truncate or remove updates.jsonl between the readiness read and
-// persist so a second extract would fail-soft.
-var afterInspectGrokTranscriptHook func()
 
-func invokeAfterInspectGrokTranscriptHook() {
-	if afterInspectGrokTranscriptHook == nil {
-		return
-	}
-	afterInspectGrokTranscriptHook()
-}

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -830,14 +830,6 @@ func (c *RootCLI) runHookPrompt(
 	return nil
 }
 
-// resolveHookTranscriptSessionIDFunc resolves the session ID
-// runHookTranscriptWithBlocks records the transcript event against. It
-// defaults to resolveHookSessionID; tests override it to force the
-// "session resolution yielded nothing" fail-soft skip in isolation, so the
-// (recorded, err) contract can be pinned independently of any particular
-// caller's own upstream preconditions (#1681 CRITICAL regression coverage).
-var resolveHookTranscriptSessionIDFunc = resolveHookSessionID
-
 // runHookTranscript records the last assistant-message turn as a
 // `transcript` event. It reads Stop-hook stdin to find
 // the last assistant turn and stores it as a `transcript` event. The

--- a/presentation/cli/hook_state_internal_test.go
+++ b/presentation/cli/hook_state_internal_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestResolveHookStateDir_UsesHomeFallbackWhenEnvironmentIsEmpty(t *testing.T) {
 	homeDir := t.TempDir()
-	originalHomeDirFunc := userHomeDirFunc
-	userHomeDirFunc = func() (string, error) { return homeDir, nil }
-	t.Cleanup(func() { userHomeDirFunc = originalHomeDirFunc })
+	originalHomeDirFunc := currentUserHomeDirFunc()
+	storeUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(func() { storeUserHomeDirFunc(originalHomeDirFunc) })
 	t.Setenv(hookStateDirEnvKey, "")
 
 	got, err := resolveHookStateDir()

--- a/presentation/cli/init.go
+++ b/presentation/cli/init.go
@@ -13,8 +13,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var userHomeDirFunc = os.UserHomeDir
-
 const dbPathEnvKey = "TRACEARY_DB_PATH"
 
 func dbPathFlagUsage() string {

--- a/presentation/cli/main_test.go
+++ b/presentation/cli/main_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	testDefaultUserHomeDirFunc = func() (string, error) { return testDefaultUserHomeDir, nil }
-	userHomeDirFunc = testDefaultUserHomeDirFunc
+	storeUserHomeDirFunc(testDefaultUserHomeDirFunc)
 
 	if stateDir := strings.TrimSpace(os.Getenv(testHookStateDirEnvKey)); stateDir != "" {
 		testDefaultHookStateDir = stateDir

--- a/presentation/cli/memory_inbox_review_internal_test.go
+++ b/presentation/cli/memory_inbox_review_internal_test.go
@@ -124,9 +124,9 @@ func TestReviewModel_AcceptQueuesDecisionAndAdvances(t *testing.T) {
 }
 
 func TestReviewModel_DecisionCardShowsAcceptEvidenceContext(t *testing.T) {
-	previousTopNow := topNowFunc
-	topNowFunc = func() time.Time { return time.Date(2026, 5, 9, 0, 0, 0, 0, time.UTC) }
-	t.Cleanup(func() { topNowFunc = previousTopNow })
+	previousTopNow := currentTopNowFunc()
+	storeTopNowFunc(func() time.Time { return time.Date(2026, 5, 9, 0, 0, 0, 0, time.UTC) })
+	t.Cleanup(func() { storeTopNowFunc(previousTopNow) })
 
 	model := newReviewTestModel(buildReviewCandidateWithOptions(t, reviewCandidateOptions{
 		id:         "id-context",

--- a/presentation/cli/test_seams.go
+++ b/presentation/cli/test_seams.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// Test-only seams live in package-level slots so a serial test can replace
+// them while a parallel test still reads them. Production never writes.
+// Each wrapper loads the current pointer; Set* / store* publish a new one.
+
+type (
+	userHomeDirFn                    = func() (string, error)
+	antigravityBundleExistsFn        = func(string) bool
+	nowFn                            = func() time.Time
+	antigravityProcessCwdFn          = func(int) (string, error)
+	antigravityParentPIDFn           = func() int
+	resolveHookTranscriptSessionIDFn = func([]byte, string) (types.SessionID, error)
+	afterInspectGrokTranscriptHookFn = func()
+	detectRepoContextFn              = func(context.Context) (string, error)
+)
+
+var (
+	userHomeDirSlot                    atomic.Pointer[userHomeDirFn]
+	antigravityBundleExistsSlot        atomic.Pointer[antigravityBundleExistsFn]
+	gcNowSlot                          atomic.Pointer[nowFn]
+	topNowSlot                         atomic.Pointer[nowFn]
+	antigravityPendingNowSlot          atomic.Pointer[nowFn]
+	antigravityProcessCwdSlot          atomic.Pointer[antigravityProcessCwdFn]
+	antigravityParentPIDSlot           atomic.Pointer[antigravityParentPIDFn]
+	resolveHookTranscriptSessionIDSlot atomic.Pointer[resolveHookTranscriptSessionIDFn]
+	afterInspectGrokTranscriptHookSlot atomic.Pointer[afterInspectGrokTranscriptHookFn]
+	detectRepoContextSlot              atomic.Pointer[detectRepoContextFn]
+)
+
+func init() {
+	storeUserHomeDirFunc(os.UserHomeDir)
+	storeAntigravityBundleExistsFunc(defaultAntigravityBundleExists)
+	storeGCNowFunc(time.Now)
+	storeTopNowFunc(time.Now)
+	storeAntigravityPendingNowFunc(time.Now)
+	storeAntigravityProcessCwdFunc(defaultAntigravityProcessCwd)
+	storeAntigravityParentPIDFunc(os.Getppid)
+	storeResolveHookTranscriptSessionIDFunc(resolveHookSessionID)
+	storeDetectRepoContextFunc(detectRepoContext)
+}
+
+func storeUserHomeDirFunc(f userHomeDirFn) {
+	userHomeDirSlot.Store(&f)
+}
+
+func userHomeDirFunc() (string, error) {
+	return (*userHomeDirSlot.Load())()
+}
+
+func currentUserHomeDirFunc() userHomeDirFn {
+	return *userHomeDirSlot.Load()
+}
+
+func storeAntigravityBundleExistsFunc(f antigravityBundleExistsFn) {
+	antigravityBundleExistsSlot.Store(&f)
+}
+
+func antigravityBundleExistsFunc(path string) bool {
+	return (*antigravityBundleExistsSlot.Load())(path)
+}
+
+func storeGCNowFunc(f nowFn) {
+	gcNowSlot.Store(&f)
+}
+
+func gcNowFunc() time.Time {
+	return (*gcNowSlot.Load())()
+}
+
+func storeTopNowFunc(f nowFn) {
+	topNowSlot.Store(&f)
+}
+
+func topNowFunc() time.Time {
+	return (*topNowSlot.Load())()
+}
+
+func currentTopNowFunc() nowFn {
+	return *topNowSlot.Load()
+}
+
+func storeAntigravityPendingNowFunc(f nowFn) {
+	antigravityPendingNowSlot.Store(&f)
+}
+
+func antigravityPendingNowFunc() time.Time {
+	return (*antigravityPendingNowSlot.Load())()
+}
+
+func storeAntigravityProcessCwdFunc(f antigravityProcessCwdFn) {
+	antigravityProcessCwdSlot.Store(&f)
+}
+
+func antigravityProcessCwdFunc(pid int) (string, error) {
+	return (*antigravityProcessCwdSlot.Load())(pid)
+}
+
+func storeAntigravityParentPIDFunc(f antigravityParentPIDFn) {
+	antigravityParentPIDSlot.Store(&f)
+}
+
+func antigravityParentPIDFunc() int {
+	return (*antigravityParentPIDSlot.Load())()
+}
+
+func storeResolveHookTranscriptSessionIDFunc(f resolveHookTranscriptSessionIDFn) {
+	resolveHookTranscriptSessionIDSlot.Store(&f)
+}
+
+func resolveHookTranscriptSessionIDFunc(payload []byte, client string) (types.SessionID, error) {
+	return (*resolveHookTranscriptSessionIDSlot.Load())(payload, client)
+}
+
+func storeAfterInspectGrokTranscriptHook(fn afterInspectGrokTranscriptHookFn) {
+	if fn == nil {
+		afterInspectGrokTranscriptHookSlot.Store(nil)
+		return
+	}
+	afterInspectGrokTranscriptHookSlot.Store(&fn)
+}
+
+func invokeAfterInspectGrokTranscriptHook() {
+	p := afterInspectGrokTranscriptHookSlot.Load()
+	if p == nil || *p == nil {
+		return
+	}
+	(*p)()
+}
+
+func storeDetectRepoContextFunc(f detectRepoContextFn) {
+	detectRepoContextSlot.Store(&f)
+}
+
+func detectRepoContextFunc(ctx context.Context) (string, error) {
+	return (*detectRepoContextSlot.Load())(ctx)
+}

--- a/presentation/cli/test_seams_test.go
+++ b/presentation/cli/test_seams_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestExportTestSeams_ConcurrentHomeDirReadDuringReplace(t *testing.T) {
+	homeA := t.TempDir()
+	homeB := t.TempDir()
+	t.Setenv(dbPathEnvKey, "")
+	orig := currentUserHomeDirFunc()
+	t.Cleanup(func() { storeUserHomeDirFunc(orig) })
+
+	doneWrite := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-doneWrite:
+				return
+			default:
+				_, _ = resolveDBPath("")
+				_, _ = userHomeDirFunc()
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		defer close(doneWrite)
+		for i := 0; i < 2000; i++ {
+			storeUserHomeDirFunc(func() (string, error) { return homeA, nil })
+			storeUserHomeDirFunc(func() (string, error) { return homeB, nil })
+		}
+		storeUserHomeDirFunc(orig)
+	}()
+	wg.Wait()
+}

--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -31,8 +31,6 @@ func init() {
 const defaultTopLimit = 500
 const shortTopSessionIDLength = 12
 
-var topNowFunc = time.Now
-
 // topSnapshotProfile values control the JSON projection for
 // `sessions --snapshot --json`.
 const (


### PR DESCRIPTION
## Summary

`Set*Func` seams in `export_test.go` were package-level function variables. A serial test writing `userHomeDirFunc` overlapped a parallel test reading it via `resolveDBPath`, so `go test ./presentation/cli/ -race` reported a DATA RACE and could not be a gate.

The seams are now `atomic.Pointer` slots. Call sites still look like `userHomeDirFunc()`. Production never writes the slots.

## Tests

- `TestExportTestSeams_ConcurrentHomeDirReadDuringReplace` swaps the home-dir slot while `resolveDBPath` runs
- `go test ./presentation/cli/ -race -count=1` twice: no `DATA RACE`

Closes #1698
Leaves parent #1907 open
