### PR TITLE
docs: document transcript-only discard scope and per-record accrual

### DIFF
--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -3,7 +3,7 @@
 [English](./README.md)
 
 Traceary は、ローカル状態を 1 つの SQLite DB ファイルに保存します。
-このガイドでは、何がどこに保存されるのか、現在の schema がどう構成されているのか、`gc` / backup の既定動作が実際に何を意味するのかを整理します。
+このガイドでは、何がどこに保存されるのか、現在の schema がどう構成されているのか、`compact` / backup の既定動作が実際に何を意味するのかを整理します。
 
 ## ローカルファーストの配置
 
@@ -66,7 +66,7 @@ Traceary は確認済みのコマンド構造だけを正規化します。直�
 
 `input_truncated` または `output_truncated` が true の場合、保存済み payload はすでに上限内の head/tail projection であり、新規 row では対応する `*_original_bytes` column に元の byte 数を記録します。検索 index は `command_text` / `input_text` / `output_text` を `events.body` と独立に持つため、合成 body を消しても audit テキストの検索性は失われません。切り詰められた byte は過去 row から復元できません。
 
-`command_audits.event_id` は `ON DELETE CASCADE` なので、`gc` で event を削除すると対応する audit payload も同時に消えます。
+`command_audits.event_id` は `ON DELETE CASCADE` なので、event row を削除すると対応する audit payload も同時に消えます。
 
 ### `sessions`
 
@@ -186,10 +186,22 @@ fold schema より前の store には被覆の証跡が無いため、破棄候�
 
 実務上の意味:
 
-- `gc` は opt-in であり、Traceary が background で自動削除することはありません
-- 被覆済みの transcript 本文だけを破棄したい場合は `--target events` を使ってください
+- `store compact` は operator が手動で実行するもので、Traceary が background で自動的に履歴を破棄することはありません
+- `store compact` が破棄する kind は `transcript` 本文のみです。`prompt` 本文と `command_audits` のテキストは常に残ります
 - 長期の監査履歴を残したい場合は、強めの cleanup の前に backup を取ってください
 - cold 行の export と **verify-before-delete** は [Archive-before-GC](./archive-before-gc.ja.md)（#1309）を参照。フルファイル backup は [バックアップガイド](../backup/README.ja.md)
+
+## レコードごとのストレージ蓄積
+
+`store compact` が破棄できる部分を除き、各 event row は永続的にストレージを蓄積します。`select_discardable_event_bodies.sql` の allowlist は現時点では `{transcript}` のみです。終了済みかつ被覆済みセッションの `transcript` 本文だけが本文破棄の対象になります。
+
+以下は破棄パスの対象外であり、常に残ります。
+
+- `command_audits.command_text`、`input_text`、`output_text` — `command_executed` event の構造化 audit 記録
+- `prompt` event の本文
+- すべての kind の event skeleton（id、kind、session_id、created_at など）
+
+参照コーパスでの実測値: 約 **2.67 KiB/event** が永続的に蓄積し、約 **0.35 KiB/event** が破棄可能（被覆済みの `transcript` 本文）で、上限の目安は約 **4 KiB/event** です。`store compact` は破棄可能な部分を削減しますが、ストアの総サイズを上限付きにするものではありません。永続的に蓄積する部分は、compact の実行頻度に関係なく event 数に比例して増加します。
 
 ## 履歴 content の可逆的な dedupe
 

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -3,7 +3,7 @@
 [日本語](./README.ja.md)
 
 Traceary stores its local state in a single SQLite database file.
-This guide explains what gets written there, how the schema is organized today, and what the current `gc` / backup defaults mean in practice.
+This guide explains what gets written there, how the schema is organized today, and what the current `compact` / backup defaults mean in practice.
 
 ## Local-first layout
 
@@ -66,7 +66,7 @@ Traceary normalizes only command structure it has verified. Direct executables u
 
 When `input_truncated` or `output_truncated` is true, the stored payload is already a bounded head/tail projection and the corresponding `*_original_bytes` column records the original size for new rows. Search indexes `command_text` / `input_text` / `output_text` independently of `events.body`, so clearing the composed body does not drop searchable audit text. The omitted truncated bytes are not recoverable from historical rows.
 
