### PR TITLE
fix: make Gemini managed hook generation refresh required after upgrade

### DIFF
--- a/docs/release/post-upgrade-plugins.ja.md
+++ b/docs/release/post-upgrade-plugins.ja.md
@@ -37,12 +37,29 @@ release 済みバイナリを更新するたびに、次を実行してくださ
 |---|---|---|---|---|
 | Claude Code | Claude Code 内で `claude plugins update <Traceary marketplace key>`。正確な key は `traceary doctor --client claude --json` の `FixCommand` を使います。 | 更新済み package を読み込むため、Claude Code を再起動するか新しい process を開始します。 | `traceary doctor --client claude --json` の `claude-plugin-version` が `pass`。 | Claude Code / Traceary package を意図的に導入していない場合だけ `--skip claude='理由'`。 |
 | Codex | `traceary -v` と一致する checkout の `plugins/traceary/` から再導入します。Codex plugin 文書も参照してください。 | `/plugins` で refresh / reinstall してから、新しい Codex session を開始します。 | `traceary doctor --client codex --json` の `codex-plugin-version` が `pass`。 | Codex / Traceary package を意図的に導入していない場合だけ `--skip codex='理由'`。 |
-| Gemini CLI（レガシー extension） | `gemini extensions update traceary`。 | Gemini CLI を再起動します。 | `traceary doctor --client gemini --json` の `gemini-plugin-version` が `pass`。 | レガシー extension を意図的に導入していない場合だけ `--skip gemini='理由'`。 |
+| Gemini CLI（レガシー extension） | `gemini extensions update traceary`、その後 managed hook generation を更新（下記参照）。 | Gemini CLI を再起動します。 | `traceary doctor --client gemini --json` の `gemini-plugin-version` と `gemini-config` がどちらも `pass`。 | レガシー extension を意図的に導入していない場合だけ `--skip gemini='理由'`。 |
 | Antigravity | 下記の安全な dual path 手順を行ってから、`agy plugin install integrations/antigravity-plugin`。 | Antigravity を終了して開き直すか、新しい CLI session を開始します。 | `traceary doctor --client antigravity --json` のすべての `antigravity-plugin-version` が `pass`。一方が pass で、もう一方が version のない不完全 twin なら、後者の `skip` は許可されます。 | Antigravity / Traceary package を意図的に導入していない場合だけ `--skip antigravity='理由'`。 |
 | Grok Build | `./scripts/install-grok-plugin.sh`。 | Grok Build を再起動するか、新しい session を開始します。 | `traceary doctor --client grok --json` の `grok-plugin` が `pass`。 | Grok Build / Traceary package を意図的に導入していない場合だけ `--skip grok='理由'`。 |
 | Kimi Code | `./scripts/install-kimi-plugin.sh`。installer は新しい generation を stage し、managed `traceary` symlink を atomic に切り替え、install record を保持します。 | `/plugins reload` を実行するか、**新しい Kimi session を開始**します。 | `traceary doctor --client kimi --json` の `kimi-plugin-version` と native `kimi-plugin` が健全。 | Kimi Code / Traceary package を意図的に導入していない場合だけ `--skip kimi='理由'`。 |
 
 doctor が正確な非対話コマンドを `FixCommand` に出す場合は、そちらを優先してください。ホスト CLI のフラグを推測で追加してはいけません。
+
+## Gemini managed hook generation の更新
+
+`gemini extensions update traceary` は `~/.gemini/extensions/traceary/` 内の extension パッケージを更新しますが、`~/.gemini/settings.json` 内にすでに存在する Traceary 管理の hook エントリは**書き換えません**。それらのエントリは古い hook generation によって書かれたものであり、timeout が古い値のまま残ることがあります（例: 現行の 10000 ms に対して 5000 ms）。Doctor はこれを `gemini-config=warn` として `installed=…ms desired=…ms` のドリフトメッセージと共に報告します。
+
+`gemini extensions update traceary` を実行したあと、次のコマンドを実行してください。
+
+```sh
+# プレビュー — Traceary 管理エントリへの変更内容だけを表示します。
+traceary doctor --fix --dry-run --client gemini --project-dir <dir>
+
+# 適用 — Traceary 管理エントリだけを書き換え、Traceary 以外の hook は保持します。
+traceary doctor --fix --client gemini --project-dir <dir>
+```
+
+dry-run の出力が Traceary 管理の hook エントリだけを変更する場合にのみ適用してください。
+適用後は `traceary doctor --client gemini --json` を再実行し、`gemini-plugin-version` と `gemini-config` の両方が `pass` になっていることを確認してください。
 
 ## Antigravity の stale dual path 修復
 

