### PR TITLE
fix: pin memory-hygiene scan duration tests to a fake clock

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **memory hygiene scan テストが 1ms の wall-clock 予算に依存しない (#1771)** — partial（revision churn）と cannot-progress は fake clock を進め、`MaxDuration` は 1 時間なので `context.WithTimeout` が先に切れない。scratch: 両ケースと `go test ./application/usecase/ -count=50`。
 - **`go test ./presentation/cli/ -race` が export-test seam で data race を出さない (#1698)** — `Set*Func` seam は `atomic.Pointer` スロットなので、serial なテストが差し替えているあいだに parallel なテストが `resolveDBPath` / `userHomeDirFunc` を読んでも定義済みです。production はスロットを書きません。scratch: 並行差し替え対 `resolveDBPath` のテストと、`-race -count=1` を 2 回走らせて `DATA RACE` なし。
 
 ## [v0.38.0] - 2026-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Memory-hygiene scan tests no longer depend on a 1ms wall-clock budget (#1771)** — the partial (revision-churn) and cannot-progress branches drive a fake clock and use a one-hour `MaxDuration` so `context.WithTimeout` cannot expire first. Scratch: both cases plus `go test ./application/usecase/ -count=50`.
 - **`go test ./presentation/cli/ -race` no longer reports a data race on export-test seams (#1698)** — `Set*Func` seams are `atomic.Pointer` slots, so a serial test can replace them while a parallel test still reads `resolveDBPath` / `userHomeDirFunc`. Production never writes the slots. Scratch: a concurrent replace-vs-`resolveDBPath` test plus two `-race -count=1` package runs report no `DATA RACE`.
 
 ## [v0.38.0] - 2026-08-16

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -16,6 +16,11 @@ import (
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
 
+// memoryHygieneDeterministicDuration is far larger than any wall-clock the
+// test process can spend, so context.WithTimeout(budget.MaxDuration()) cannot
+// fire first. Exhaustion is driven by the fake scan clock (#1771).
+const memoryHygieneDeterministicDuration = time.Hour
+
 func memoryHygieneTestBudget(
 	t *testing.T,
 	rows int,
@@ -643,7 +648,9 @@ func TestMemoryHygieneScan_RevisionChurnReturnsPartialOnlyAfterDurationExhausts(
 		MaxScanBytes:   1 << 20,
 		MaxResultBytes: 1 << 20,
 		MaxComparisons: 100,
-		MaxDuration:    time.Millisecond,
+		// Larger than any real wall-clock the test can spend; the stub
+		// advances the fake clock by this amount so exhaustion is deterministic (#1771).
+		MaxDuration: memoryHygieneDeterministicDuration,
 	})
 	if err != nil {
 		t.Fatalf("MemoryHygieneScanBudgetFrom() error = %v", err)
@@ -774,7 +781,7 @@ func TestMemoryHygieneScan_TimeLimitWithoutCursorProgressReturnsTypedError(t *te
 	scope := workspaceScope(t, "github.com/example/repo")
 	query := &stubMemoryQueryService{
 		scanClock:   &memoryHygieneTestClock{now: time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)},
-		scanAdvance: time.Millisecond,
+		scanAdvance: memoryHygieneDeterministicDuration,
 		summaries: []apptypes.MemorySummary{
 			acceptedSummaryAt(t, "mem-a", scope, "git status", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
 		},
@@ -785,7 +792,7 @@ func TestMemoryHygieneScan_TimeLimitWithoutCursorProgressReturnsTypedError(t *te
 		MaxScanBytes:   1 << 20,
 		MaxResultBytes: 1 << 20,
 		MaxComparisons: 1,
-		MaxDuration:    time.Millisecond,
+		MaxDuration:    memoryHygieneDeterministicDuration,
 	})
 	if err != nil {
 		t.Fatalf("MemoryHygieneScanBudgetFrom() error = %v", err)


### PR DESCRIPTION
## Summary

`TestMemoryHygieneScan_RevisionChurnReturnsPartialOnlyAfterDurationExhausts` used `MaxDuration: time.Millisecond`. `Scan` also applies `context.WithTimeout(ctx, budget.MaxDuration())`, so a loaded runner could expire the real deadline before the first page and return cannot-progress instead of a partial result.

Both duration tests now use a one-hour budget (so the context deadline cannot fire first) and advance the existing fake scan clock by that amount. Partial and cannot-progress stay pinned on `Scan`.

## Tests

- Revision-churn continuation: Partial + `revision_changed`, no error
- Time-limit with no cursor progress: `ErrMemoryHygieneContinuationCannotProgress`
- `go test ./application/usecase/ -count=50` exit 0

Closes #1771
Leaves parent #1907 open
