### PR TITLE
fix: batch command-audit payload hydration to O(1) queries

### DIFF
--- a/infrastructure/sqlite/command_audit_payload.go
+++ b/infrastructure/sqlite/command_audit_payload.go
@@ -2,6 +2,8 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"log/slog"
 
 	"golang.org/x/xerrors"
@@ -13,10 +15,52 @@ import (
 // Compile-time interface assertion.
 var _ queryservice.CommandAuditPayloadQueryService = (*EventDatasource)(nil)
 
+// batchHydrateAuditCodecSQL fetches codec-managed payload columns for a page
+// of event IDs in one query. All three field groups are always selected so the
+// SQL is static; callers skip decoding of unrequested fields at no query cost.
+const batchHydrateAuditCodecSQL = `
+SELECT event_id,
+  CASE WHEN length(CAST(command_text AS BLOB)) <= ? THEN command_text END,
+  command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256,
+  length(CAST(command_text AS BLOB)),
+  CASE WHEN length(CAST(input_text AS BLOB)) <= ? THEN input_text END,
+  input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256,
+  length(CAST(input_text AS BLOB)),
+  CASE WHEN length(CAST(output_text AS BLOB)) <= ? THEN output_text END,
+  output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256,
+  length(CAST(output_text AS BLOB))
+  FROM command_audits
+ WHERE event_id IN (SELECT CAST(value AS TEXT) FROM json_each(?))`
+
+// batchHydrateAuditLegacySQL fetches plain-text payload columns for a page of
+// event IDs in one query (pre-codec stores). The size bound uses
+// maxDecodedPayloadBytes because legacy stores use identity codec (stored == decoded).
+const batchHydrateAuditLegacySQL = `
+SELECT event_id,
+  CASE WHEN length(CAST(command_text AS BLOB)) <= ? THEN command_text END,
+  length(CAST(command_text AS BLOB)),
+  CASE WHEN length(CAST(input_text AS BLOB)) <= ? THEN input_text END,
+  length(CAST(input_text AS BLOB)),
+  CASE WHEN length(CAST(output_text AS BLOB)) <= ? THEN output_text END,
+  length(CAST(output_text AS BLOB))
+  FROM command_audits
+ WHERE event_id IN (SELECT CAST(value AS TEXT) FROM json_each(?))`
+
+// auditPayloadValues holds the decoded plaintext for the three codec-managed
+// command_audits columns. A zero-value NullString means the field was not
+// requested or the row had no audit record.
+type auditPayloadValues struct {
+	command sql.NullString
+	input   sql.NullString
+	output  sql.NullString
+}
+
 // HydrateCommandAudits decodes selected codec-managed command_audits columns
 // onto listed events. Listing joins only fixed-size metadata; this is the
 // exclusive read path for command_text / input_text / output_text on list and
 // search results.
+//
+// Query cost: O(1) schema probe + O(1) batch SELECT regardless of page size.
 func (d *EventDatasource) HydrateCommandAudits(
 	ctx context.Context,
 	events []*model.Event,
@@ -42,6 +86,13 @@ func (d *EventDatasource) HydrateCommandAudits(
 		}
 	}()
 
+	// Collect event IDs that have a CommandAudit entry, preserving order.
+	type auditEntry struct {
+		event *model.Event
+		audit *model.CommandAudit
+	}
+	entries := make([]auditEntry, 0, len(events))
+	ids := make([]string, 0, len(events))
 	for _, event := range events {
 		if event == nil {
 			continue
@@ -50,55 +101,210 @@ func (d *EventDatasource) HydrateCommandAudits(
 		if !ok || audit == nil {
 			continue
 		}
-		hydrated, err := hydrateCommandAuditFields(ctx, db, audit, fields)
+		entries = append(entries, auditEntry{event, audit})
+		ids = append(ids, audit.EventID().String())
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	// Schema probe: once per call, not once per field per event.
+	hasCodec, err := auditHasCodecColumns(ctx, db)
+	if err != nil {
+		return xerrors.Errorf("inspect command_audits schema: %w", err)
+	}
+	if d.onAuditHydrationQuery != nil {
+		d.onAuditHydrationQuery("schema")
+	}
+
+	// Batch-fetch all payload columns for the whole id page in one SELECT.
+	payloads, err := batchFetchAuditPayloads(ctx, db, ids, fields, hasCodec)
+	if err != nil {
+		return err
+	}
+	if d.onAuditHydrationQuery != nil {
+		d.onAuditHydrationQuery("payload")
+	}
+
+	// Reconstruct domain objects from pre-decoded values (no further queries).
+	for _, e := range entries {
+		values := payloads[e.audit.EventID().String()]
+		hydrated, err := restoreCommandAuditFromValues(e.audit, fields, values)
 		if err != nil {
-			return xerrors.Errorf("hydrate command audit payloads for %s: %w", event.EventID(), err)
+			return xerrors.Errorf("restore hydrated command audit for %s: %w", e.audit.EventID(), err)
 		}
-		event.AttachCommandAudit(hydrated)
+		e.event.AttachCommandAudit(hydrated)
 	}
 	return nil
 }
 
-func hydrateCommandAuditFields(
+// batchFetchAuditPayloads fetches codec-managed payload fields for all ids in
+// a single SELECT using json_each. It returns a map keyed by event ID string.
+// Event IDs present in ids but absent from command_audits are silently omitted.
+//
+// Codec / integrity / size-limit semantics are identical to hydrateAuditPayload.
+func batchFetchAuditPayloads(
 	ctx context.Context,
-	q queryRowContexter,
+	queryer eventSearchQueryer,
+	ids []string,
+	fields queryservice.CommandAuditPayloadFields,
+	hasCodec bool,
+) (map[string]auditPayloadValues, error) {
+	jsonIDs, err := json.Marshal(ids)
+	if err != nil {
+		return nil, xerrors.Errorf("encode audit event ID list: %w", err)
+	}
+	result := make(map[string]auditPayloadValues, len(ids))
+	if hasCodec {
+		return batchFetchAuditCodecPayloads(ctx, queryer, string(jsonIDs), fields, result)
+	}
+	return batchFetchAuditLegacyPayloads(ctx, queryer, string(jsonIDs), fields, result)
+}
+
+func batchFetchAuditCodecPayloads(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	jsonIDs string,
+	fields queryservice.CommandAuditPayloadFields,
+	result map[string]auditPayloadValues,
+) (map[string]auditPayloadValues, error) {
+	rows, err := queryer.QueryContext(ctx, batchHydrateAuditCodecSQL,
+		maxStoredPayloadBytes, maxStoredPayloadBytes, maxStoredPayloadBytes, jsonIDs)
+	if err != nil {
+		return nil, xerrors.Errorf("batch fetch audit codec payloads: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var eventID string
+		var cmdRow payloadRow
+		var cmdLen sql.NullInt64
+		var inpRow payloadRow
+		var inpLen sql.NullInt64
+		var outRow payloadRow
+		var outLen sql.NullInt64
+
+		if err := rows.Scan(
+			&eventID,
+			&cmdRow.Stored, &cmdRow.Codec, &cmdRow.FormatVersion, &cmdRow.PlaintextBytes, &cmdRow.StoredBytes, &cmdRow.SHA256, &cmdLen,
+			&inpRow.Stored, &inpRow.Codec, &inpRow.FormatVersion, &inpRow.PlaintextBytes, &inpRow.StoredBytes, &inpRow.SHA256, &inpLen,
+			&outRow.Stored, &outRow.Codec, &outRow.FormatVersion, &outRow.PlaintextBytes, &outRow.StoredBytes, &outRow.SHA256, &outLen,
+		); err != nil {
+			return nil, xerrors.Errorf("scan batch audit codec row: %w", err)
+		}
+
+		var values auditPayloadValues
+		if fields.Command {
+			if cmdLen.Valid && cmdLen.Int64 > maxStoredPayloadBytes {
+				return nil, &PayloadIntegrityError{Codec: cmdRow.Codec.String, RowID: eventID, Field: "command", Reason: "stored length exceeds limit"}
+			}
+			plain, err := cmdRow.decode(maxDecodedPayloadBytes)
+			if err != nil {
+				return nil, annotatePayloadError(err, eventID, "command")
+			}
+			values.command = sql.NullString{String: string(plain), Valid: true}
+		}
+		if fields.Input {
+			if inpLen.Valid && inpLen.Int64 > maxStoredPayloadBytes {
+				return nil, &PayloadIntegrityError{Codec: inpRow.Codec.String, RowID: eventID, Field: "input", Reason: "stored length exceeds limit"}
+			}
+			plain, err := inpRow.decode(maxDecodedPayloadBytes)
+			if err != nil {
+				return nil, annotatePayloadError(err, eventID, "input")
+			}
+			values.input = sql.NullString{String: string(plain), Valid: true}
+		}
+		if fields.Output {
+			if outLen.Valid && outLen.Int64 > maxStoredPayloadBytes {
+				return nil, &PayloadIntegrityError{Codec: outRow.Codec.String, RowID: eventID, Field: "output", Reason: "stored length exceeds limit"}
+			}
+			plain, err := outRow.decode(maxDecodedPayloadBytes)
+			if err != nil {
+				return nil, annotatePayloadError(err, eventID, "output")
+			}
+			values.output = sql.NullString{String: string(plain), Valid: true}
+		}
+		result[eventID] = values
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("iterate batch audit codec rows: %w", err)
+	}
+	return result, nil
+}
+
+func batchFetchAuditLegacyPayloads(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	jsonIDs string,
+	fields queryservice.CommandAuditPayloadFields,
+	result map[string]auditPayloadValues,
+) (map[string]auditPayloadValues, error) {
+	rows, err := queryer.QueryContext(ctx, batchHydrateAuditLegacySQL,
+		maxDecodedPayloadBytes, maxDecodedPayloadBytes, maxDecodedPayloadBytes, jsonIDs)
+	if err != nil {
+		return nil, xerrors.Errorf("batch fetch audit legacy payloads: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var eventID string
+		var cmdVal sql.NullString
+		var cmdLen sql.NullInt64
+		var inpVal sql.NullString
+		var inpLen sql.NullInt64
+		var outVal sql.NullString
+		var outLen sql.NullInt64
+
+		if err := rows.Scan(&eventID, &cmdVal, &cmdLen, &inpVal, &inpLen, &outVal, &outLen); err != nil {
+			return nil, xerrors.Errorf("scan batch audit legacy row: %w", err)
+		}
+
+		var values auditPayloadValues
+		if fields.Command {
+			if cmdLen.Valid && cmdLen.Int64 > maxDecodedPayloadBytes {
+				return nil, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: "command", Reason: "stored length exceeds limit"}
+			}
+			values.command = cmdVal
+		}
+		if fields.Input {
+			if inpLen.Valid && inpLen.Int64 > maxDecodedPayloadBytes {
+				return nil, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: "input", Reason: "stored length exceeds limit"}
+			}
+			values.input = inpVal
+		}
+		if fields.Output {
+			if outLen.Valid && outLen.Int64 > maxDecodedPayloadBytes {
+				return nil, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: "output", Reason: "stored length exceeds limit"}
+			}
+			values.output = outVal
+		}
+		result[eventID] = values
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("iterate batch audit legacy rows: %w", err)
+	}
+	return result, nil
+}
+
+// restoreCommandAuditFromValues rebuilds a CommandAudit from pre-decoded
+// payload values. Audit metadata (wrapper, command name, truncation flags,
+// etc.) is taken from the listing-time snapshot in audit.
+func restoreCommandAuditFromValues(
 	audit *model.CommandAudit,
 	fields queryservice.CommandAuditPayloadFields,
+	values auditPayloadValues,
 ) (*model.CommandAudit, error) {
-	if audit == nil {
-		return nil, nil
-	}
 	command := audit.Command()
 	input := audit.Input()
 	output := audit.Output()
-	eventID := audit.EventID().String()
-
-	if fields.Command {
-		value, err := hydrateAuditPayload(ctx, q, eventID, "command")
-		if err != nil {
-			return nil, err
-		}
-		if value.Valid {
-			command = value.String
-		}
+	if fields.Command && values.command.Valid {
+		command = values.command.String
 	}
-	if fields.Input {
-		value, err := hydrateAuditPayload(ctx, q, eventID, "input")
-		if err != nil {
-			return nil, err
-		}
-		if value.Valid {
-			input = value.String
-		}
+	if fields.Input && values.input.Valid {
+		input = values.input.String
 	}
-	if fields.Output {
-		value, err := hydrateAuditPayload(ctx, q, eventID, "output")
-		if err != nil {
-			return nil, err
-		}
-		if value.Valid {
-			output = value.String
-		}
+	if fields.Output && values.output.Valid {
+		output = values.output.String
 	}
 
 	snapshot := model.CommandAuditSnapshot{

--- a/infrastructure/sqlite/command_audit_payload_test.go
+++ b/infrastructure/sqlite/command_audit_payload_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,6 +189,176 @@ INSERT INTO command_audits(
 		// decode to the full line, not leave the command_name basename.
 		if strings.TrimSpace(fresh[0].Body()) != "" {
 			t.Fatalf("events.body should stay empty after #1675, got %q", fresh[0].Body())
+		}
+	})
+}
+
+// TestHydrateCommandAuditsQueryCount pins the O(1) batch hydration contract:
+// for a page of N events, HydrateCommandAudits must issue exactly 1 schema
+// probe and 1 batch SELECT — not O(N) or O(N × fields) queries.
+func TestHydrateCommandAuditsQueryCount(t *testing.T) {
+	t.Parallel()
+
+	const pageSize = 25
+	const sessionID = "session-qcount"
+
+	t.Run("codec shape emits O(1) queries for N events", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		path := filepath.Join(t.TempDir(), "qcount-codec.db")
+		database := NewDatabase(path, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+		if err := database.initialize(ctx); err != nil {
+			t.Fatalf("initialize: %v", err)
+		}
+		raw, err := database.open(ctx)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer database.release(raw)
+
+		commandPayload := mustEncodeAuditPayload(t, "ls -la", payloadCodecZstd)
+		for i := range pageSize {
+			eventID := fmt.Sprintf("evt-qcount-codec-%02d", i)
+			if _, err := raw.ExecContext(ctx, `
+INSERT INTO events(id, kind, client, agent, session_id, workspace, body, body_availability, created_at, source_hook)
+VALUES(?, 'command_executed', 'cli', 'claude', ?, '/repo', '', 'available', ?, '')`,
+				eventID, sessionID,
+				time.Date(2026, 8, 9, 12, 0, i, 0, time.UTC).Format(time.RFC3339Nano),
+			); err != nil {
+				t.Fatalf("insert event %d: %v", i, err)
+			}
+			if _, err := raw.ExecContext(ctx, `
+INSERT INTO command_audits(
+  event_id, command_text, command_wrapper, command_name, input_text, output_text,
+  input_truncated, output_truncated, input_original_bytes, output_original_bytes,
+  exit_code, failed, failure_reason,
+  command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256,
+  input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256,
+  output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256
+) VALUES(
+  ?, ?, '', 'ls', '', '',
+  0, 0, 0, 0,
+  0, 0, 'none',
+  ?, ?, ?, ?, ?,
+  NULL, NULL, NULL, NULL, NULL,
+  NULL, NULL, NULL, NULL, NULL
+)`,
+				eventID, commandPayload.Bytes,
+				commandPayload.Codec, commandPayload.FormatVersion, commandPayload.PlaintextBytes, commandPayload.StoredBytes, commandPayload.SHA256,
+			); err != nil {
+				t.Fatalf("insert command_audit %d: %v", i, err)
+			}
+		}
+
+		datasource := NewEventDatasource(database)
+		listed, err := datasource.ListRecent(ctx, pageSize, 0, types.EventKindCommandExecuted, "", "", sessionID, "", false, time.Time{}, time.Time{}, "")
+		if err != nil {
+			t.Fatalf("ListRecent: %v", err)
+		}
+		if len(listed) != pageSize {
+			t.Fatalf("ListRecent len = %d, want %d", len(listed), pageSize)
+		}
+
+		var queryKinds []string
+		datasource.SetAuditHydrationQueryHookForTest(func(kind string) {
+			queryKinds = append(queryKinds, kind)
+		})
+
+		if err := datasource.HydrateCommandAudits(ctx, listed, queryservice.CommandOnlyPayload()); err != nil {
+			t.Fatalf("HydrateCommandAudits: %v", err)
+		}
+
+		// Exactly 2 queries: one schema probe + one batch SELECT.
+		if len(queryKinds) != 2 {
+			t.Errorf("expected 2 queries (schema + payload), got %d: %v", len(queryKinds), queryKinds)
+		}
+		if len(queryKinds) >= 1 && queryKinds[0] != "schema" {
+			t.Errorf("first query kind = %q, want %q", queryKinds[0], "schema")
+		}
+		if len(queryKinds) >= 2 && queryKinds[1] != "payload" {
+			t.Errorf("second query kind = %q, want %q", queryKinds[1], "payload")
+		}
+
+		// Correctness: all events must have decoded command payloads.
+		for i, ev := range listed {
+			audit, ok := ev.CommandAudit().Value()
+			if !ok || audit == nil {
+				t.Errorf("event[%d]: missing audit after hydration", i)
+				continue
+			}
+			if audit.Command() != "ls -la" {
+				t.Errorf("event[%d]: command = %q, want %q", i, audit.Command(), "ls -la")
+			}
+		}
+	})
+
+	t.Run("legacy shape emits O(1) queries for N events", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		path := filepath.Join(t.TempDir(), "qcount-legacy.db")
+		database := NewDatabase(path, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+		if err := database.initialize(ctx); err != nil {
+			t.Fatalf("initialize: %v", err)
+		}
+		raw, err := database.open(ctx)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer database.release(raw)
+
+		// Simulate a legacy (pre-codec) store: command_text is plain-text and
+		// all codec metadata columns are NULL.
+		for i := range pageSize {
+			eventID := fmt.Sprintf("evt-qcount-legacy-%02d", i)
+			if _, err := raw.ExecContext(ctx, `
+INSERT INTO events(id, kind, client, agent, session_id, workspace, body, body_availability, created_at, source_hook)
+VALUES(?, 'command_executed', 'cli', 'claude', ?, '/repo', '', 'available', ?, '')`,
+				eventID, sessionID,
+				time.Date(2026, 8, 9, 12, 0, i, 0, time.UTC).Format(time.RFC3339Nano),
+			); err != nil {
+				t.Fatalf("insert event %d: %v", i, err)
+			}
+			if _, err := raw.ExecContext(ctx, `
+INSERT INTO command_audits(
+  event_id, command_text, command_wrapper, command_name, input_text, output_text,
+  input_truncated, output_truncated, input_original_bytes, output_original_bytes,
+  exit_code, failed, failure_reason,
+  command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256,
+  input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256,
+  output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256
+) VALUES(?, 'ls -la', '', 'ls', '', '', 0, 0, 0, 0, 0, 0, 'none',
+  NULL, NULL, NULL, NULL, NULL,
+  NULL, NULL, NULL, NULL, NULL,
+  NULL, NULL, NULL, NULL, NULL)`,
+				eventID,
+			); err != nil {
+				t.Fatalf("insert command_audit %d: %v", i, err)
+			}
+		}
+
+		datasource := NewEventDatasource(database)
+		listed, err := datasource.ListRecent(ctx, pageSize, 0, types.EventKindCommandExecuted, "", "", sessionID, "", false, time.Time{}, time.Time{}, "")
+		if err != nil {
+			t.Fatalf("ListRecent: %v", err)
+		}
+		if len(listed) != pageSize {
+			t.Fatalf("ListRecent len = %d, want %d", len(listed), pageSize)
+		}
+
+		var queryKinds []string
+		datasource.SetAuditHydrationQueryHookForTest(func(kind string) {
+			queryKinds = append(queryKinds, kind)
+		})
+
+		if err := datasource.HydrateCommandAudits(ctx, listed, queryservice.CommandOnlyPayload()); err != nil {
+			t.Fatalf("HydrateCommandAudits: %v", err)
+		}
+
+		// Exactly 2 queries: one schema probe + one batch SELECT.
+		if len(queryKinds) != 2 {
+			t.Errorf("expected 2 queries (schema + payload), got %d: %v", len(queryKinds), queryKinds)
 		}
 	})
 }

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -51,6 +51,7 @@ type EventDatasource struct {
 	db                       *Database
 	onListWindowBatch        func(batchIndex, batchSize int)
 	timelinePayloadQueryHook func(kind string)
+	onAuditHydrationQuery    func(kind string) // test-only; "schema" or "payload"
 }
 
 // NewEventDatasource creates a new EventDatasource bound to the given

--- a/infrastructure/sqlite/export_test.go
+++ b/infrastructure/sqlite/export_test.go
@@ -65,6 +65,14 @@ func (d *EventDatasource) SetTimelinePayloadQueryHookForTest(hook func(kind stri
 	d.timelinePayloadQueryHook = hook
 }
 
+// SetAuditHydrationQueryHookForTest installs a hook called once for the
+// schema probe ("schema") and once for the batch payload SELECT ("payload")
+// inside HydrateCommandAudits. Tests use it to assert O(1) query count for
+// a page of N events. Pass nil to clear.
+func (d *EventDatasource) SetAuditHydrationQueryHookForTest(hook func(kind string)) {
+	d.onAuditHydrationQuery = hook
+}
+
 // SetGarbageCollectionNowForTest fixes the timestamp persisted by gc discards.
 func (d *StoreManagementDatasource) SetGarbageCollectionNowForTest(now func() time.Time) {
 	d.now = now

--- a/infrastructure/sqlite/payload_hydration.go
+++ b/infrastructure/sqlite/payload_hydration.go
@@ -173,6 +173,14 @@ func loadEventPlaintext(ctx context.Context, q queryRowContexter, eventID string
 	return decodeEventPlaintext(ctx, q, eventID, hasCodec)
 }
 
+func auditHasCodecColumns(ctx context.Context, q queryRowContexter) (bool, error) {
+	var has int
+	if err := q.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pragma_table_info('command_audits') WHERE name='command_codec')`).Scan(&has); err != nil {
+		return false, xerrors.Errorf("inspect audit payload metadata: %w", err)
+	}
+	return has != 0, nil
+}
+
 func eventHasCodecColumns(ctx context.Context, q queryRowContexter) (bool, error) {
 	var has int
 	if err := q.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pragma_table_info('events') WHERE name='body_codec')`).Scan(&has); err != nil {


### PR DESCRIPTION
## Summary

`HydrateCommandAudits` issued one schema probe and one payload SELECT per event per field. This PR hoists the schema probe and fetches the requested page in one `json_each` SELECT, still going through codec + integrity + size limits.

## Test plan

- [x] `go test ./infrastructure/sqlite/ -run TestHydrateCommandAudits`
  - `TestHydrateCommandAuditsQueryCount` asserts exactly schema + payload queries for a 25-event page (codec and legacy shapes)
  - decoded values remain correct; fail-closed integrity is unchanged

Closes #1730

Leaves parent #1968 open.