--- a/docs/release/post-upgrade-plugins.md
+++ b/docs/release/post-upgrade-plugins.md
@@ -37,12 +37,35 @@ After every released binary upgrade:
 |---|---|---|---|---|
 | Claude Code | In Claude Code, run `claude plugins update <Traceary marketplace key>`; `traceary doctor --client claude --json` prints the exact key in `FixCommand`. | Restart Claude Code (or start a new process) so the updated package is loaded. | `traceary doctor --client claude --json` → `claude-plugin-version` is `pass`. | `--skip claude='reason'` only when Claude Code/its Traceary package is intentionally not installed. |
 | Codex | Reinstall the plugin from `plugins/traceary/` in the checkout that matches `traceary -v`; see the Codex plugin documentation. | Use `/plugins` to refresh/reinstall the package, then start a new Codex session. | `traceary doctor --client codex --json` → `codex-plugin-version` is `pass`. | `--skip codex='reason'` only when Codex/its Traceary package is intentionally not installed. |
-| Gemini CLI (legacy extension) | `gemini extensions update traceary`. | Restart Gemini CLI. | `traceary doctor --client gemini --json` → `gemini-plugin-version` is `pass`. | `--skip gemini='reason'` only when the legacy extension is intentionally not installed. |
+| Gemini CLI (legacy extension) | `gemini extensions update traceary`, then refresh managed hook generation (see below). | Restart Gemini CLI. | `traceary doctor --client gemini --json` → `gemini-plugin-version` is `pass` and `gemini-config` is `pass`. | `--skip gemini='reason'` only when the legacy extension is intentionally not installed. |
 | Antigravity | Use the safe dual-path procedure below, then `agy plugin install integrations/antigravity-plugin`. | Quit and reopen Antigravity (or start a new CLI session). | `traceary doctor --client antigravity --json` → every `antigravity-plugin-version` is `pass`, or an incomplete twin is the documented `skip` while another copy passes. | `--skip antigravity='reason'` only when Antigravity/its Traceary package is intentionally not installed. |
 | Grok Build | `./scripts/install-grok-plugin.sh`. | Restart Grok Build or start a new session. | `traceary doctor --client grok --json` → `grok-plugin` is `pass`. | `--skip grok='reason'` only when Grok Build/its Traceary package is intentionally not installed. |
 | Kimi Code | `./scripts/install-kimi-plugin.sh`. The installer stages a new generation and atomically flips the managed `traceary` symlink while preserving the install record. | Run `/plugins reload` **or start a new Kimi session**. | `traceary doctor --client kimi --json` → `kimi-plugin-version` and native `kimi-plugin` are healthy. | `--skip kimi='reason'` only when Kimi Code/its Traceary package is intentionally not installed. |
 
 Prefer the `FixCommand` printed by doctor when it provides an exact non-interactive command. Do not invent host CLI flags.
+
+## Gemini managed hook generation refresh
+
+`gemini extensions update traceary` updates the extension package in
+`~/.gemini/extensions/traceary/` but does **not** rewrite the Traceary-managed
+hook entries already present in `~/.gemini/settings.json`. Those entries were
+written by an older hook generation and may have stale timeouts (for example,
+5000 ms instead of the current 10000 ms). Doctor reports this as
+`gemini-config=warn` with an `installed=…ms desired=…ms` drift message.
+
+After running `gemini extensions update traceary`, run:
+
+```sh
+# Preview — shows only what would change in Traceary-managed entries.
+traceary doctor --fix --dry-run --client gemini --project-dir <dir>
+
+# Apply — rewrites only Traceary-managed entries; non-Traceary hooks are preserved.
+traceary doctor --fix --client gemini --project-dir <dir>
+```
+
+Only apply if the dry-run output touches Traceary-managed hook entries only.
+After applying, rerun `traceary doctor --client gemini --json` and confirm
+both `gemini-plugin-version` and `gemini-config` are `pass`.
 
 ## Antigravity stale dual-path remediation
 

