### PR TITLE
fix: keep dedupe identification running after one unreadable body

### DIFF
--- a/infrastructure/sqlite/content_event_dedupe_datasource.go
+++ b/infrastructure/sqlite/content_event_dedupe_datasource.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sort"
 	"strings"
@@ -26,9 +27,10 @@ import (
 const contentEventDedupeProximityWindow = 10 * time.Second
 
 const (
-	contentEventDedupeReasonProximity = "near-simultaneous hook duplicate"
-	contentEventDedupeReasonStrict    = "strict exact duplicate"
-	contentEventDedupeReasonMalformed = "skipped: malformed or unparseable created_at"
+	contentEventDedupeReasonProximity      = "near-simultaneous hook duplicate"
+	contentEventDedupeReasonStrict         = "strict exact duplicate"
+	contentEventDedupeReasonMalformed      = "skipped: malformed or unparseable created_at"
+	contentEventDedupeReasonUnreadableBody = "skipped: unreadable body"
 )
 
 // dedupeMemberRef is one row's participation in an identity group.
@@ -110,6 +112,19 @@ func (k dedupeGroupKey) forensicKey() string {
 		k.kind, k.client, k.agent, k.sessionID, k.workspace, hook,
 		"body:" + hex.EncodeToString(k.bodyDigest[:8]),
 	}, "|")
+}
+
+// unreadableDedupeIdentity renders the identity tuple for a row whose body
+// could not be decoded. The body component is a fixed "body:unreadable"
+// literal rather than a digest, deliberately distinguishable from
+// dedupeGroupKey.forensicKey (which always carries a real digest, even for a
+// genuinely empty body) — an unreadable row has no digest to report.
+func unreadableDedupeIdentity(kind, client, agent, sessionID, workspace, sourceHook string) string {
+	hook := sourceHook
+	if hook == "" {
+		hook = "-"
+	}
+	return strings.Join([]string{kind, client, agent, sessionID, workspace, hook, "body:unreadable"}, "|")
 }
 
 // stringInterner collapses the small set of repeated agent/hook/workspace values
@@ -249,6 +264,21 @@ type dedupeSurvey struct {
 	scannedBySource map[dedupeSourceKey]int
 	scannedCount    int
 	totalEligible   int
+	// unreadable holds rows whose body failed to decode with a tolerable
+	// (payload-integrity) error. They never join a group; planContentEventDedupe
+	// reports each as its own skip entry.
+	unreadable []dedupeUnreadableRow
+}
+
+// dedupeUnreadableRow is one scanned row whose body could not be decoded. It
+// carries no body: only the identity columns that were readable, plus a
+// body-free integrity detail for operator diagnosis.
+type dedupeUnreadableRow struct {
+	id         string
+	agent      string
+	sourceHook string
+	identity   string
+	detail     string
 }
 
 // identifyDedupeGroups streams every eligible hook content event and records
@@ -352,7 +382,21 @@ func (d *StoreManagementDatasource) identifyDedupeGroups(
 
 		body, err := decodeDedupeCandidateBody(payload, storedLength, hasCodec, id)
 		if err != nil {
-			return dedupeSurvey{}, err
+			detail, tolerable := dedupeUnreadableBodyReason(err)
+			if !tolerable {
+				return dedupeSurvey{}, err
+			}
+			slog.Warn("content-event dedupe: unreadable body skipped", "event_id", id, "detail", detail)
+			survey.unreadable = append(survey.unreadable, dedupeUnreadableRow{
+				id:         id,
+				agent:      rowAgent,
+				sourceHook: sourceHook.String,
+				identity:   unreadableDedupeIdentity(kind, client, rowAgent, sessionID, workspace, sourceHook.String),
+				detail:     detail,
+			})
+			survey.scannedBySource[dedupeSourceKey{agent: interner.intern(rowAgent), hook: interner.intern(sourceHook.String)}]++
+			survey.scannedCount++
+			continue
 		}
 
 		key := newDedupeGroupKey(
@@ -416,6 +460,20 @@ func decodeDedupeCandidateBody(
 		return "", xerrors.Errorf("decode dedupe candidate %s: %w", eventID, annotatePayloadError(err, eventID, "body"))
 	}
 	return string(plain), nil
+}
+
+// dedupeUnreadableBodyReason classifies a decodeDedupeCandidateBody failure.
+// Only a *PayloadIntegrityError is tolerable: it means the row's payload is
+// corrupt or unsupported, which is a per-row condition. Any other error means
+// the store is not in the shape the scan assumes, so the caller must abort.
+// The returned detail is body-free by construction (codec name plus the
+// integrity reason), safe to surface in ContentEventDedupeSkip.Reason.
+func dedupeUnreadableBodyReason(err error) (string, bool) {
+	var integrity *PayloadIntegrityError
+	if !errors.As(err, &integrity) {
+		return "", false
+	}
+	return fmt.Sprintf("codec=%s reason=%s", integrity.Codec, integrity.Reason), true
 }
 
 // dedupeEligibilityScope records which optional retention schema this store
@@ -652,6 +710,20 @@ func planContentEventDedupe(survey dedupeSurvey, strict bool) dedupePlan {
 			})
 		}
 	}
