### PR TITLE
fix: attestation verify must not false-fail on SQLITE_BUSY

### DIFF
--- a/infrastructure/sqlite/attestation_store.go
+++ b/infrastructure/sqlite/attestation_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -11,6 +12,27 @@ import (
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
+
+// attestationVerifyBusyAttempts bounds the retry on SQLite lock contention
+// (initial attempt + 2 retries). See AttestationChainUndeterminedError.
+const attestationVerifyBusyAttempts = 3
+
+// attestationVerifyBusyBackoff holds the fixed delay before each retry,
+// indexed by attempt number (attempt 1 has no prior delay).
+var attestationVerifyBusyBackoff = [attestationVerifyBusyAttempts]time.Duration{
+	0, 25 * time.Millisecond, 50 * time.Millisecond,
+}
+
+// AttestationChainUndeterminedError reports that verification could not
+// obtain a read snapshot (SQLite lock contention). It is not an integrity
+// verdict: the chain is neither proven intact nor proven broken.
+type AttestationChainUndeterminedError struct{ Err error }
+
+func (e *AttestationChainUndeterminedError) Error() string {
+	return "attestation chain verification undetermined: " + e.Err.Error()
+}
+
+func (e *AttestationChainUndeterminedError) Unwrap() error { return e.Err }
 
 // attestationChainSnapshot is the verified head and per-seq link digests
 // from one read-only transaction.
@@ -32,7 +54,35 @@ func VerifyAttestationChain(ctx context.Context, db *sql.DB) error {
 	return err
 }
 
+// verifyAttestationChainSnapshot applies the attempt policy around one
+// snapshot read: retry while the failure is SQLite lock contention, up to
+// attestationVerifyBusyAttempts, honoring ctx cancellation between attempts.
+// Any non-busy error is returned unchanged so a real chain break can never
+// be relabeled as busy. A terminal busy is wrapped as
+// AttestationChainUndeterminedError, which is explicitly not an integrity
+// verdict.
 func verifyAttestationChainSnapshot(ctx context.Context, db *sql.DB) (attestationChainSnapshot, error) {
+	var snapshot attestationChainSnapshot
+	var err error
+	for attempt := 1; attempt <= attestationVerifyBusyAttempts; attempt++ {
+		if attempt > 1 {
+			timer := time.NewTimer(attestationVerifyBusyBackoff[attempt-1])
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return attestationChainSnapshot{}, xerrors.Errorf("attestation verify retry cancelled: %w", ctx.Err())
+			case <-timer.C:
+			}
+		}
+		snapshot, err = verifyAttestationChainSnapshotOnce(ctx, db)
+		if err == nil || !isSQLiteBusy(err) {
+			return snapshot, err
+		}
+	}
+	return attestationChainSnapshot{}, &AttestationChainUndeterminedError{Err: err}
+}
+
+func verifyAttestationChainSnapshotOnce(ctx context.Context, db *sql.DB) (attestationChainSnapshot, error) {
 	if db == nil {
 		return attestationChainSnapshot{}, xerrors.Errorf("attestation verify requires a database")
 	}

--- a/infrastructure/sqlite/attestation_store_test.go
+++ b/infrastructure/sqlite/attestation_store_test.go
@@ -357,11 +357,7 @@ func newAttestationTestStore(t *testing.T) (string, *sqlite.EventDatasource) {
 
 func openAttestationDB(t *testing.T, path string) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(path)+"?_pragma=foreign_keys(1)")
-	if err != nil {
-		t.Fatalf("sql.Open() error = %v", err)
-	}
-	return db
+	return sqlite.OpenStoreForTest(path)
 }
 
 func assertAttestationCount(t *testing.T, db *sql.DB, want int) {

--- a/infrastructure/sqlite/attestation_store_test.go
+++ b/infrastructure/sqlite/attestation_store_test.go
@@ -3,8 +3,11 @@ package sqlite_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -120,8 +123,13 @@ func TestVerifyAttestationChain_CommandTextTamperFailsAndOutputDoesNot(t *testin
 	if _, err := db.Exec(`UPDATE command_audits SET command_text = 'rm' WHERE event_id = 'command-tamper'`); err != nil {
 		t.Fatalf("UPDATE command_text: %v", err)
 	}
-	if err := sqlite.VerifyAttestationChain(ctx, db); err == nil {
+	err = sqlite.VerifyAttestationChain(ctx, db)
+	if err == nil {
 		t.Fatal("VerifyAttestationChain() error = nil after command_text UPDATE")
+	}
+	var undetermined *sqlite.AttestationChainUndeterminedError
+	if errors.As(err, &undetermined) {
+		t.Fatalf("VerifyAttestationChain() reported a real chain break as undetermined: %v", err)
 	}
 }
 
@@ -343,6 +351,128 @@ func TestVerifyAttestationChain_ConcurrentAppendDoesNotFalseFail(t *testing.T) {
 	for err := range errCh {
 		t.Errorf("concurrent verify/append error = %v", err)
 	}
+}
+
+func TestVerifyAttestationChain_TransientContentionIsAbsorbed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path, events := newAttestationTestStore(t)
+	seed := model.EventOf(
+		types.EventID("prompt-seed"), types.EventKindPrompt,
+		types.Client("cli"), types.Agent("codex"),
+		types.SessionID("session-1"), types.Workspace("ws"),
+		"seed",
+		time.Date(2026, 8, 14, 17, 0, 0, 0, time.UTC),
+	)
+	if err := events.Save(ctx, seed); err != nil {
+		t.Fatalf("Save(seed) error = %v", err)
+	}
+
+	release := blockAttestationReads(t, path)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		release()
+	}()
+
+	db := openZeroBusyTimeoutAttestationDB(t, path)
+	defer func() { _ = db.Close() }()
+	if err := sqlite.VerifyAttestationChain(ctx, db); err != nil {
+		t.Fatalf("VerifyAttestationChain() error = %v, want nil once contention clears mid-retry", err)
+	}
+}
+
+func TestVerifyAttestationChain_PersistentContentionIsUndetermined(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path, events := newAttestationTestStore(t)
+	seed := model.EventOf(
+		types.EventID("prompt-seed"), types.EventKindPrompt,
+		types.Client("cli"), types.Agent("codex"),
+		types.SessionID("session-1"), types.Workspace("ws"),
+		"seed",
+		time.Date(2026, 8, 14, 18, 0, 0, 0, time.UTC),
+	)
+	if err := events.Save(ctx, seed); err != nil {
+		t.Fatalf("Save(seed) error = %v", err)
+	}
+
+	release := blockAttestationReads(t, path)
+	defer release()
+
+	db := openZeroBusyTimeoutAttestationDB(t, path)
+	defer func() { _ = db.Close() }()
+	err := sqlite.VerifyAttestationChain(ctx, db)
+	if err == nil {
+		t.Fatal("VerifyAttestationChain() error = nil, want undetermined under persistent contention")
+	}
+	var undetermined *sqlite.AttestationChainUndeterminedError
+	if !errors.As(err, &undetermined) {
+		t.Fatalf("VerifyAttestationChain() error = %v, want AttestationChainUndeterminedError", err)
+	}
+	for _, chainWord := range []string{"attestation link", "attestation head", "digest"} {
+		if strings.Contains(err.Error(), chainWord) {
+			t.Fatalf("VerifyAttestationChain() undetermined message = %q, must not carry chain wording %q", err.Error(), chainWord)
+		}
+	}
+}
+
+// blockAttestationReads acquires an exclusive file lock on the store so any
+// other connection is denied WAL index access (SQLITE_BUSY family) until
+// release is called. A plain BEGIN EXCLUSIVE in WAL mode does not block
+// readers, so this uses locking_mode=EXCLUSIVE per the design note's primary
+// strategy (#1969 §5); it proved deterministic locally, so the
+// journal_mode=DELETE fallback described there is not needed.
+func blockAttestationReads(t *testing.T, path string) (release func()) {
+	t.Helper()
+	dsn := (&url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(path),
+		RawQuery: url.Values{
+			"_pragma": []string{"journal_mode(WAL)", "locking_mode(EXCLUSIVE)"},
+		}.Encode(),
+	}).String()
+	conn, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open blocking connection: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	if _, err := conn.Exec(`BEGIN IMMEDIATE`); err != nil {
+		_ = conn.Close()
+		t.Fatalf("BEGIN IMMEDIATE on blocking connection: %v", err)
+	}
+	if _, err := conn.Exec(`UPDATE attestation_head SET seq = seq WHERE singleton = 1`); err != nil {
+		_ = conn.Close()
+		t.Fatalf("touch attestation_head to take the exclusive lock: %v", err)
+	}
+	released := false
+	return func() {
+		if released {
+			return
+		}
+		released = true
+		_, _ = conn.Exec(`ROLLBACK`)
+		_ = conn.Close()
+	}
+}
+
+// openZeroBusyTimeoutAttestationDB opens a verify handle with
+// busy_timeout(0) so SQLite reports SQLITE_BUSY immediately instead of
+// blocking inside the driver, letting the Go-level retry in
+// verifyAttestationChainSnapshot be exercised deterministically.
+func openZeroBusyTimeoutAttestationDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	dsn := (&url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(path),
+		RawQuery: url.Values{
+			"_pragma": []string{"journal_mode(WAL)", "busy_timeout(0)", "foreign_keys(1)"},
+		}.Encode(),
+	}).String()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	return db
 }
 
 func newAttestationTestStore(t *testing.T) (string, *sqlite.EventDatasource) {

--- a/infrastructure/sqlite/export_test.go
+++ b/infrastructure/sqlite/export_test.go
@@ -69,3 +69,8 @@ func (d *EventDatasource) SetTimelinePayloadQueryHookForTest(hook func(kind stri
 func (d *StoreManagementDatasource) SetGarbageCollectionNowForTest(now func() time.Time) {
 	d.now = now
 }
+
+// OpenStoreForTest opens a live store through the same coordinated-lease,
+// WAL, busy_timeout DSN production readers and writers use, so tests do not
+// hand-write a divergent DSN for the store they exercise.
+func OpenStoreForTest(path string) *sql.DB { return openCoordinatedDB(path, sqliteDSN(path)) }


### PR DESCRIPTION
## 概要
Closes #1969

Leaves parent #1968 open.

## 変更内容
- Test fixture `openAttestationDB` now opens through production `sqliteDSN` (`OpenStoreForTest`) so verify sees WAL + `busy_timeout`.
- `VerifyAttestationChain` retries SQLITE_BUSY up to 3 times (25/50ms, context-aware) and returns typed `AttestationChainUndeterminedError` on terminal contention. Real chain-break errors are unchanged.
- Doctor / `Relation` mapping is unchanged in this PR.

## テスト確認
- [x] `go test ./infrastructure/sqlite/ -run TestVerifyAttestationChain_ConcurrentAppendDoesNotFalseFail -count=50` green (10.9s)
- [x] `go test ./infrastructure/sqlite/ -run TestVerifyAttestationChain -count=5` green

## Design
Claude Opus 5 medium: `.ai/spec/1969.md` (option c: fixture + verifier classification).
Implementation: Claude Sonnet 5 medium.

Do not close parent #1968.
