### PR TITLE
fix: compare remaining gc age-delete timestamps with ts_norm

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **残っている本番の age-delete SQL は timestamp を `ts_norm` で比較する (#1720)** — 空 session 削除、expired memory 削除、memory-edge の `valid_to`、stale extracted の decay と preview count は両辺を wrap する。`T00:00:00.5Z` 対 cutoff `T00:00:00Z` は残し、`T00:00:00Z` 対 cutoff `T00:00:00.5Z` は消す。`CollectGarbage`（compact の work-copy 経路）から駆動し、手書きの `DELETE` は使わない。
 - **memory hygiene scan テストが 1ms の wall-clock 予算に依存しない (#1771)** — partial（revision churn）と cannot-progress は fake clock を進め、`MaxDuration` は 1 時間なので `context.WithTimeout` が先に切れない。scratch: 両ケースと `go test ./application/usecase/ -count=50`。
 - **`go test ./presentation/cli/ -race` が export-test seam で data race を出さない (#1698)** — `Set*Func` seam は `atomic.Pointer` スロットなので、serial なテストが差し替えているあいだに parallel なテストが `resolveDBPath` / `userHomeDirFunc` を読んでも定義済みです。production はスロットを書きません。scratch: 並行差し替え対 `resolveDBPath` のテストと、`-race -count=1` を 2 回走らせて `DATA RACE` なし。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Remaining production age-delete SQL compares timestamps with `ts_norm` (#1720)** — empty-session delete, expired-memory delete, memory-edge `valid_to`, stale extracted decay, and their preview counts wrap both sides. `T00:00:00.5Z` vs cutoff `T00:00:00Z` is kept; `T00:00:00Z` vs cutoff `T00:00:00.5Z` is deleted. Driven through `CollectGarbage` (the compact work-copy path), not a hand-written `DELETE`.
 - **Memory-hygiene scan tests no longer depend on a 1ms wall-clock budget (#1771)** — the partial (revision-churn) and cannot-progress branches drive a fake clock and use a one-hour `MaxDuration` so `context.WithTimeout` cannot expire first. Scratch: both cases plus `go test ./application/usecase/ -count=50`.
 - **`go test ./presentation/cli/ -race` no longer reports a data race on export-test seams (#1698)** — `Set*Func` seams are `atomic.Pointer` slots, so a serial test can replace them while a parallel test still reads `resolveDBPath` / `userHomeDirFunc`. Production never writes the slots. Scratch: a concurrent replace-vs-`resolveDBPath` test plus two `-race -count=1` package runs report no `DATA RACE`.
 

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -727,6 +727,63 @@ func TestDatasource_CollectGarbageAll_PreviewMatchesApplyWithProductionMigration
 	assertNoForeignKeyViolations(t, db)
 }
 
+func TestDatasource_CollectGarbage_usesTsNormOnAgeDeleteBoundaries(t *testing.T) {
+	t.Parallel()
+
+	// Lexical RFC3339Nano compares '.' (0x2E) below 'Z' (0x5A), so a
+	// sub-second timestamp sorts before the whole-second form of the same
+	// instant (#1185). collectGarbageInTx still deletes empty sessions and
+	// expired memories; those comparisons must go through ts_norm.
+	whole := time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC)
+	frac := time.Date(2026, 5, 10, 0, 0, 0, 500000000, time.UTC)
+
+	t.Run("fractional session after whole-second cutoff is kept", func(t *testing.T) {
+		dbPath, store := prepareRetentionFixture(t)
+		db := openRetentionDB(t, dbPath)
+		defer func() { _ = db.Close() }()
+		execRetentionSQL(t, db, `INSERT INTO sessions (session_id, started_at, ended_at, client, agent, repo) VALUES
+			('frac-after', '2026-05-09T00:00:00Z', '2026-05-10T00:00:00.5Z', 'cli', 'codex', 'repo')`)
+		if _, err := store.CollectGarbage(context.Background(), whole, apptypes.GarbageCollectionTargetSessions, false); err != nil {
+			t.Fatalf("CollectGarbage() error = %v", err)
+		}
+		assertRetentionIDs(t, db, "sessions", "session_id", []string{"frac-after"})
+	})
+
+	t.Run("whole-second session before fractional cutoff is deleted", func(t *testing.T) {
+		dbPath, store := prepareRetentionFixture(t)
+		db := openRetentionDB(t, dbPath)
+		defer func() { _ = db.Close() }()
+		execRetentionSQL(t, db, `INSERT INTO sessions (session_id, started_at, ended_at, client, agent, repo) VALUES
+			('whole-before', '2026-05-09T00:00:00Z', '2026-05-10T00:00:00Z', 'cli', 'codex', 'repo')`)
+		if _, err := store.CollectGarbage(context.Background(), frac, apptypes.GarbageCollectionTargetSessions, false); err != nil {
+			t.Fatalf("CollectGarbage() error = %v", err)
+		}
+		assertRetentionIDs(t, db, "sessions", "session_id", nil)
+	})
+
+	t.Run("fractional expired memory after whole-second cutoff is kept", func(t *testing.T) {
+		dbPath, store := prepareRetentionFixture(t)
+		db := openRetentionDB(t, dbPath)
+		defer func() { _ = db.Close() }()
+		insertRetentionMemory(t, db, "mem-frac", "expired", "", "2026-05-10T00:00:00.5Z")
+		if _, err := store.CollectGarbage(context.Background(), whole, apptypes.GarbageCollectionTargetMemories, false); err != nil {
+			t.Fatalf("CollectGarbage() error = %v", err)
+		}
+		assertRetentionIDs(t, db, "memories", "id", []string{"mem-frac"})
+	})
+
+	t.Run("whole-second expired memory before fractional cutoff is deleted", func(t *testing.T) {
+		dbPath, store := prepareRetentionFixture(t)
+		db := openRetentionDB(t, dbPath)
+		defer func() { _ = db.Close() }()
+		insertRetentionMemory(t, db, "mem-whole", "expired", "", "2026-05-10T00:00:00Z")
+		if _, err := store.CollectGarbage(context.Background(), frac, apptypes.GarbageCollectionTargetMemories, false); err != nil {
+			t.Fatalf("CollectGarbage() error = %v", err)
+		}
+		assertRetentionIDs(t, db, "memories", "id", nil)
+	})
+}
+
 func prepareRetentionFixture(t *testing.T) (string, *sqlite.StoreManagementDatasource) {
 	t.Helper()
 

--- a/infrastructure/sqlite/sql/clear_deleted_memory_supersedes_refs.sql
+++ b/infrastructure/sqlite/sql/clear_deleted_memory_supersedes_refs.sql
@@ -4,5 +4,5 @@ UPDATE memories
        SELECT id
          FROM memories
         WHERE status IN ('expired', 'superseded', 'rejected')
-          AND updated_at < ?
+          AND ts_norm(updated_at) < ts_norm(?)
  )

--- a/infrastructure/sqlite/sql/clear_stale_extracted_candidate_supersedes_refs.sql
+++ b/infrastructure/sqlite/sql/clear_stale_extracted_candidate_supersedes_refs.sql
@@ -5,5 +5,5 @@ UPDATE memories
          FROM memories
         WHERE status = 'candidate'
           AND source IN ('extracted', 'extracted-hidden', 'compact-summary')
-          AND updated_at < ?
+          AND ts_norm(updated_at) < ts_norm(?)
  )

--- a/infrastructure/sqlite/sql/count_deletable_events.sql
+++ b/infrastructure/sqlite/sql/count_deletable_events.sql
@@ -1,1 +1,1 @@
-SELECT COUNT(*) FROM events WHERE created_at < ?
+SELECT COUNT(*) FROM events WHERE ts_norm(created_at) < ts_norm(?)

--- a/infrastructure/sqlite/sql/count_empty_sessions.sql
+++ b/infrastructure/sqlite/sql/count_empty_sessions.sql
@@ -1,7 +1,7 @@
 SELECT COUNT(*)
 FROM sessions
 WHERE ended_at IS NOT NULL
-  AND COALESCE(ended_at, started_at) < ?
+  AND ts_norm(COALESCE(ended_at, started_at)) < ts_norm(?)
   AND NOT EXISTS (
       SELECT 1
         FROM events

--- a/infrastructure/sqlite/sql/count_old_memories.sql
+++ b/infrastructure/sqlite/sql/count_old_memories.sql
@@ -1,4 +1,4 @@
 SELECT COUNT(*)
 FROM memories
 WHERE status IN ('expired', 'superseded', 'rejected')
-  AND updated_at < ?
+  AND ts_norm(updated_at) < ts_norm(?)

--- a/infrastructure/sqlite/sql/count_old_memory_edges.sql
+++ b/infrastructure/sqlite/sql/count_old_memory_edges.sql
@@ -1,6 +1,6 @@
 SELECT COUNT(*)
 FROM memory_edges
-WHERE (valid_to IS NOT NULL AND valid_to < ?)
+WHERE (valid_to IS NOT NULL AND ts_norm(valid_to) < ts_norm(?))
    OR NOT EXISTS (
        SELECT 1
          FROM memories

--- a/infrastructure/sqlite/sql/count_old_memory_edges_after_memory_gc.sql
+++ b/infrastructure/sqlite/sql/count_old_memory_edges_after_memory_gc.sql
@@ -1,7 +1,7 @@
 SELECT COUNT(*)
 FROM memory_edges
 WHERE (
-       (valid_to IS NOT NULL AND valid_to < ?)
+       (valid_to IS NOT NULL AND ts_norm(valid_to) < ts_norm(?))
     OR NOT EXISTS (
         SELECT 1
           FROM memories
@@ -18,12 +18,12 @@ AND NOT EXISTS (
       FROM memories
      WHERE memories.id = memory_edges.from_memory_id
        AND memories.status IN ('expired', 'superseded', 'rejected')
-       AND memories.updated_at < ?
+       AND ts_norm(memories.updated_at) < ts_norm(?)
 )
 AND NOT EXISTS (
     SELECT 1
       FROM memories
      WHERE memories.id = memory_edges.to_memory_id
        AND memories.status IN ('expired', 'superseded', 'rejected')
-       AND memories.updated_at < ?
+       AND ts_norm(memories.updated_at) < ts_norm(?)
 )

--- a/infrastructure/sqlite/sql/count_stale_extracted_candidates.sql
+++ b/infrastructure/sqlite/sql/count_stale_extracted_candidates.sql
@@ -2,4 +2,4 @@ SELECT COUNT(*)
 FROM memories
 WHERE status = 'candidate'
   AND source IN ('extracted', 'extracted-hidden', 'compact-summary')
-  AND updated_at < ?
+  AND ts_norm(updated_at) < ts_norm(?)

--- a/infrastructure/sqlite/sql/delete_empty_sessions.sql
+++ b/infrastructure/sqlite/sql/delete_empty_sessions.sql
@@ -1,6 +1,6 @@
 DELETE FROM sessions
 WHERE ended_at IS NOT NULL
-  AND COALESCE(ended_at, started_at) < ?
+  AND ts_norm(COALESCE(ended_at, started_at)) < ts_norm(?)
   AND NOT EXISTS (
       SELECT 1
         FROM events

--- a/infrastructure/sqlite/sql/delete_old_memories.sql
+++ b/infrastructure/sqlite/sql/delete_old_memories.sql
@@ -1,3 +1,3 @@
 DELETE FROM memories
 WHERE status IN ('expired', 'superseded', 'rejected')
-  AND updated_at < ?
+  AND ts_norm(updated_at) < ts_norm(?)

--- a/infrastructure/sqlite/sql/delete_old_memory_edges.sql
+++ b/infrastructure/sqlite/sql/delete_old_memory_edges.sql
@@ -1,5 +1,5 @@
 DELETE FROM memory_edges
-WHERE (valid_to IS NOT NULL AND valid_to < ?)
+WHERE (valid_to IS NOT NULL AND ts_norm(valid_to) < ts_norm(?))
    OR NOT EXISTS (
        SELECT 1
          FROM memories

--- a/infrastructure/sqlite/sql/delete_stale_extracted_candidates.sql
+++ b/infrastructure/sqlite/sql/delete_stale_extracted_candidates.sql
@@ -6,4 +6,4 @@ SET status = 'expired',
     updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE status = 'candidate'
   AND source IN ('extracted', 'extracted-hidden', 'compact-summary')
-  AND updated_at < ?
+  AND ts_norm(updated_at) < ts_norm(?)


### PR DESCRIPTION
## Summary

Remaining `collectGarbageInTx` age-delete SQL (empty sessions, expired memories, memory-edge `valid_to`, stale extracted decay, and their preview counts) compared timestamps lexically. Variable-width RFC3339Nano makes `T00:00:00.5Z` sort before `T00:00:00Z` (#1185). Event body discard already used `ts_norm`.

Both sides are now `ts_norm(...)`. Tests drive `CollectGarbage` (the compact work-copy path), not a hand-written `DELETE` and not a restored `store gc` CLI.

## Tests

- Fractional session/memory after a whole-second cutoff is kept
- Whole-second session/memory before a fractional cutoff is deleted

Closes #1720
Leaves parent #1907 open
