### PR TITLE
fix: keep plugin-version checks on large-store doctor

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Fixed
+- **大容量 store の `doctor` が host package identity を引き続き報告する (#1970)** — bounded `metadata_only_large_store` の早期 return に `*-plugin-version` ファミリーと native な Grok/Kimi plugin 有効化チェックが加わりました。host manifest・host plugin cache・host CLI probe だけを読みます。これにより `scripts/verify-post-upgrade-plugin-refresh.sh` は、bounded doctor の閾値（2 GiB）以上の live store に対しても `--skip` なしで post-upgrade gate を実行できます。store は引き続き open しません。
+
 ## [v0.39.0] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Fixed
+- **Large-store `doctor` still reports host package identity (#1970)** — the bounded `metadata_only_large_store` early return now includes the `*-plugin-version` family plus the native Grok/Kimi plugin activation checks, produced from host manifests, host plugin caches, and host CLI probes only. `scripts/verify-post-upgrade-plugin-refresh.sh` can therefore run the post-upgrade gate against a live store at or above the 2 GiB bounded-doctor threshold instead of needing `--skip`. The store is still never opened.
+
 ## [v0.39.0] - 2026-08-16
 
 ### Added

--- a/docs/operations/large-store-doctor.ja.md
+++ b/docs/operations/large-store-doctor.ja.md
@@ -13,8 +13,16 @@ traceary doctor --json --warnings-ok
 report には `mode: "metadata_only_large_store"` と
 `large-store-diagnostics` の警告が含まれます。これは出力欠落ではなく完了した
 結果です。filesystem metadata だけを使い、SQLite の open、migration、event の
-list、event body や command payload の読み取り、hook spool の検査、credential や
+list、event body や command payload の読み取り、credential や
 identifier sample の出力を行いません。
+
+bounded report には host package identity（`*-plugin-version` ファミリーと
+native な Grok/Kimi plugin 有効化チェック）が引き続き含まれます。これらは
+host manifest・host plugin cache・host CLI probe（`grok inspect --json`、
+`kimi.plugin.json` など）のみを読み、Traceary store は読みません。そのため
+live store が大容量であることは、古い host package を報告しない理由には
+なりません。それ以外の client 単位チェック（config 解決、event coverage、
+hook route）は引き続き bounded report から除外されます。
 
 ## 結果の解釈
 

--- a/docs/operations/large-store-doctor.md
+++ b/docs/operations/large-store-doctor.md
@@ -13,8 +13,16 @@ traceary doctor --json --warnings-ok
 The report has `mode: "metadata_only_large_store"` and the
 `large-store-diagnostics` warning. This is a completed result, not missing
 output. It uses filesystem metadata only; it does not open SQLite, run
-migrations, list events, read event bodies or command payloads, inspect hook
-spools, or print credentials or identifier samples.
+migrations, list events, read event bodies or command payloads, or print
+credentials or identifier samples.
+
+The bounded report still includes host package identity: the `*-plugin-version`
+family plus the native Grok/Kimi plugin activation checks. These read only
+host manifests, host plugin caches, and host CLI probes (`grok inspect --json`,
+`kimi.plugin.json`, and similar) — never the Traceary store — so a large live
+store is not a reason a stale host package goes unreported. Every other
+per-client check (config resolution, event coverage, hook routes) stays
+excluded from the bounded report.
 
 ## Interpret the result
 

--- a/docs/release/post-upgrade-plugins.ja.md
+++ b/docs/release/post-upgrade-plugins.ja.md
@@ -23,6 +23,14 @@ release 済みバイナリを更新するたびに、次を実行してくださ
 
    例の skip は、この機械に意図的に存在しないホストに置き換えてください。導入済みの古い package を隠すために skip を使ってはいけません。この gate は `traceary doctor --client <host> --json --warnings-ok` を実行し、各ホストの canonical plugin check 名と status だけを読みます（Grok は `grok-plugin`、他ホストは `*-plugin-version`）。`warn` または `fail` なら失敗します。prompt・transcript・command・database event の本文は出力しません。
 
+   この gate は live の既定 store path に対して有効です。store が bounded
+   doctor の閾値（2 GiB）以上でも変わりません。host package identity
+   ファミリー（`*-plugin-version` と native な Grok/Kimi plugin check）は
+   host manifest・host plugin cache・host CLI probe だけを読むため、doctor
+   が `mode: "metadata_only_large_store"` を返しても report に残ります。
+   store が大容量であることは、ホストを `--skip` する理由には**なりません**。
+   `--skip` はこの機械に意図的に導入していないホスト専用です。
+
 ## ホスト別の更新・有効化・検証マトリクス
 
 | Host | 更新 | 有効化 | version 検証 | 許可する skip |

--- a/docs/release/post-upgrade-plugins.md
+++ b/docs/release/post-upgrade-plugins.md
@@ -23,6 +23,14 @@ After every released binary upgrade:
 
    Replace the sample skips with the hosts intentionally absent from this machine. Do **not** use a skip to hide a stale installed package. The gate runs `traceary doctor --client <host> --json --warnings-ok`, reads only each host's canonical plugin check name/status (`grok-plugin` for Grok; `*-plugin-version` for the other hosts), and fails on `warn` or `fail`; it never emits prompt, transcript, command, or database-event bodies.
 
+   This gate is valid against the live default store path, including a store
+   at or above the 2 GiB bounded-doctor threshold: the host package identity
+   family (`*-plugin-version` and the native Grok/Kimi plugin checks) reads
+   only host manifests, host plugin caches, and host CLI probes, so it stays
+   in the report even when doctor returns `mode: "metadata_only_large_store"`.
+   A large store is **not** a reason to `--skip` a host — `--skip` is reserved
+   for hosts that are intentionally not installed on this machine.
+
 ## Host refresh and verification matrix
 
 | Host | Refresh | Activation | Version verification | Supported skip |

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -307,6 +307,20 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		// reported via directory entry counts and byte sizes only (pending /
 		// stale inflight / dead-letter).
 		report.Checks = append(report.Checks, inspectHookSpoolFilesystemMetadata())
+		// Host package identity (installed plugin/manifest version, native
+		// grok/kimi activation state) reads only host manifests, host plugin
+		// caches, and host CLI probes, so it stays available in the bounded
+		// report; it is independent of the Traceary store.
+		if resolvedProjectDir, projectDirErr := resolveHooksProjectDir(input.projectDir); projectDirErr != nil {
+			report.Checks = append(report.Checks, doctorCheck{
+				Name:    "project-dir",
+				Status:  doctorStatusFail,
+				Message: localizef("failed to resolve project directory: %v", "project directory の解決に失敗しました: %v", projectDirErr),
+			})
+			report.Checks = append(report.Checks, c.inspectPluginVersionChecks(input.currentVersion)...)
+		} else {
+			report.Checks = append(report.Checks, c.hostPackageIdentityChecks(ctx, resolvedClients, resolvedProjectDir, input.currentVersion)...)
+		}
 		return report, nil
 	}
 	if c.payloadCodecInspector != nil {
@@ -377,14 +391,8 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			// Kimi has no hook install path (the plugin is the distribution
 			// path), so the shared ResolveInstallPath would fail closed; the
 			// plugin state is probed directly from the Kimi home instead.
-			state, probeErr := probeKimiDoctorState(ctx, resolvedProjectDir)
-			if probeErr != nil {
-				// probeKimiDoctorState renders path-free errors only; keep the
-				// remediation generic rather than echoing host internals.
-				report.Checks = append(report.Checks, doctorCheck{Name: "kimi-inspect", Status: doctorStatusWarn, Message: localizef("failed to inspect the Kimi plugin installation: %v", "Kimi plugin の導入状態を検査できませんでした: %v", probeErr), Hint: Localize("reinstall the native Traceary Kimi plugin with scripts/install-kimi-plugin.sh, then rerun doctor", "scripts/install-kimi-plugin.sh で native Traceary Kimi plugin を再インストールしてから doctor を再実行してください")})
-			} else {
-				report.Checks = append(report.Checks, buildKimiDoctorChecks(state, input.currentVersion)...)
-			}
+			nativeChecks, _ := c.nativeHostPackageChecks(ctx, targetClient, resolvedProjectDir, input.currentVersion)
+			report.Checks = append(report.Checks, nativeChecks...)
 			report.Checks = append(report.Checks, c.inspectClientEventCoverage(ctx, targetClient, "", resolvedProjectDir, input.coverageThreshold))
 			continue
 		}
@@ -416,12 +424,8 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			continue
 		}
 		if targetClient == "grok" {
-			state, probeErr := probeGrokDoctorState(ctx, resolvedProjectDir)
-			if probeErr != nil {
-				report.Checks = append(report.Checks, doctorCheck{Name: "grok-inspect", Status: doctorStatusWarn, Message: localizef("failed to inspect Grok installation: %v", "Grok installation の検査に失敗しました: %v", probeErr), Hint: Localize("run `grok inspect --json` and retry doctor after resolving the host error", "`grok inspect --json` のエラーを解消してから doctor を再実行してください")})
-			} else {
-				report.Checks = append(report.Checks, buildGrokDoctorChecks(state, input.currentVersion)...)
-			}
+			nativeChecks, _ := c.nativeHostPackageChecks(ctx, targetClient, resolvedProjectDir, input.currentVersion)
+			report.Checks = append(report.Checks, nativeChecks...)
 			report.Checks = append(report.Checks, c.inspectClientEventCoverage(ctx, targetClient, outputPath, resolvedProjectDir, input.coverageThreshold))
 			continue
 		}

