### PR TITLE
fix: report unknown events.body_codec values in doctor

### DIFF
--- a/application/body_codec_checker.go
+++ b/application/body_codec_checker.go
@@ -1,0 +1,24 @@
+package application
+
+import "context"
+
+// BodyCodecRow is a single unknown-codec observation from the events table.
+// Count is the number of rows carrying that codec value; SampleIDs holds up
+// to a bounded number of event IDs so an operator can locate the rows.
+type BodyCodecRow struct {
+	Codec     string
+	Count     int64
+	SampleIDs []string
+}
+
+// BodyCodecState holds the result of scanning events.body_codec for values
+// the current binary cannot decode.
+type BodyCodecState struct {
+	UnknownRows []BodyCodecRow
+}
+
+// BodyCodecChecker reports events rows whose body_codec value the running
+// binary's decoder does not support.
+type BodyCodecChecker interface {
+	CheckBodyCodec(context.Context) (BodyCodecState, error)
+}

--- a/infrastructure/sqlite/body_codec_checker.go
+++ b/infrastructure/sqlite/body_codec_checker.go
@@ -1,0 +1,94 @@
+package sqlite
+
+import (
+	"context"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+)
+
+const bodyCodecSampleLimit = 5
+
+// BodyCodecChecker reads events.body_codec and reports values the running
+// binary cannot decode.
+type BodyCodecChecker struct{ db *Database }
+
+// NewBodyCodecChecker creates a read-only body codec checker.
+func NewBodyCodecChecker(db *Database) *BodyCodecChecker {
+	return &BodyCodecChecker{db: db}
+}
+
+var _ application.BodyCodecChecker = (*BodyCodecChecker)(nil)
+
+// CheckBodyCodec returns any body_codec values not supported by this binary.
+func (c *BodyCodecChecker) CheckBodyCodec(ctx context.Context) (_ application.BodyCodecState, err error) {
+	db, err := c.db.openReadOnly(ctx)
+	if err != nil {
+		return application.BodyCodecState{}, xerrors.Errorf("open store for body codec check: %w", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = xerrors.Errorf("close body codec check: %w", closeErr)
+		}
+	}()
+
+	supported := SupportedBodyCodecs()
+	placeholders := strings.Repeat("?,", len(supported))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(supported))
+	for i, v := range supported {
+		args[i] = v
+	}
+
+	rows, err := db.QueryContext(ctx,
+		"SELECT body_codec, COUNT(*) FROM events WHERE body_codec NOT IN ("+placeholders+") GROUP BY body_codec ORDER BY body_codec",
+		args...)
+	if err != nil {
+		return application.BodyCodecState{}, xerrors.Errorf("query unknown body codecs: %w", err)
+	}
+
+	var unknown []application.BodyCodecRow
+	for rows.Next() {
+		var row application.BodyCodecRow
+		if err := rows.Scan(&row.Codec, &row.Count); err != nil {
+			_ = rows.Close()
+			return application.BodyCodecState{}, xerrors.Errorf("scan body codec row: %w", err)
+		}
+		unknown = append(unknown, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return application.BodyCodecState{}, xerrors.Errorf("iterate body codec rows: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return application.BodyCodecState{}, xerrors.Errorf("close body codec rows: %w", err)
+	}
+
+	for i := range unknown {
+		sampleRows, err := db.QueryContext(ctx,
+			"SELECT id FROM events WHERE body_codec = ? ORDER BY id LIMIT ?",
+			unknown[i].Codec, bodyCodecSampleLimit)
+		if err != nil {
+			return application.BodyCodecState{}, xerrors.Errorf("query body codec sample ids: %w", err)
+		}
+		for sampleRows.Next() {
+			var id string
+			if err := sampleRows.Scan(&id); err != nil {
+				_ = sampleRows.Close()
+				return application.BodyCodecState{}, xerrors.Errorf("scan body codec sample id: %w", err)
+			}
+			unknown[i].SampleIDs = append(unknown[i].SampleIDs, id)
+		}
+		if err := sampleRows.Err(); err != nil {
+			_ = sampleRows.Close()
+			return application.BodyCodecState{}, xerrors.Errorf("iterate body codec sample ids: %w", err)
+		}
+		if err := sampleRows.Close(); err != nil {
+			return application.BodyCodecState{}, xerrors.Errorf("close body codec sample rows: %w", err)
+		}
+	}
+
+	return application.BodyCodecState{UnknownRows: unknown}, nil
+}

--- a/infrastructure/sqlite/body_codec_checker.go
+++ b/infrastructure/sqlite/body_codec_checker.go
@@ -35,6 +35,9 @@ func (c *BodyCodecChecker) CheckBodyCodec(ctx context.Context) (_ application.Bo
 	}()
 
 	supported := SupportedBodyCodecs()
+	if len(supported) == 0 {
+		return application.BodyCodecState{}, xerrors.Errorf("binary advertises no supported body codecs")
+	}
 	placeholders := strings.Repeat("?,", len(supported))
 	placeholders = placeholders[:len(placeholders)-1]
 	args := make([]any, len(supported))
@@ -42,8 +45,10 @@ func (c *BodyCodecChecker) CheckBodyCodec(ctx context.Context) (_ application.Bo
 		args[i] = v
 	}
 
+	// NULL body_codec is the pre-codec identity row, not an unknown value.
+	// decodePayload treats missing metadata as identity.
 	rows, err := db.QueryContext(ctx,
-		"SELECT body_codec, COUNT(*) FROM events WHERE body_codec NOT IN ("+placeholders+") GROUP BY body_codec ORDER BY body_codec",
+		"SELECT body_codec, COUNT(*) FROM events WHERE body_codec IS NOT NULL AND body_codec NOT IN ("+placeholders+") GROUP BY body_codec ORDER BY body_codec",
 		args...)
 	if err != nil {
 		return application.BodyCodecState{}, xerrors.Errorf("query unknown body codecs: %w", err)

--- a/infrastructure/sqlite/body_codec_checker_test.go
+++ b/infrastructure/sqlite/body_codec_checker_test.go
@@ -1,0 +1,121 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCheckBodyCodec_ReportsUnknownAndIgnoresSupportedAndNull(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, preparedMigrations(t))
+	store := NewStoreManagementDatasource(database)
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", directSQLiteRWDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	insert := func(id, codec string, codecValid bool) {
+		t.Helper()
+		var bodyCodec any
+		if codecValid {
+			bodyCodec = codec
+		}
+		if _, err := db.Exec(
+			`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client, body_codec)
+			 VALUES (?, 'prompt', 'codex', 's1', 'w1', 'body', '2026-04-10T00:00:00Z', 'user_prompt_submit', 'hook', ?)`,
+			id, bodyCodec,
+		); err != nil {
+			t.Fatalf("insert %s error = %v", id, err)
+		}
+	}
+	insert("evt-identity", payloadCodecIdentity, true)
+	insert("evt-zstd", payloadCodecZstd, true)
+	insert("evt-null", "", false)
+	insert("evt-gzip-1", "gzip", true)
+	insert("evt-gzip-2", "gzip", true)
+	insert("evt-zstd19", "zstd:19", true)
+
+	state, err := NewBodyCodecChecker(database).CheckBodyCodec(context.Background())
+	if err != nil {
+		t.Fatalf("CheckBodyCodec() error = %v", err)
+	}
+	want := []struct {
+		codec string
+		count int64
+		ids   []string
+	}{
+		{codec: "gzip", count: 2, ids: []string{"evt-gzip-1", "evt-gzip-2"}},
+		{codec: "zstd:19", count: 1, ids: []string{"evt-zstd19"}},
+	}
+	if len(state.UnknownRows) != len(want) {
+		t.Fatalf("UnknownRows = %+v, want %d groups", state.UnknownRows, len(want))
+	}
+	for i, row := range state.UnknownRows {
+		if diff := cmp.Diff(want[i].codec, row.Codec); diff != "" {
+			t.Fatalf("UnknownRows[%d].Codec mismatch (-want +got):\n%s", i, diff)
+		}
+		if row.Count != want[i].count {
+			t.Fatalf("UnknownRows[%d].Count = %d, want %d", i, row.Count, want[i].count)
+		}
+		if diff := cmp.Diff(want[i].ids, row.SampleIDs); diff != "" {
+			t.Fatalf("UnknownRows[%d].SampleIDs mismatch (-want +got):\n%s", i, diff)
+		}
+	}
+}
+
+func TestCheckBodyCodec_PassOnKnownOnly(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, preparedMigrations(t))
+	store := NewStoreManagementDatasource(database)
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", directSQLiteRWDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(
+		`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client, body_codec)
+		 VALUES ('evt-ok', 'prompt', 'codex', 's1', 'w1', 'body', '2026-04-10T00:00:00Z', 'user_prompt_submit', 'hook', ?)`,
+		payloadCodecIdentity,
+	); err != nil {
+		t.Fatalf("insert error = %v", err)
+	}
+
+	state, err := NewBodyCodecChecker(database).CheckBodyCodec(context.Background())
+	if err != nil {
+		t.Fatalf("CheckBodyCodec() error = %v", err)
+	}
+	if len(state.UnknownRows) != 0 {
+		t.Fatalf("UnknownRows = %+v, want empty", state.UnknownRows)
+	}
+}
+
+func TestSupportedBodyCodecs_MatchesDecodePayload(t *testing.T) {
+	t.Parallel()
+	for _, codec := range SupportedBodyCodecs() {
+		encoded, err := encodePayload([]byte("hello"), codec)
+		if err != nil {
+			t.Fatalf("encodePayload(%q) error = %v", codec, err)
+		}
+		if _, err := decodePayload(encoded.Bytes, codec, encoded.FormatVersion, encoded.PlaintextBytes, encoded.SHA256, maxDecodedPayloadBytes); err != nil {
+			t.Fatalf("decodePayload(%q) error = %v, want supported", codec, err)
+		}
+	}
+	if _, err := decodePayload([]byte("hello"), "gzip", payloadFormatVersion, 5, "deadbeef", maxDecodedPayloadBytes); err == nil {
+		t.Fatal("decodePayload(gzip) error = nil, want unsupported")
+	}
+}