--- a/presentation/cli/doctor_managed_generation.go
+++ b/presentation/cli/doctor_managed_generation.go
@@ -104,18 +104,22 @@ func (c *RootCLI) attachManagedGenerationCheck(ctx context.Context, check doctor
 		return check
 	}
 	dryRunCommand := fmt.Sprintf("traceary doctor --fix --dry-run --client %s --project-dir %s", client, shellQuote(projectDir))
+	applyCommand := fmt.Sprintf("traceary doctor --fix --client %s --project-dir %s", client, shellQuote(projectDir))
 	check.Status = doctorStatusWarn
 	check.Message = localizef(
-		"%s config has Traceary-managed hooks but their generation is stale (%s). Host budgets or command payloads lag the installed Traceary version; prompt/transcript coverage can silently drop: %s",
-		"%s config に Traceary 管理 hook はありますが generation が古いです (%s)。host budget や command payload がインストール済み Traceary より遅れ、prompt/transcript coverage が黙って欠けることがあります: %s",
+		"%s config has Traceary-managed hooks but the hook generation is stale (%s); the %s package may be current but managed entries in %s were written by an older generation. Run `traceary doctor --fix --client %s` to refresh",
+		"%s config に Traceary 管理 hook はありますが hook の generation が古いです (%s)。%s パッケージは最新でも %s の managed エントリは古い generation で書かれています。`traceary doctor --fix --client %s` で更新してください",
 		client,
 		strings.Join(reasons, "; "),
+		client,
 		outputPath,
+		client,
 	)
 	check.Hint = localizef(
-		"preview the non-destructive refresh with `%s`; it rewrites only Traceary-managed entries (timeouts, commands) and preserves non-Traceary hooks",
-		"`%s` で非破壊 refresh をプレビューしてください。Traceary 管理エントリ（timeout / command）だけを更新し、Traceary 以外の hook は保持します",
+		"auto-fix is available: preview with `%s`, then apply with `%s`; rewrites only Traceary-managed entries (timeouts, commands) and preserves non-Traceary hooks",
+		"自動修復が利用可能: `%s` でプレビューし、`%s` で適用してください。Traceary 管理エントリ（timeout / command）だけを更新し、Traceary 以外の hook は保持します",
 		dryRunCommand,
+		applyCommand,
 	)
 	check.FixCommand = dryRunCommand
 	check.AutoFixAvailable = true