+
+	// SQL row order is unspecified, so the unreadable rows are sorted by event
+	// id before their skip entries are appended, the same way sortedEventIDs
+	// makes group skips deterministic.
+	unreadable := append([]dedupeUnreadableRow(nil), survey.unreadable...)
+	sort.Slice(unreadable, func(i, j int) bool { return unreadable[i].id < unreadable[j].id })
+	for _, row := range unreadable {
+		plan.skipped = append(plan.skipped, apptypes.ContentEventDedupeSkip{
+			GroupKey: row.identity,
+			EventIDs: []string{row.id},
+			Reason:   contentEventDedupeReasonUnreadableBody + " (" + row.detail + ")",
+		})
+	}
+
 	return plan
 }
 

--- a/infrastructure/sqlite/content_event_dedupe_test.go
+++ b/infrastructure/sqlite/content_event_dedupe_test.go
@@ -86,6 +86,186 @@ func seedDedupeFixture(t *testing.T) (string, *sqlite.StoreManagementDatasource,
 	return dbPath, storeManager, eventDS
 }
 
+// seedUnreadableBodyDedupeFixture builds a store with one near-simultaneous
+// decodable duplicate pair, one row whose body cannot be decoded, and a second
+// decodable duplicate pair under a different hook. It is deliberately separate
+// from seedDedupeFixture, whose exact ScannedCount/Sources assertions a new row
+// would break.
+func seedUnreadableBodyDedupeFixture(t *testing.T) (string, *sqlite.StoreManagementDatasource) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	_, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	type row struct {
+		id, kind, body, createdAt, sourceHook string
+	}
+	// Pair 1: near-simultaneous prompt duplicates. Canonical = u1 (earliest).
+	for _, r := range []row{
+		{"evt-u1", "prompt", "hello codex", "2026-05-01T00:00:00Z", "user_prompt_submit"},
+		{"evt-u2", "prompt", "hello codex", "2026-05-01T00:00:03Z", "user_prompt_submit"},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client)
+			 VALUES (?, ?, 'codex', 's1', 'w1', ?, ?, ?, 'hook')`,
+			r.id, r.kind, r.body, r.createdAt, r.sourceHook,
+		); err != nil {
+			t.Fatalf("insert %s error = %v", r.id, err)
+		}
+	}
+
+	// evt-x1: a row whose body cannot be decoded. body_codec is set but the
+	// other four payload metadata columns are left NULL, so payloadRow.decode
+	// reports "incomplete metadata" -- a tolerable *PayloadIntegrityError -- at
+	// negligible fixture cost (no oversized blob needed). Same (agent,
+	// source_hook) bucket as pair 1, inserted between the two pairs, so it also
+	// exercises B4 (both surrounding groups still identified) and B6 (scanned
+	// count includes it, candidate count does not).
+	if _, err := db.Exec(
+		`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client, body_codec)
+		 VALUES ('evt-x1', 'prompt', 'codex', 's1', 'w1', 'corrupt', '2026-05-01T00:00:05Z', 'user_prompt_submit', 'hook', 'zstd')`,
+	); err != nil {
+		t.Fatalf("insert evt-x1 error = %v", err)
+	}
+
+	// Pair 2 under a different hook.
+	for _, r := range []row{
+		{"evt-v1", "transcript", "transcript body", "2026-05-01T00:01:00Z", "stop"},
+		{"evt-v2", "transcript", "transcript body", "2026-05-01T00:01:01Z", "stop"},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client)
+			 VALUES (?, ?, 'codex', 's1', 'w1', ?, ?, ?, 'hook')`,
+			r.id, r.kind, r.body, r.createdAt, r.sourceHook,
+		); err != nil {
+			t.Fatalf("insert %s error = %v", r.id, err)
+		}
+	}
+
+	var availability string
+	if err := db.QueryRow(`SELECT body_availability FROM events WHERE id = 'evt-x1'`).Scan(&availability); err != nil {
+		t.Fatalf("read evt-x1 body_availability error = %v", err)
+	}
+	if availability != "available" {
+		t.Fatalf("evt-x1 body_availability = %q, want available (so it stays eligible)", availability)
+	}
+
+	return dbPath, storeManager
+}
+
+// B1/B2/B4/B6: one unreadable body between two decodable duplicate groups
+// does not stop identification, the remaining groups are still planned, the
+// unreadable row is reported as its own distinguishable skip entry, and the
+// counts stay honest.
+func TestStoreManagementDatasource_DedupeContentEvents_UnreadableBody_DryRun(t *testing.T) {
+	t.Parallel()
+	dbPath, storeManager := seedUnreadableBodyDedupeFixture(t)
+
+	result, err := storeManager.DedupeContentEvents(context.Background(), apptypes.ContentEventDedupeParams{Agent: "codex"})
+	if err != nil {
+		t.Fatalf("DedupeContentEvents() error = %v", err)
+	}
+
+	// B1 + B4: both surrounding groups are still planned.
+	if diff := cmp.Diff(map[string][]string{
+		"evt-u1": {"evt-u2"},
+		"evt-v1": {"evt-v2"},
+	}, groupByKept(result)); diff != "" {
+		t.Fatalf("plan (-want +got):\n%s", diff)
+	}
+	if result.MovedCount() != 2 {
+		t.Fatalf("MovedCount = %d, want 2", result.MovedCount())
+	}
+
+	// B2: the unreadable row is reported distinguishably, not silently dropped.
+	if len(result.Skipped) != 1 {
+		t.Fatalf("Skipped = %#v, want exactly one entry", result.Skipped)
+	}
+	skip := result.Skipped[0]
+	if diff := cmp.Diff([]string{"evt-x1"}, skip.EventIDs); diff != "" {
+		t.Fatalf("Skipped[0].EventIDs (-want +got):\n%s", diff)
+	}
+	if !strings.HasPrefix(skip.Reason, "skipped: unreadable body") {
+		t.Fatalf("Skipped[0].Reason = %q, want the unreadable-body prefix", skip.Reason)
+	}
+	if skip.Reason == "skipped: malformed or unparseable created_at" {
+		t.Fatalf("Skipped[0].Reason = %q, must not equal the malformed-timestamp constant", skip.Reason)
+	}
+	if !strings.HasSuffix(skip.GroupKey, "body:unreadable") {
+		t.Fatalf("Skipped[0].GroupKey = %q, want suffix body:unreadable", skip.GroupKey)
+	}
+
+	// B6: the unreadable row still counts as scanned, in both the overall total
+	// and its (agent, source_hook) bucket, but never as a candidate.
+	if result.ScannedCount != 5 {
+		t.Fatalf("ScannedCount = %d, want 5 (2 + 1 unreadable + 2)", result.ScannedCount)
+	}
+	var promptSource apptypes.ContentEventDedupeSourceStat
+	found := false
+	for _, source := range result.Sources {
+		if source.SourceHook == "user_prompt_submit" {
+			promptSource, found = source, true
+		}
+	}
+	if !found {
+		t.Fatalf("Sources = %#v, missing user_prompt_submit bucket", result.Sources)
+	}
+	if promptSource.ScannedCount != 3 {
+		t.Fatalf("prompt bucket ScannedCount = %d, want 3 (2 decodable + 1 unreadable)", promptSource.ScannedCount)
+	}
+	if promptSource.CandidateCount != 1 {
+		t.Fatalf("prompt bucket CandidateCount = %d, want 1 (the unreadable row is never a candidate)", promptSource.CandidateCount)
+	}
+
+	// Dry-run must not mutate.
+	if dedupeArchiveCount(t, dbPath) != 0 {
+		t.Fatalf("archive count = %d, want 0 after dry-run", dedupeArchiveCount(t, dbPath))
+	}
+}
+
+// B3: the unreadable row is never archived, on top of the decodable pairs
+// still being applied normally.
+func TestStoreManagementDatasource_DedupeContentEvents_UnreadableBody_Apply(t *testing.T) {
+	t.Parallel()
+	dbPath, storeManager := seedUnreadableBodyDedupeFixture(t)
+	now := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+
+	result, err := storeManager.DedupeContentEvents(context.Background(), apptypes.ContentEventDedupeParams{
+		Agent: "codex", Apply: true, RunID: "dedupe-unreadable-1", Now: now,
+	})
+	if err != nil {
+		t.Fatalf("DedupeContentEvents(apply) error = %v", err)
+	}
+	if result.MovedCount() != 2 {
+		t.Fatalf("MovedCount = %d, want 2", result.MovedCount())
+	}
+	if !eventExists(t, dbPath, "evt-x1") {
+		t.Fatal("unreadable row evt-x1 was removed by apply")
+	}
+	for _, id := range []string{"evt-u2", "evt-v2"} {
+		if eventExists(t, dbPath, id) {
+			t.Fatalf("decodable duplicate %s was not archived", id)
+		}
+	}
+	for _, id := range []string{"evt-u1", "evt-v1"} {
+		if !eventExists(t, dbPath, id) {
+			t.Fatalf("canonical row %s was wrongly removed", id)
+		}
+	}
+	if got := dedupeArchiveCount(t, dbPath); got != 2 {
+		t.Fatalf("archive count = %d, want 2 (the unreadable row is never archived)", got)
+	}
+}
+
 func dedupeArchiveCount(t *testing.T, dbPath string) int {
 	t.Helper()
 	db, err := sql.Open("sqlite", "file:"+dbPath)

--- a/infrastructure/sqlite/content_event_dedupe_unreadable_internal_test.go
+++ b/infrastructure/sqlite/content_event_dedupe_unreadable_internal_test.go
@@ -1,0 +1,101 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A decode failure that is not a *PayloadIntegrityError means the store is not
+// in the shape the scan assumes, so it must still abort the whole run rather
+// than being classified as a per-row skip.
+func TestDedupeUnreadableBodyReason_NonIntegrityErrorAborts(t *testing.T) {
+	t.Parallel()
+
+	_, tolerable := dedupeUnreadableBodyReason(errors.New("boom"))
+	if tolerable {
+		t.Fatal("tolerable = true for a non-integrity decode error, want false")
+	}
+}
+
+// An oversized stored payload is classified as a tolerable integrity error,
+// not silently truncated, and its detail names the codec and the reason
+// without ever including payload content.
+func TestDedupeUnreadableBodyReason_OversizedStoredBodyIsTolerable(t *testing.T) {
+	t.Parallel()
+
+	payload := payloadRow{Codec: sql.NullString{String: "zstd", Valid: true}}
+	storedLength := sql.NullInt64{Int64: maxStoredPayloadBytes + 1, Valid: true}
+	_, err := decodeDedupeCandidateBody(payload, storedLength, true, "evt-oversized")
+	if err == nil {
+		t.Fatal("decodeDedupeCandidateBody() error = nil, want an oversized-length error")
+	}
+
+	detail, tolerable := dedupeUnreadableBodyReason(err)
+	if !tolerable {
+		t.Fatal("tolerable = false, want true for an oversized stored body")
+	}
+	if !strings.Contains(detail, "codec=zstd") || !strings.Contains(detail, "stored length exceeds limit") {
+		t.Fatalf("detail = %q, want it to name the codec and the reason", detail)
+	}
+}
+
+// permittedDedupeDrops is what compaction's deleteNonCanonicalDuplicateEvents
+// relies on to decide which duplicates it may drop. A row whose body cannot be
+// decoded has no identity, so it must never appear as a drop candidate, and its
+// presence must not stop an otherwise-decodable duplicate pair from being
+// planned.
+func TestPermittedDedupeDrops_PreservesUnreadableBody(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	rows := []struct{ id, body, createdAt string }{
+		{"evt-p1", "hello", "2026-05-01T00:00:00Z"},
+		{"evt-p2", "hello", "2026-05-01T00:00:03Z"},
+	}
+	for _, r := range rows {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client)
+			 VALUES (?, 'prompt', 'codex', 's1', 'w1', ?, ?, 'user_prompt_submit', 'hook')`,
+			r.id, r.body, r.createdAt,
+		); err != nil {
+			t.Fatalf("insert %s error = %v", r.id, err)
+		}
+	}
+	// evt-px: body_codec is set but the other four payload metadata columns are
+	// left NULL, so payloadRow.decode reports "incomplete metadata" -- a
+	// tolerable *PayloadIntegrityError.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client, body_codec)
+		 VALUES ('evt-px', 'prompt', 'codex', 's1', 'w1', 'corrupt', '2026-05-01T00:00:05Z', 'user_prompt_submit', 'hook', 'zstd')`,
+	); err != nil {
+		t.Fatalf("insert evt-px error = %v", err)
+	}
+
+	drops, err := permittedDedupeDrops(ctx, db)
+	if err != nil {
+		t.Fatalf("permittedDedupeDrops() error = %v", err)
+	}
+	if _, ok := drops["evt-px"]; ok {
+		t.Fatal("unreadable row evt-px was included in the drop set")
+	}
+	if kept, ok := drops["evt-p2"]; !ok || kept != "evt-p1" {
+		t.Fatalf("drops[evt-p2] = (%q, %v), want (evt-p1, true)", kept, ok)
+	}
+}


### PR DESCRIPTION
## 概要
Closes #1699

Leaves parent #1968 open.

## 変更内容
- `identifyDedupeGroups` continues after a single `*PayloadIntegrityError` decode.
- That row is skipped with `contentEventDedupeReasonUnreadableBody` (identity suffix `body:unreadable`) and logged; remaining groups are still planned/applied.
- Non-integrity decode errors still abort.

## テスト確認
- [x] `go test ./infrastructure/sqlite/... ./application/usecase/...` (attestation concurrent flake is #1969, already merged)

## Design
Claude Opus 5 medium: `.ai/spec/1699.md`
Implementation: Claude Sonnet 5 medium

Do not close parent #1968.