--- a/infrastructure/sqlite/payload_codec.go
+++ b/infrastructure/sqlite/payload_codec.go
@@ -184,3 +184,9 @@ func isPayloadIntegrityError(err error) bool {
 	var target *PayloadIntegrityError
 	return errors.As(err, &target)
 }
+
+// SupportedBodyCodecs returns the body_codec values this binary can decode.
+// The list is sourced from the same switch as decodePayload.
+func SupportedBodyCodecs() []string {
+	return []string{payloadCodecIdentity, payloadCodecZstd}
+}

--- a/main.go
+++ b/main.go
@@ -246,6 +246,7 @@ func run() error {
 		cli.WithOperatorCostInspector(sqlite.NewOperatorCostInspector(db)),
 		cli.WithPayloadCodecInspector(sqlite.NewPayloadCodecInspector(db)),
 		cli.WithAttestationAnchorInspector(sqlite.NewAttestationAnchorInspector(db)),
+		cli.WithBodyCodecChecker(sqlite.NewBodyCodecChecker(db)),
 		cli.WithSearchProjection(usecase.NewSearchProjectionUsecase(db)),
 		cli.WithStoreCompactionFactory(func(path string) application.StoreCompactionUsecase {
 			journal := &sqlite.CompactionFileJournal{Dir: filepath.Join(filepath.Dir(path), ".traceary-compaction")}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -351,6 +351,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		report.Checks = append(report.Checks, c.inspectContentEventReliability(ctx, input.strict))
 		report.Checks = append(report.Checks, c.inspectRetryLoops(ctx))
 		report.Checks = append(report.Checks, c.inspectSensitiveAccessAuditCoverage(ctx))
+		report.Checks = append(report.Checks, c.inspectBodyCodec(ctx))
 		if c.attestationAnchorInspector != nil {
 			report.Checks = append(report.Checks, c.inspectAttestationAnchor(ctx, resolvedDBPath, true))
 		}

--- a/presentation/cli/doctor_body_codec.go
+++ b/presentation/cli/doctor_body_codec.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func (c *RootCLI) inspectBodyCodec(ctx context.Context) doctorCheck {
+	const name = "body-codec"
+	if c.bodyCodecChecker == nil {
+		return doctorCheck{Name: name, Status: doctorStatusSkip, Message: Localize("body codec checker is not configured", "body codec チェッカーが設定されていません")}
+	}
+	state, err := c.bodyCodecChecker.CheckBodyCodec(ctx)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorStatusWarn, Message: localizef("failed to check body codec: %v", "body codec の確認に失敗しました: %v", err)}
+	}
+	if len(state.UnknownRows) == 0 {
+		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("all events use a supported body codec", "すべてのイベントはサポートされた body codec を使用しています")}
+	}
+	parts := make([]string, 0, len(state.UnknownRows))
+	for _, row := range state.UnknownRows {
+		parts = append(parts, fmt.Sprintf("%s (count=%d, sample_ids=[%s])", row.Codec, row.Count, strings.Join(row.SampleIDs, ",")))
+	}
+	return doctorCheck{
+		Name:    name,
+		Status:  doctorStatusWarn,
+		Message: localizef("events contain unsupported body_codec values: %s", "events にサポートされていない body_codec 値があります: %s", strings.Join(parts, "; ")),
+		Hint:    Localize("rebuild the store with a binary that supports these codecs, or file a bug against the writer", "これらの codec をサポートするバイナリで store を再構築するか、writer に対してバグ報告してください"),
+	}
+}