--- a/presentation/cli/doctor_managed_generation_test.go
+++ b/presentation/cli/doctor_managed_generation_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -109,5 +110,186 @@ func TestAttachManagedGenerationCheck_EndToEnd(t *testing.T) {
 	// Sanity: path lives under the project.
 	if !strings.HasPrefix(path, projectDir) && !strings.Contains(path, filepath.Base(projectDir)) {
 		t.Logf("install path = %s (projectDir = %s)", path, projectDir)
+	}
+}
+
+// TestGeminiConfig_StaleGeneration_ReportsAutoFix verifies that when installed
+// hook timeouts lag the current generation (5000 vs 10000) the check is WARN,
+// message names both the installed and desired values, and auto-fix is wired.
+func TestGeminiConfig_StaleGeneration_ReportsAutoFix(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	root := NewRootCLI(
+		WithHooksOrchestrator(filesystem.NewHooksOrchestrator(map[string]application.HooksClientHandler{
+			"gemini": filesystem.NewGeminiHooksHandler(),
+		})),
+		WithHooksInspector(filesystem.NewHooksInspector()),
+	)
+
+	path, err := root.hooksOrchestrator.Install(context.Background(), "gemini", "traceary", projectDir, types.None[string](), true)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := strings.ReplaceAll(string(content), "10000", "5000")
+	if stale == string(content) {
+		t.Fatal("fixture expected timeout 10000 in generated gemini hooks")
+	}
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := root.inspectDoctorConfigFile(context.Background(), "gemini", path, projectDir)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status = %s, want warn", check.Status)
+	}
+	if !strings.Contains(check.Message, "5000ms") || !strings.Contains(check.Message, "10000ms") {
+		t.Errorf("message should contain both installed=5000ms and desired=10000ms, got: %q", check.Message)
+	}
+	if !strings.Contains(check.Message, "traceary doctor --fix --client gemini") {
+		t.Errorf("message should name the fix command, got: %q", check.Message)
+	}
+	if !strings.Contains(check.Hint, "auto-fix") {
+		t.Errorf("hint should mention auto-fix, got: %q", check.Hint)
+	}
+	if !strings.Contains(check.FixCommand, "--dry-run") {
+		t.Errorf("FixCommand should be the dry-run preview, got: %q", check.FixCommand)
+	}
+	if !check.AutoFixAvailable {
+		t.Error("AutoFixAvailable must be true for stale generation")
+	}
+	if check.FixFunc == nil {
+		t.Error("FixFunc must be non-nil for stale generation")
+	}
+}
+
+// TestGeminiConfig_FixApply_UpdatesOnlyTracearyEntries seeds settings.json
+// with stale Traceary timeouts plus a non-Traceary top-level key, then:
+//   - verifies dry-run leaves the file unchanged
+//   - verifies apply restores 10000ms timeouts
+//   - verifies the non-Traceary key is preserved byte-for-byte
+//   - verifies a subsequent doctor inspect returns pass
+func TestGeminiConfig_FixApply_UpdatesOnlyTracearyEntries(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	root := NewRootCLI(
+		WithHooksOrchestrator(filesystem.NewHooksOrchestrator(map[string]application.HooksClientHandler{
+			"gemini": filesystem.NewGeminiHooksHandler(),
+		})),
+		WithHooksInspector(filesystem.NewHooksInspector()),
+	)
+
+	path, err := root.hooksOrchestrator.Install(context.Background(), "gemini", "traceary", projectDir, types.None[string](), true)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Inject a non-Traceary top-level key alongside the generated hooks.
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(content, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	doc["custom_user_setting"] = json.RawMessage(`"must-survive"`)
+	mixed, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Stale the Traceary-managed timeouts.
+	stale := strings.ReplaceAll(string(mixed), "10000", "5000")
+	if stale == string(mixed) {
+		t.Fatal("fixture expected timeout 10000 in generated gemini hooks")
+	}
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := root.inspectDoctorConfigFile(context.Background(), "gemini", path, projectDir)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status = %s, want warn before fix", check.Status)
+	}
+
+	// Dry-run must not modify the file.
+	beforeFix, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := check.FixFunc(context.Background(), true); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	afterDry, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(beforeFix) != string(afterDry) {
+		t.Error("dry-run must not modify the file")
+	}
+
+	// Apply must restore 10000ms timeouts.
+	if _, err := check.FixFunc(context.Background(), false); err != nil {
+		t.Fatalf("fix apply: %v", err)
+	}
+	afterFix, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(afterFix), "10000") {
+		t.Errorf("after fix should contain 10000ms timeout, got:\n%s", afterFix)
+	}
+
+	// Non-Traceary key must survive.
+	var afterDoc map[string]json.RawMessage
+	if err := json.Unmarshal(afterFix, &afterDoc); err != nil {
+		t.Fatalf("unmarshal after fix: %v", err)
+	}
+	if string(afterDoc["custom_user_setting"]) != `"must-survive"` {
+		t.Errorf("non-Traceary key was not preserved; got %s", afterDoc["custom_user_setting"])
+	}
+
+	// Re-inspect must pass.
+	pass := root.inspectDoctorConfigFile(context.Background(), "gemini", path, projectDir)
+	if pass.Status != doctorStatusPass {
+		t.Fatalf("after fix status = %s, want pass", pass.Status)
+	}
+}
+
+// TestGeminiConfig_DocPresence asserts that both language variants of the
+// post-upgrade-plugins docs include the required managed hook generation
+// refresh step for the Gemini client.
+func TestGeminiConfig_DocPresence(t *testing.T) {
+	files := []string{
+		"../../docs/release/post-upgrade-plugins.md",
+		"../../docs/release/post-upgrade-plugins.ja.md",
+	}
+	required := []string{
+		"traceary doctor --fix",
+		"--client gemini",
+	}
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, want := range required {
+			if !strings.Contains(string(content), want) {
+				t.Errorf("%s: missing required string %q", f, want)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`gemini extensions update` refreshes the package but not managed hook generation in `.gemini/settings.json`, so 0.39.0 stays at 5s while doctor wants 10s. This PR:

- Makes the doctor warn name the installed vs desired timeouts and the exact `traceary doctor --fix --client gemini` command
- Adds a required post-upgrade step in `docs/release/post-upgrade-plugins.md` (+ `.ja`)

## Test plan

- [x] `go test ./presentation/cli/ -run 'ManagedGeneration|Gemini|DoctorManaged'`
  - stale generation reports AutoFix
  - `--fix` updates only Traceary-managed entries

Closes #1971

Leaves parent #1968 open.