--- a/presentation/cli/doctor_host_package_identity.go
+++ b/presentation/cli/doctor_host_package_identity.go
@@ -1,0 +1,59 @@
+package cli
+
+import "context"
+
+// nativeHostPackageChecks probes and builds the native plugin activation
+// checks for hosts that ship a Traceary plugin distribution with its own
+// probe (grok, kimi). It reads only host manifests/caches and host CLI
+// output; it never touches the Traceary store. handled is false for any
+// other client, so callers can tell "not a native host" apart from "native
+// host with zero checks".
+func (c *RootCLI) nativeHostPackageChecks(ctx context.Context, client, projectDir, currentVersion string) (checks []doctorCheck, handled bool) {
+	switch client {
+	case "grok":
+		state, probeErr := probeGrokDoctorState(ctx, projectDir)
+		if probeErr != nil {
+			return []doctorCheck{{
+				Name:    "grok-inspect",
+				Status:  doctorStatusWarn,
+				Message: localizef("failed to inspect Grok installation: %v", "Grok installation の検査に失敗しました: %v", probeErr),
+				Hint:    Localize("run `grok inspect --json` and retry doctor after resolving the host error", "`grok inspect --json` のエラーを解消してから doctor を再実行してください"),
+			}}, true
+		}
+		return buildGrokDoctorChecks(state, currentVersion), true
+	case "kimi":
+		state, probeErr := probeKimiDoctorState(ctx, projectDir)
+		if probeErr != nil {
+			// probeKimiDoctorState renders path-free errors only; keep the
+			// remediation generic rather than echoing host internals.
+			return []doctorCheck{{
+				Name:    "kimi-inspect",
+				Status:  doctorStatusWarn,
+				Message: localizef("failed to inspect the Kimi plugin installation: %v", "Kimi plugin の導入状態を検査できませんでした: %v", probeErr),
+				Hint:    Localize("reinstall the native Traceary Kimi plugin with scripts/install-kimi-plugin.sh, then rerun doctor", "scripts/install-kimi-plugin.sh で native Traceary Kimi plugin を再インストールしてから doctor を再実行してください"),
+			}}, true
+		}
+		return buildKimiDoctorChecks(state, currentVersion), true
+	default:
+		return nil, false
+	}
+}
+
+// hostPackageIdentityChecks produces the host package identity family: the
+// installed package version for every host manifest/cache
+// (inspectPluginVersionChecks) plus the native grok/kimi activation checks
+// for the resolved clients. It is store-independent by construction — every
+// call it makes reads host manifests, host plugin caches, or host CLI probes
+// only — so it stays available in the bounded (large-store) doctor report.
+func (c *RootCLI) hostPackageIdentityChecks(ctx context.Context, clients []string, projectDir, currentVersion string) []doctorCheck {
+	checks := make([]doctorCheck, 0, len(clients)+4)
+	for _, client := range clients {
+		nativeChecks, handled := c.nativeHostPackageChecks(ctx, client, projectDir, currentVersion)
+		if !handled {
+			continue
+		}
+		checks = append(checks, nativeChecks...)
+	}
+	checks = append(checks, c.inspectPluginVersionChecks(currentVersion)...)
+	return checks
+}