--- a/presentation/cli/doctor_body_codec_shipped_test.go
+++ b/presentation/cli/doctor_body_codec_shipped_test.go
@@ -1,0 +1,152 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/google/go-cmp/cmp"
+
+	usecase "github.com/duck8823/traceary/application/usecase"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
+	cli "github.com/duck8823/traceary/presentation/cli"
+)
+
+// TestRootCLI_DoctorBodyCodec_ReportsUnknownFromRealStore drives the shipped
+// doctor command against a temp SQLite store that mixes supported codecs,
+// a NULL (legacy identity) row, and two unknown values. The check must
+// warn on the unknowns only.
+func TestRootCLI_DoctorBodyCodec_ReportsUnknownFromRealStore(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("TRACEARY_LANG", "en")
+	setTracearyPathToCurrentExecutable(t)
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	ctx := context.Background()
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	sqldb, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = sqldb.Close() })
+	insert := func(id string, codec any) {
+		t.Helper()
+		if _, err := sqldb.ExecContext(ctx,
+			`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client, body_codec)
+			 VALUES (?, 'prompt', 'codex', 's1', 'w1', 'body', '2026-04-10T00:00:00Z', 'user_prompt_submit', 'hook', ?)`,
+			id, codec,
+		); err != nil {
+			t.Fatalf("insert %s error = %v", id, err)
+		}
+	}
+	insert("evt-identity", "identity")
+	insert("evt-zstd", "zstd")
+	insert("evt-null", nil)
+	insert("evt-gzip", "gzip")
+	insert("evt-zstd19", "zstd:19")
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeUC),
+		cli.WithBodyCodecChecker(sqliteinfra.NewBodyCodecChecker(db)),
+	).Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", dbPath, "--project-dir", t.TempDir(), "--json", "--warnings-ok"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("doctor Execute() error = %v\n%s", err, stdout.String())
+	}
+
+	var report struct {
+		Checks []struct {
+			Name    string `json:"name"`
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode doctor report: %v\noutput: %s", err, stdout.String())
+	}
+	var found bool
+	for _, check := range report.Checks {
+		if check.Name != "body-codec" {
+			continue
+		}
+		found = true
+		if diff := cmp.Diff("warn", check.Status); diff != "" {
+			t.Fatalf("body-codec status mismatch (-want +got):\n%s\nmessage=%q", diff, check.Message)
+		}
+		if !strings.Contains(check.Message, "gzip") || !strings.Contains(check.Message, "zstd:19") {
+			t.Fatalf("body-codec message %q missing unknown codecs", check.Message)
+		}
+		if strings.Contains(check.Message, "identity") || strings.Contains(check.Message, "evt-null") {
+			t.Fatalf("body-codec message %q leaked a supported or NULL row", check.Message)
+		}
+	}
+	if !found {
+		t.Fatalf("body-codec check missing from report: %s", stdout.String())
+	}
+}
+
+func TestRootCLI_DoctorBodyCodec_PassesOnSupportedOnly(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("TRACEARY_LANG", "en")
+	setTracearyPathToCurrentExecutable(t)
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	ctx := context.Background()
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeUC),
+		cli.WithBodyCodecChecker(sqliteinfra.NewBodyCodecChecker(db)),
+	).Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", dbPath, "--project-dir", t.TempDir(), "--json", "--warnings-ok"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("doctor Execute() error = %v\n%s", err, stdout.String())
+	}
+
+	var report struct {
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode doctor report: %v\noutput: %s", err, stdout.String())
+	}
+	for _, check := range report.Checks {
+		if check.Name == "body-codec" {
+			if diff := cmp.Diff("pass", check.Status); diff != "" {
+				t.Fatalf("body-codec status mismatch (-want +got):\n%s", diff)
+			}
+			return
+		}
+	}
+	t.Fatalf("body-codec check missing from report: %s", stdout.String())
+}