-Because `command_audits.event_id` uses `ON DELETE CASCADE`, deleting an event through `gc` also deletes its audit payload.
+Because `command_audits.event_id` uses `ON DELETE CASCADE`, event row deletion also deletes the corresponding audit payload.
 
 ### `sessions`
 
@@ -189,10 +189,22 @@ Future discard reasons must use an additive sidecar column, never a new `body_av
 
 Practical implications:
 
-- `gc` is opt-in; Traceary does not delete history automatically in the background
-- use `--target events` to discard covered transcript bodies only
+- `store compact` is operator-initiated; Traceary does not discard history automatically in the background
+- `transcript` bodies are the only kind discarded by `store compact`; `prompt` bodies and `command_audits` text always remain
 - if you care about long-term audit history, take a backup before an aggressive cleanup
 - for cold-row export with **verify-before-delete**, see [Archive-before-GC](./archive-before-gc.md) (#1309); full-file backup remains [Backup guide](../backup/README.md)
+
+## Per-record storage accrual
+
+Each event row accrues storage permanently except for the fraction that `store compact` can discard. The allowlist in `select_discardable_event_bodies.sql` is currently exactly `{transcript}`: only `transcript` bodies from ended, covered sessions are eligible for body discard.
+
+The following are outside the discard path and always remain:
+
+- `command_audits.command_text`, `input_text`, `output_text` — the structured audit record for `command_executed` events
+- `prompt` event bodies
+- event skeletons (id, kind, session_id, created_at, and other metadata columns) for all kinds
+
+Measured composition on the reference corpus: roughly **2.67 KiB/event** accrues permanently and roughly **0.35 KiB/event** is discardable (covered `transcript` bodies), against a roughly **4 KiB/event** ceiling. `store compact` reduces the discardable portion; it does not bound the total store size. The permanently-accruing share grows with the number of events regardless of how often compact runs.
 
 ## Reversible historical content dedupe
 

--- a/infrastructure/sqlite/discardable_event_bodies_test.go
+++ b/infrastructure/sqlite/discardable_event_bodies_test.go
@@ -1,9 +1,30 @@
 package sqlite
 
 import (
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+// TestSelectDiscardableEventBodiesKindAllowlist pins that the SQL allowlist for
+// irreversible body discard names exactly {transcript}. Widening it requires an
+// explicit policy decision; this test fails closed if a kind is added without
+// updating the documentation in docs/storage/README.md.
+func TestSelectDiscardableEventBodiesKindAllowlist(t *testing.T) {
+	t.Parallel()
+	re := regexp.MustCompile(`(?i)\bkind\s*=\s*'([^']+)'`)
+	var kinds []string
+	for _, m := range re.FindAllStringSubmatch(selectDiscardableEventBodiesQuery, -1) {
+		kinds = append(kinds, m[1])
+	}
+	sort.Strings(kinds)
+	if diff := cmp.Diff([]string{"transcript"}, kinds); diff != "" {
+		t.Errorf("discardable kind allowlist mismatch (-want +got):\n%s", diff)
+	}
+}
 
 func TestDiscardableEventBodiesWrappersContainPlaceholder(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Body discard via `store compact` only targets `transcript` bodies. Prompt bodies and `command_audits` text never enter that path, so ~2.67 KiB/event of the record accrues permanently. This PR documents that as a *reduction*, not a bounded-store guarantee, remaps leftover `gc` / `--target events` wording onto `store compact`, and pins the SQL kind allowlist to `{transcript}`.

Does **not** widen discard scope (issue owner chose option 3).

## Test plan

- [x] `go test ./infrastructure/sqlite/ ./cmd/repo-tooling/ -run 'TestDiscard|TestDocs|TestRepo'`
- [x] `TestSelectDiscardableEventBodiesKindAllowlist` asserts the embedded SQL allowlist is exactly `{transcript}`

Closes #1797

Leaves parent #1968 open.