--- a/presentation/cli/doctor_host_package_identity_internal_test.go
+++ b/presentation/cli/doctor_host_package_identity_internal_test.go
@@ -80,6 +80,25 @@ func newLargeStoreDoctorRootCLI(store *trackingStoreStub, events *trackingEventS
 // writeLargeStoreFixture creates a sparse >=2 GiB file that is a valid
 // filesystem entry but not a valid SQLite file, exercising the bounded
 // large-store decision path without allocating a multi-GB artifact.
+// setLargeStoreDoctorPath puts a throwaway `traceary` on PATH so the
+// bounded report's path check is pass, not fail. CI runners do not have
+// the binary on PATH; --warnings-ok does not ignore fail.
+func setLargeStoreDoctorPath(t *testing.T) {
+	t.Helper()
+	current, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error = %v", err)
+	}
+	dir := t.TempDir()
+	link := filepath.Join(dir, "traceary")
+	if err := os.Symlink(current, link); err != nil {
+		if err := os.WriteFile(link, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("failed to create traceary test executable: %v", err)
+		}
+	}
+	t.Setenv("PATH", dir)
+}
+
 func writeLargeStoreFixture(t *testing.T) string {
 	t.Helper()
 	largeStore := filepath.Join(t.TempDir(), "large-metadata-only.db")
@@ -142,6 +161,7 @@ func TestDoctorLargeStore_HostPackageIdentitySurvivesEarlyReturn(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv("TRACEARY_LANG", "en")
+			setLargeStoreDoctorPath(t)
 			home := t.TempDir()
 			t.Setenv("HOME", home)
 			SetUserHomeDirFunc(func() (string, error) { return home, nil })
@@ -191,6 +211,7 @@ func TestDoctorLargeStore_HostPackageIdentitySurvivesEarlyReturn(t *testing.T) {
 // it must never write a host file (#1970).
 func TestDoctorLargeStore_FixStaysNonDestructive(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
+	setLargeStoreDoctorPath(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	SetUserHomeDirFunc(func() (string, error) { return home, nil })
@@ -241,6 +262,7 @@ func TestDoctorLargeStore_FixStaysNonDestructive(t *testing.T) {
 // store-backed check (grok-event-coverage) is present (#1970).
 func TestDoctorLargeStore_NativeGrokCheckSurvives(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
+	setLargeStoreDoctorPath(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	SetUserHomeDirFunc(func() (string, error) { return home, nil })
@@ -304,6 +326,7 @@ func TestDoctorLargeStore_NativeGrokCheckSurvives(t *testing.T) {
 // plugin activation checks survive the bounded early return (#1970).
 func TestDoctorLargeStore_NativeKimiCheckSurvives(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
+	setLargeStoreDoctorPath(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	SetUserHomeDirFunc(func() (string, error) { return home, nil })
@@ -390,6 +413,7 @@ func TestDoctorLargeStore_NativeKimiCheckSurvives(t *testing.T) {
 // bounded report (#1970).
 func TestDoctorLargeStore_BoundedSetStaysBounded(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
+	setLargeStoreDoctorPath(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	SetUserHomeDirFunc(func() (string, error) { return home, nil })

--- a/presentation/cli/doctor_host_package_identity_internal_test.go
+++ b/presentation/cli/doctor_host_package_identity_internal_test.go
@@ -1,0 +1,435 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/infrastructure/filesystem"
+)
+
+// trackingStoreStub records whether Initialize (SQLite open) was ever called.
+type trackingStoreStub struct {
+	minimalStoreStub
+	initCalled bool
+}
+
+func (s *trackingStoreStub) Initialize(ctx context.Context) error {
+	s.initCalled = true
+	return s.minimalStoreStub.Initialize(ctx)
+}
+
+// trackingEventStub counts List calls so tests can assert the bounded
+// large-store path never reads events.
+type trackingEventStub struct {
+	hydrateCallTrackingEventUC
+	listCalls int
+}
+
+func (u *trackingEventStub) List(ctx context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error) {
+	u.listCalls++
+	return u.hydrateCallTrackingEventUC.List(ctx, criteria)
+}
+
+type panicLargeStoreCapacityInspector struct{ calls int }
+
+func (p *panicLargeStoreCapacityInspector) InspectCapacity(context.Context) (apptypes.CapacityReport, error) {
+	p.calls++
+	panic("capacity inspector must not run for large store")
+}
+
+type panicLargeStorePayloadCodecInspector struct{ calls int }
+
+func (p *panicLargeStorePayloadCodecInspector) InspectPayloadCodec(context.Context) (application.PayloadCodecState, error) {
+	p.calls++
+	panic("payload codec inspector must not run for large store")
+}
+
+// newLargeStoreDoctorRootCLI builds a RootCLI wired the same way production
+// doctor runs are, plus store/event/capacity/codec stubs that panic or count
+// calls so tests can assert the bounded path never touches the store.
+func newLargeStoreDoctorRootCLI(store *trackingStoreStub, events *trackingEventStub, capacity *panicLargeStoreCapacityInspector, codec *panicLargeStorePayloadCodecInspector) *RootCLI {
+	return NewRootCLI(
+		WithStoreManagement(store),
+		WithEvent(events),
+		WithCapacityInspector(capacity),
+		WithPayloadCodecInspector(codec),
+		WithHooksOrchestrator(filesystem.NewHooksOrchestrator(map[string]application.HooksClientHandler{
+			"claude":      filesystem.NewClaudeHooksHandler(),
+			"codex":       filesystem.NewCodexHooksHandlerWithHomeDirFunc(func() (string, error) { return CallUserHomeDirFunc() }),
+			"gemini":      filesystem.NewGeminiHooksHandler(),
+			"antigravity": filesystem.NewAntigravityHooksHandler(),
+			"grok":        filesystem.NewGrokHooksHandler(),
+			"kimi":        filesystem.NewKimiHooksHandler(),
+		})),
+		WithHooksInspector(filesystem.NewHooksInspector()),
+		WithPluginCacheInspector(filesystem.NewPluginCacheInspector()),
+		WithClaudePluginDetector(filesystem.NewClaudePluginDetectorAdapter()),
+	)
+}
+
+// writeLargeStoreFixture creates a sparse >=2 GiB file that is a valid
+// filesystem entry but not a valid SQLite file, exercising the bounded
+// large-store decision path without allocating a multi-GB artifact.
+func writeLargeStoreFixture(t *testing.T) string {
+	t.Helper()
+	largeStore := filepath.Join(t.TempDir(), "large-metadata-only.db")
+	file, err := os.OpenFile(largeStore, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	if err := file.Truncate(2 << 30); err != nil {
+		_ = file.Close()
+		t.Fatalf("Truncate() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	return largeStore
+}
+
+func decodeLargeStoreDoctorReport(t *testing.T, data []byte) doctorReport {
+	t.Helper()
+	var report doctorReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v (body=%s)", err, data)
+	}
+	return report
+}
+
+func largeStoreCheckByName(report doctorReport, name string) doctorCheck {
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	return doctorCheck{}
+}
+
+func writePluginManifest(t *testing.T, path, version string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{"name":"traceary","version":"` + version + `"}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+// TestDoctorLargeStore_HostPackageIdentitySurvivesEarlyReturn drives the
+// shipped doctor command against a >=2 GiB sparse store fixture and asserts
+// that the bounded metadata-only report still carries the per-host plugin
+// version family, produced from host manifests only (#1970).
+func TestDoctorLargeStore_HostPackageIdentitySurvivesEarlyReturn(t *testing.T) {
+	tests := map[string]struct {
+		manifestVersion string
+		wantStatus      string
+	}{
+		"matching manifest version passes":   {manifestVersion: "0.39.0", wantStatus: doctorStatusPass},
+		"stale manifest version still warns": {manifestVersion: "0.38.0", wantStatus: doctorStatusWarn},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("TRACEARY_LANG", "en")
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			SetUserHomeDirFunc(func() (string, error) { return home, nil })
+			t.Cleanup(ResetUserHomeDirFunc)
+
+			writePluginManifest(t, filepath.Join(home, ".codex", "plugins", "cache", "v"+tc.manifestVersion, "traceary", tc.manifestVersion, ".codex-plugin", "plugin.json"), tc.manifestVersion)
+			writePluginManifest(t, filepath.Join(home, ".gemini", "extensions", "traceary", "gemini-extension.json"), tc.manifestVersion)
+			writePluginManifest(t, filepath.Join(home, ".kimi-code", "plugins", "managed", "traceary", "kimi.plugin.json"), tc.manifestVersion)
+
+			largeStore := writeLargeStoreFixture(t)
+			store := &trackingStoreStub{}
+			events := &trackingEventStub{}
+			capacity := &panicLargeStoreCapacityInspector{}
+			codec := &panicLargeStorePayloadCodecInspector{}
+			rootCmd := newLargeStoreDoctorRootCLI(store, events, capacity, codec).Command()
+			rootCmd.Version = "0.39.0"
+			stdout := &bytes.Buffer{}
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetArgs([]string{"doctor", "--db-path", largeStore, "--json", "--warnings-ok"})
+
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			report := decodeLargeStoreDoctorReport(t, stdout.Bytes())
+			if report.Mode != "metadata_only_large_store" {
+				t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
+			}
+			if store.initCalled {
+				t.Fatal("large-store doctor initialized SQLite, want metadata-only outcome")
+			}
+			if events.listCalls != 0 {
+				t.Fatalf("large-store doctor listed %d events, want no event/payload reads", events.listCalls)
+			}
+			for _, checkName := range []string{"codex-plugin-version", "gemini-plugin-version", "kimi-plugin-version"} {
+				check := largeStoreCheckByName(report, checkName)
+				if check.Status != tc.wantStatus {
+					t.Fatalf("%s = %#v, want status %s", checkName, check, tc.wantStatus)
+				}
+			}
+		})
+	}
+}
+
+// TestDoctorLargeStore_FixStaysNonDestructive asserts that --fix against a
+// large store applies only guided remediation to the plugin-version checks;
+// it must never write a host file (#1970).
+func TestDoctorLargeStore_FixStaysNonDestructive(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	manifestPath := filepath.Join(home, ".gemini", "extensions", "traceary", "gemini-extension.json")
+	writePluginManifest(t, manifestPath, "0.38.0")
+
+	largeStore := writeLargeStoreFixture(t)
+	store := &trackingStoreStub{}
+	events := &trackingEventStub{}
+	capacity := &panicLargeStoreCapacityInspector{}
+	codec := &panicLargeStorePayloadCodecInspector{}
+	rootCmd := newLargeStoreDoctorRootCLI(store, events, capacity, codec).Command()
+	rootCmd.Version = "0.39.0"
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", largeStore, "--json", "--warnings-ok", "--fix"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	report := decodeLargeStoreDoctorReport(t, stdout.Bytes())
+	if report.Mode != "metadata_only_large_store" {
+		t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
+	}
+	var fixLog *doctorFixLog
+	for i := range report.Fixes {
+		if report.Fixes[i].Name == "gemini-plugin-version" {
+			fixLog = &report.Fixes[i]
+			break
+		}
+	}
+	if fixLog == nil {
+		t.Fatalf("fixes = %#v, want a gemini-plugin-version entry", report.Fixes)
+	}
+	if !strings.HasPrefix(fixLog.Action, "skip: guided remediation only; run `") {
+		t.Fatalf("fix action = %q, want guided-remediation-only skip", fixLog.Action)
+	}
+	if info, err := os.Stat(manifestPath); err != nil || info.Size() == 0 {
+		t.Fatalf("manifest at %s changed or vanished after --fix", manifestPath)
+	}
+}
+
+// TestDoctorLargeStore_NativeGrokCheckSurvives asserts the native Grok
+// plugin activation check survives the bounded early return, and that no
+// store-backed check (grok-event-coverage) is present (#1970).
+func TestDoctorLargeStore_NativeGrokCheckSurvives(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
+	t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+
+	projectDir := t.TempDir()
+	pluginHook := filepath.Join(projectDir, "integrations", "grok-plugin", "hooks", "hooks.json")
+	writeGrokDoctorHookFixture(t, pluginHook, true)
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 0.2.99 (build)\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary-grok","version":"0.39.0","path":"/Users/operator/.grok/plugins/traceary-grok"}]`), nil
+		case "--cwd " + projectDir + " inspect --json":
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":4,"mcpServers":0}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary-grok"}}]}`), nil
+		default:
+			t.Fatalf("unexpected Grok arguments: %v", args)
+			return nil, nil
+		}
+	}
+
+	largeStore := writeLargeStoreFixture(t)
+	store := &trackingStoreStub{}
+	events := &trackingEventStub{}
+	capacity := &panicLargeStoreCapacityInspector{}
+	codec := &panicLargeStorePayloadCodecInspector{}
+	rootCmd := newLargeStoreDoctorRootCLI(store, events, capacity, codec).Command()
+	rootCmd.Version = "0.39.0"
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--client", "grok", "--project-dir", projectDir, "--db-path", largeStore, "--json", "--warnings-ok"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	report := decodeLargeStoreDoctorReport(t, stdout.Bytes())
+	if report.Mode != "metadata_only_large_store" {
+		t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
+	}
+	check := largeStoreCheckByName(report, "grok-plugin")
+	if check.Status != doctorStatusPass {
+		t.Fatalf("grok-plugin = %#v, want pass", check)
+	}
+	if store.initCalled {
+		t.Fatal("large-store doctor initialized SQLite, want metadata-only outcome")
+	}
+	for _, forbidden := range []string{"grok-event-coverage", "grok-config"} {
+		if largeStoreCheckByName(report, forbidden).Name != "" {
+			t.Fatalf("bounded report contains store-backed check %q", forbidden)
+		}
+	}
+}
+
+// TestDoctorLargeStore_NativeKimiCheckSurvives asserts the native Kimi
+// plugin activation checks survive the bounded early return (#1970).
+func TestDoctorLargeStore_NativeKimiCheckSurvives(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	originalLookPath, originalOutput := kimiDoctorLookPath, kimiDoctorOutput
+	t.Cleanup(func() { kimiDoctorLookPath, kimiDoctorOutput = originalLookPath, originalOutput })
+	kimiDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/kimi", nil }
+	kimiDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) == 1 && args[0] == "--version" {
+			return []byte("0.39.0\n"), nil
+		}
+		return nil, nil
+	}
+
+	manifestDir := filepath.Join(home, ".kimi-code", "plugins", "managed", "traceary")
+	for _, skill := range []string{"traceary-memory-remember", "traceary-memory-review", "traceary-session-history", "traceary-session-refine"} {
+		if err := os.MkdirAll(filepath.Join(manifestDir, "skills", skill), 0o755); err != nil {
+			t.Fatalf("mkdir skill %s: %v", skill, err)
+		}
+		if err := os.WriteFile(filepath.Join(manifestDir, "skills", skill, "SKILL.md"), []byte("# skill\n"), 0o600); err != nil {
+			t.Fatalf("write skill: %v", err)
+		}
+	}
+	manifest := `{
+  "name": "traceary",
+  "version": "0.39.0",
+  "hooks": [
+    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 10},
+    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 10},
+    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 10},
+    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 10},
+    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 10},
+    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 10},
+    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 10},
+    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 10},
+    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 10},
+    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 10}
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(manifestDir, "kimi.plugin.json"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	record := `{"plugins": [{"id": "traceary", "root": "` + manifestDir + `", "source": "local-path", "enabled": true, "state": "ok", "installedAt": "2026-07-19T00:00:00Z"}]}`
+	if err := os.WriteFile(filepath.Join(home, ".kimi-code", "plugins", "installed.json"), []byte(record), 0o600); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+
+	largeStore := writeLargeStoreFixture(t)
+	store := &trackingStoreStub{}
+	events := &trackingEventStub{}
+	capacity := &panicLargeStoreCapacityInspector{}
+	codec := &panicLargeStorePayloadCodecInspector{}
+	rootCmd := newLargeStoreDoctorRootCLI(store, events, capacity, codec).Command()
+	rootCmd.Version = "0.39.0"
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--client", "kimi", "--db-path", largeStore, "--json", "--warnings-ok"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	report := decodeLargeStoreDoctorReport(t, stdout.Bytes())
+	if report.Mode != "metadata_only_large_store" {
+		t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
+	}
+	if check := largeStoreCheckByName(report, "kimi-plugin"); check.Status != doctorStatusPass {
+		t.Fatalf("kimi-plugin = %#v, want pass", check)
+	}
+	if check := largeStoreCheckByName(report, "kimi-plugin-version"); check.Status != doctorStatusPass {
+		t.Fatalf("kimi-plugin-version = %#v, want pass", check)
+	}
+	if store.initCalled {
+		t.Fatal("large-store doctor initialized SQLite, want metadata-only outcome")
+	}
+	if largeStoreCheckByName(report, "kimi-event-coverage").Name != "" {
+		t.Fatal("bounded report contains store-backed check kimi-event-coverage")
+	}
+}
+
+// TestDoctorLargeStore_BoundedSetStaysBounded asserts the additive host
+// package identity family does not pull any store-backed check into the
+// bounded report (#1970).
+func TestDoctorLargeStore_BoundedSetStaysBounded(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	largeStore := writeLargeStoreFixture(t)
+	store := &trackingStoreStub{}
+	events := &trackingEventStub{}
+	capacity := &panicLargeStoreCapacityInspector{}
+	codec := &panicLargeStorePayloadCodecInspector{}
+	rootCmd := newLargeStoreDoctorRootCLI(store, events, capacity, codec).Command()
+	rootCmd.Version = "0.39.0"
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", largeStore, "--json", "--warnings-ok"})
+
+	started := time.Now()
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("bounded metadata-only doctor took %s, want <= 1s", elapsed)
+	}
+	report := decodeLargeStoreDoctorReport(t, stdout.Bytes())
+	if report.Mode != "metadata_only_large_store" {
+		t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
+	}
+	forbidden := []string{
+		"claude-config", "codex-config", "gemini-config",
+		"claude-event-coverage", "codex-event-coverage", "gemini-event-coverage",
+		"memory-inbox", "store-growth-budget", "version",
+	}
+	for _, name := range forbidden {
+		if got := largeStoreCheckByName(report, name); got.Name != "" {
+			t.Fatalf("bounded report unexpectedly contains store-backed check %q: %#v", name, got)
+		}
+	}
+	diagnostics := largeStoreCheckByName(report, "large-store-diagnostics")
+	if diagnostics.Status != doctorStatusWarn {
+		t.Fatalf("large-store-diagnostics = %#v, want warn", diagnostics)
+	}
+}


### PR DESCRIPTION
## 概要
Closes #1970

Leaves parent #1968 open.

## 変更内容
- Bounded large-store doctor (`mode=metadata_only_large_store`) now emits host package identity checks (`*-plugin-version`, native `grok-plugin` / `kimi-plugin`) without opening SQLite.
- Client loop grok/kimi probes extracted to `nativeHostPackageChecks` so small-store ordering stays the same.
- Docs: large-store doctor + post-upgrade plugin refresh.

## テスト確認
- [x] `go test ./presentation/cli/... ./scripts/...`
- [x] `bash scripts/test-verify-post-upgrade-plugin-refresh.sh`
- [x] `go tool golangci-lint run`

## Design
Claude Opus 5 medium: `.ai/spec/1970.md`
Implementation: Claude Sonnet 5 medium

Do not close parent #1968.