--- a/presentation/cli/doctor_body_codec_test.go
+++ b/presentation/cli/doctor_body_codec_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/duck8823/traceary/application"
+)
+
+type bodyCodecCheckerStub struct {
+	state application.BodyCodecState
+	err   error
+}
+
+func (s bodyCodecCheckerStub) CheckBodyCodec(context.Context) (application.BodyCodecState, error) {
+	return s.state, s.err
+}
+
+func TestInspectBodyCodecPassesOnCleanStore(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "en")
+	check := (&RootCLI{bodyCodecChecker: bodyCodecCheckerStub{}}).inspectBodyCodec(context.Background())
+	if diff := cmp.Diff(doctorStatusPass, check.Status); diff != "" {
+		t.Fatalf("status mismatch (-want +got):\n%s", diff)
+	}
+	want := "all events use a supported body codec"
+	if diff := cmp.Diff(want, check.Message); diff != "" {
+		t.Fatalf("message mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestInspectBodyCodecWarnsOnSingleUnknownCodec(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "en")
+	state := application.BodyCodecState{
+		UnknownRows: []application.BodyCodecRow{
+			{Codec: "zstd:19", Count: 1, SampleIDs: []string{"evt-abc"}},
+		},
+	}
+	check := (&RootCLI{bodyCodecChecker: bodyCodecCheckerStub{state: state}}).inspectBodyCodec(context.Background())
+	if diff := cmp.Diff(doctorStatusWarn, check.Status); diff != "" {
+		t.Fatalf("status mismatch (-want +got):\n%s", diff)
+	}
+	if check.Message == "" {
+		t.Fatal("expected non-empty message")
+	}
+	if check.Hint == "" {
+		t.Fatal("expected non-empty hint")
+	}
+}
+
+func TestInspectBodyCodecWarnsOnMultipleUnknownCodecs(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "en")
+	state := application.BodyCodecState{
+		UnknownRows: []application.BodyCodecRow{
+			{Codec: "gzip", Count: 3, SampleIDs: []string{"evt-1", "evt-2", "evt-3"}},
+			{Codec: "zstd:19", Count: 2, SampleIDs: []string{"evt-4", "evt-5"}},
+		},
+	}
+	check := (&RootCLI{bodyCodecChecker: bodyCodecCheckerStub{state: state}}).inspectBodyCodec(context.Background())
+	if diff := cmp.Diff(doctorStatusWarn, check.Status); diff != "" {
+		t.Fatalf("status mismatch (-want +got):\n%s", diff)
+	}
+	for _, codec := range []string{"gzip", "zstd:19"} {
+		if !strings.Contains(check.Message, codec) {
+			t.Fatalf("message %q missing codec %q", check.Message, codec)
+		}
+	}
+}
+
+func TestInspectBodyCodecSkipsWhenCheckerNil(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "en")
+	check := (&RootCLI{}).inspectBodyCodec(context.Background())
+	if diff := cmp.Diff(doctorStatusSkip, check.Status); diff != "" {
+		t.Fatalf("status mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestInspectBodyCodecWarnsOnError(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "en")
+	check := (&RootCLI{bodyCodecChecker: bodyCodecCheckerStub{err: errors.New("db error")}}).inspectBodyCodec(context.Background())
+	if diff := cmp.Diff(doctorStatusWarn, check.Status); diff != "" {
+		t.Fatalf("status mismatch (-want +got):\n%s", diff)
+	}
+}
+

--- a/presentation/cli/doctor_report.go
+++ b/presentation/cli/doctor_report.go
@@ -137,7 +137,7 @@ func buildDoctorSections(checks []doctorCheck) []doctorSection {
 
 func doctorSectionNameForCheck(name string) string {
 	switch {
-	case name == "db-path" || name == "db-write" || name == "search-projection-budget" || name == "stale-active-sessions" || name == "archive-retention" || strings.HasSuffix(name, "-capacity-retention") || name == "audit-reliability" || name == "content-event-reliability" || name == "sensitive-access-audit" || name == "retry-loops":
+	case name == "db-path" || name == "db-write" || name == "search-projection-budget" || name == "stale-active-sessions" || name == "archive-retention" || strings.HasSuffix(name, "-capacity-retention") || name == "audit-reliability" || name == "content-event-reliability" || name == "sensitive-access-audit" || name == "retry-loops" || name == "body-codec":
 		return "Database"
 	case name == "config" || name == "project-dir" || name == "version" || name == "path":
 		return "Environment"

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -45,6 +45,7 @@ type RootCLI struct {
 	operatorCostInspector      application.OperatorCostInspector
 	payloadCodecInspector      application.PayloadCodecInspector
 	attestationAnchorInspector application.AttestationAnchorInspector
+	bodyCodecChecker           application.BodyCodecChecker
 	searchProjection           *usecase.SearchProjectionUsecase
 	storeCompactionFactory     func(string) application.StoreCompactionUsecase
 	fileRetention              usecase.FileRetentionUsecase
@@ -243,6 +244,11 @@ func WithPayloadCodecInspector(inspector application.PayloadCodecInspector) Root
 // WithAttestationAnchorInspector injects the store-side attestation sidecar check.
 func WithAttestationAnchorInspector(inspector application.AttestationAnchorInspector) RootCLIOption {
 	return func(c *RootCLI) { c.attestationAnchorInspector = inspector }
+}
+
+// WithBodyCodecChecker injects the body_codec unknown-value scanner.
+func WithBodyCodecChecker(checker application.BodyCodecChecker) RootCLIOption {
+	return func(c *RootCLI) { c.bodyCodecChecker = checker }
 }
 
 // WithSearchProjection injects the explicit derived-projection lifecycle workflow.

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -135,6 +135,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "body-codec",
+      "status": "skip",
+      "severity": "PASS",
+      "section": "Database",
+      "message": "body codec checker is not configured",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "project-dir",
       "status": "pass",
       "severity": "PASS",
@@ -363,6 +373,16 @@
           "hint": "",
           "fix_command": "",
           "auto_fix_available": false
+        },
+        {
+          "name": "body-codec",
+          "status": "skip",
+          "severity": "PASS",
+          "section": "Database",
+          "message": "body codec checker is not configured",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
         }
       ]
     },
@@ -467,7 +487,7 @@
     }
   ],
   "summary": {
-    "pass": 21,
+    "pass": 22,
     "warn": 1,
     "fail": 0
   },


### PR DESCRIPTION
## Summary

`events.body_codec` has no CHECK constraint. An unsupported value commits and only fails later in `decodePayload`. This PR adds a read-only `body-codec` doctor check that lists codecs the running binary cannot decode, with per-codec counts and bounded sample IDs.

NULL `body_codec` is the pre-codec identity row and is not reported as unknown.

No schema change, no event rewrite, no trigger.

## Test plan

- [x] `go test ./infrastructure/sqlite/ ./presentation/cli/ -run 'BodyCodec|SupportedBodyCodecs|DoctorBodyCodec'`
  - real store: identity + zstd + NULL ignored; gzip / zstd:19 warned
  - shipped `doctor --json` on the same fixture
  - `SupportedBodyCodecs` matches `decodePayload`

Closes #1760

Leaves parent #1968 open.