### PR TITLE
fix: detect Grok plugin version from installed-plugins root

### DIFF
--- a/presentation/cli/doctor_plugin_version.go
+++ b/presentation/cli/doctor_plugin_version.go
@@ -59,8 +59,12 @@ func (c *RootCLI) detectPluginInstalls() []doctorPluginInstall {
 	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "config", "plugins", "traceary", "plugin.json"), "antigravity", agyHint)...)
 	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "antigravity-cli", "plugins", "traceary", "plugin.json"), "antigravity", agyHint)...)
 	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "extensions", "traceary", "gemini-extension.json"), "gemini", "gemini extensions update traceary")...)
+	// Grok clones the whole repository into a hash-named directory under
+	// installed-plugins and selects the package with a #subdir selector; the
+	// manifest stays at its in-repo path inside that clone, so the glob must
+	// follow the installer root rather than a fixed plugin name.
 	installs = append(installs, detectManifestInstalls(
-		filepath.Join(home, ".grok", "plugins", "traceary", "plugin.json"),
+		filepath.Join(home, ".grok", "installed-plugins", "*", "integrations", "grok-plugin", "plugin.json"),
 		"grok",
 		"./scripts/install-grok-plugin.sh  # from a matching release tag checkout",
 	)...)

--- a/presentation/cli/doctor_plugin_version_test.go
+++ b/presentation/cli/doctor_plugin_version_test.go
@@ -222,6 +222,156 @@ func TestDetectPluginInstallsIncludesAntigravityManifest(t *testing.T) {
 	t.Fatalf("detectPluginInstalls() = %+v, want Antigravity manifest", installs)
 }
 
+func TestDetectPluginInstallsIncludesGrokInstallerRootManifest(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+	manifest := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-be141821", "integrations", "grok-plugin", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(manifest, []byte(`{"name":"traceary-grok","version":"0.39.0"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	installs := (&RootCLI{}).detectPluginInstalls()
+	for _, install := range installs {
+		if install.Client == "grok" && install.ManifestPath == manifest {
+			return
+		}
+	}
+	t.Fatalf("detectPluginInstalls() = %+v, want Grok installer-root manifest", installs)
+}
+
+func TestDetectPluginInstallsGrokDoesNotDependOnCloneDirName(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+	manifest := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-deadbeef", "integrations", "grok-plugin", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(manifest, []byte(`{"name":"traceary-grok","version":"0.39.0"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	installs := (&RootCLI{}).detectPluginInstalls()
+	for _, install := range installs {
+		if install.Client == "grok" && install.ManifestPath == manifest {
+			return
+		}
+	}
+	t.Fatalf("detectPluginInstalls() = %+v, want Grok manifest regardless of clone dir name", installs)
+}
+
+func TestDetectPluginInstallsReportsAllGrokClones(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+	manifestA := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-aaaaaaaa", "integrations", "grok-plugin", "plugin.json")
+	manifestB := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-bbbbbbbb", "integrations", "grok-plugin", "plugin.json")
+	for _, manifest := range []string{manifestA, manifestB} {
+		if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(manifest, []byte(`{"name":"traceary-grok","version":"0.39.0"}`), 0o600); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+	}
+
+	installs := (&RootCLI{}).detectPluginInstalls()
+	grokCount := 0
+	for _, install := range installs {
+		if install.Client == "grok" {
+			grokCount++
+		}
+	}
+	if grokCount != 2 {
+		t.Fatalf("detectPluginInstalls() grok count = %d, want 2 (%+v)", grokCount, installs)
+	}
+}
+
+func TestDetectPluginInstallsIgnoresLegacyGrokPluginsPath(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+	legacyManifest := filepath.Join(home, ".grok", "plugins", "traceary", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(legacyManifest), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(legacyManifest, []byte(`{"name":"traceary-grok","version":"0.39.0"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	installs := (&RootCLI{}).detectPluginInstalls()
+	for _, install := range installs {
+		if install.Client == "grok" {
+			t.Fatalf("detectPluginInstalls() = %+v, want no grok install from legacy path", installs)
+		}
+	}
+}
+
+func TestInspectPluginVersionChecksGrokInstallerRootPass(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+	manifest := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-be141821", "integrations", "grok-plugin", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(manifest, []byte(`{"name":"traceary-grok","version":"0.39.0"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	checks := (&RootCLI{}).inspectPluginVersionChecks("0.39.0")
+	for _, check := range checks {
+		if check.Name == "grok-plugin-version" && check.Status == doctorStatusPass {
+			return
+		}
+	}
+	t.Fatalf("inspectPluginVersionChecks() = %+v, want passing grok-plugin-version", checks)
+}
+
+func TestInspectPluginVersionChecksGrokInstallerRootWarnsOnMismatch(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+	manifest := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-be141821", "integrations", "grok-plugin", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(manifest, []byte(`{"name":"traceary-grok","version":"0.38.0"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	checks := (&RootCLI{}).inspectPluginVersionChecks("0.39.0")
+	for _, check := range checks {
+		if check.Name == "grok-plugin-version" {
+			if check.Status != doctorStatusWarn {
+				t.Fatalf("grok-plugin-version status = %v, want warn", check.Status)
+			}
+			if !strings.Contains(check.FixCommand, "install-grok-plugin.sh") {
+				t.Fatalf("grok-plugin-version FixCommand = %q, want install-grok-plugin.sh", check.FixCommand)
+			}
+			return
+		}
+	}
+	t.Fatalf("inspectPluginVersionChecks() = %+v, want grok-plugin-version warn", checks)
+}
+
+func TestInspectPluginVersionChecksSilentWhenGrokNotInstalled(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	checks := (&RootCLI{}).inspectPluginVersionChecks("0.39.0")
+	for _, check := range checks {
+		if check.Name == "grok-plugin-version" {
+			t.Fatalf("inspectPluginVersionChecks() = %+v, want no grok-plugin-version check when Grok is not installed", checks)
+		}
+	}
+}
+
 func TestNormalizeDoctorVersion(t *testing.T) {
 	tests := map[string]string{
 		"0.9.0 (commit=abc, date=2026, go=1.24)": "0.9.0",


### PR DESCRIPTION
## 概要
Closes #1974

Leaves parent #1968 open.

## 変更内容
- Filesystem `grok-plugin-version` now globs `~/.grok/installed-plugins/*/integrations/grok-plugin/plugin.json`.
- Removed the dead `~/.grok/plugins/traceary/plugin.json` glob.

## テスト確認
- [x] `go test ./presentation/cli/`
- [x] `go tool golangci-lint run`

## Design
Claude Opus 5 medium: `.ai/spec/1974.md`
Implementation: Claude Sonnet 5 medium

Do not close parent #1968.
