### PR TITLE
fix: diagnose and once-retry rehearsal WAL autocheckpoint disable

### DIFF
--- a/infrastructure/sqlite/payload_rehearsal_store.go
+++ b/infrastructure/sqlite/payload_rehearsal_store.go
@@ -18,6 +18,53 @@ import (
 
 type rehearsalMutationGuard func() error
 
+// rehearsalAutocheckpointStage identifies which step of the disable+readback
+// sequence produced a typed error so callers can distinguish exec from read
+// from a leftover non-zero value.
+type rehearsalAutocheckpointStage string
+
+const (
+	rehearsalAutocheckpointStageExec  rehearsalAutocheckpointStage = "exec"
+	rehearsalAutocheckpointStageRead  rehearsalAutocheckpointStage = "read"
+	rehearsalAutocheckpointStageValue rehearsalAutocheckpointStage = "value"
+)
+
+// rehearsalAutocheckpointError is returned by disableRehearsalAutocheckpoint.
+// Stage distinguishes exec/read failures (transient, retryable) from a
+// non-zero readback value (structural, not retried).
+type rehearsalAutocheckpointError struct {
+	Stage    rehearsalAutocheckpointStage
+	Observed int
+	Cause    error
+}
+
+func (e *rehearsalAutocheckpointError) Error() string {
+	if e.Stage == rehearsalAutocheckpointStageValue {
+		return fmt.Sprintf("rehearsal WAL autocheckpoint is %d after PRAGMA wal_autocheckpoint=0", e.Observed)
+	}
+	return fmt.Sprintf("cannot disable rehearsal WAL autocheckpoint (%s): %v", e.Stage, e.Cause)
+}
+
+func (e *rehearsalAutocheckpointError) Unwrap() error { return e.Cause }
+
+// disableRehearsalAutocheckpoint issues PRAGMA wal_autocheckpoint=0 then reads
+// it back. It returns a typed *rehearsalAutocheckpointError on any failure so
+// run can distinguish exec/read failures (retryable) from a non-zero value
+// (not retried).
+func disableRehearsalAutocheckpoint(ctx context.Context, conn *sql.Conn) (int, error) {
+	if _, err := conn.ExecContext(ctx, `PRAGMA wal_autocheckpoint=0`); err != nil {
+		return 0, &rehearsalAutocheckpointError{Stage: rehearsalAutocheckpointStageExec, Cause: err}
+	}
+	var observed int
+	if err := conn.QueryRowContext(ctx, `PRAGMA wal_autocheckpoint`).Scan(&observed); err != nil {
+		return 0, &rehearsalAutocheckpointError{Stage: rehearsalAutocheckpointStageRead, Cause: err}
+	}
+	if observed != 0 {
+		return observed, &rehearsalAutocheckpointError{Stage: rehearsalAutocheckpointStageValue, Observed: observed}
+	}
+	return 0, nil
+}
+
 // walBudgetedMutationSession serializes the schema proof, WAL reservation and
 // mutation under one BEGIN IMMEDIATE lock.  Keeping these operations on a
 // dedicated connection closes the check/use window that exists when a WAL
@@ -33,6 +80,12 @@ type walBudgetedMutationSession struct {
 	// mutationElapsed, when configured for schema migration, measures exactly
 	// BEGIN IMMEDIATE acquisition through COMMIT completion.
 	mutationElapsed *time.Duration
+	// acquireConn, if non-nil, overrides s.db.Conn; injected in tests to count
+	// how many connections are opened.
+	acquireConn func(context.Context) (*sql.Conn, error)
+	// readAutocheckpoint, if non-nil, overrides disableRehearsalAutocheckpoint;
+	// injected in tests to simulate exec/read/value failures.
+	readAutocheckpoint func(context.Context, *sql.Conn) (int, error)
 }
 
 //nolint:wrapcheck // callers add the rehearsal operation classification.
@@ -63,19 +116,40 @@ func (s walBudgetedMutationSession) run(ctx context.Context, reservedFrames int6
 	if reservedFrames <= 0 || s.peak == nil || strings.TrimSpace(s.expectedSchemaSHA) == "" || s.lockLimit <= 0 {
 		return ErrUnsafeRehearsalTarget
 	}
-	conn, err := s.db.Conn(ctx)
+	acquireConn := s.acquireConn
+	if acquireConn == nil {
+		acquireConn = s.db.Conn
+	}
+	disableFn := s.readAutocheckpoint
+	if disableFn == nil {
+		disableFn = disableRehearsalAutocheckpoint
+	}
+
+	started := time.Now()
+
+	conn, err := acquireConn(ctx)
 	if err != nil {
 		return err
 	}
+	_, disableErr := disableFn(ctx, conn)
+	if disableErr != nil {
+		var cpErr *rehearsalAutocheckpointError
+		if errors.As(disableErr, &cpErr) && cpErr.Stage != rehearsalAutocheckpointStageValue {
+			// exec or read failure: close this connection and try once more with a
+			// fresh one. A non-zero value on the retry still aborts.
+			_ = conn.Close()
+			conn, err = acquireConn(ctx)
+			if err != nil {
+				return err
+			}
+			_, disableErr = disableFn(ctx, conn)
+		}
+	}
+	if disableErr != nil {
+		_ = conn.Close()
+		return disableErr
+	}
 	defer func() { _ = conn.Close() }()
-	started := time.Now()
-	if _, err = conn.ExecContext(ctx, `PRAGMA wal_autocheckpoint=0`); err != nil {
-		return err
-	}
-	var autoCheckpoint int
-	if err = conn.QueryRowContext(ctx, `PRAGMA wal_autocheckpoint`).Scan(&autoCheckpoint); err != nil || autoCheckpoint != 0 {
-		return errors.New("cannot disable rehearsal WAL autocheckpoint")
-	}
 	mutationStarted := time.Now()
 	if _, err = conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
 		return err

--- a/infrastructure/sqlite/payload_rehearsal_store_autocheckpoint_internal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_store_autocheckpoint_internal_test.go
@@ -1,0 +1,155 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	sqliteschema "github.com/duck8823/traceary/schema/sqlite"
+)
+
+// newAutocheckpointTestSession creates a minimal walBudgetedMutationSession
+// backed by a real WAL-mode SQLite database. The session is valid for the
+// guard check so tests can exercise the autocheckpoint seam directly.
+func newAutocheckpointTestSession(t *testing.T) walBudgetedMutationSession {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	migrations, err := sqliteschema.Migrations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = NewStoreManagementDatasource(NewDatabase(path, migrations)).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", writableRehearsalDSN(path, time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	fingerprint, err := rehearsalSchemaFingerprint(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peak := int64(0)
+	return walBudgetedMutationSession{
+		db:                db,
+		path:              path,
+		expectedSchemaSHA: fingerprint,
+		frameBytes:        4096,
+		maximum:           1 << 20, // 1 MiB — well above any test WAL
+		peak:              &peak,
+		lockLimit:         time.Second,
+	}
+}
+
+func TestWALBudgetedMutationSessionAutocheckpointSeams(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("happy path one conn", func(t *testing.T) {
+		session := newAutocheckpointTestSession(t)
+		connCount := 0
+		session.acquireConn = func(c context.Context) (*sql.Conn, error) {
+			connCount++
+			return session.db.Conn(c)
+		}
+		// readAutocheckpoint left nil → uses real disableRehearsalAutocheckpoint
+
+		err := session.run(ctx, 1, func(_ *sql.Conn) error { return nil })
+		if err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+		if connCount != 1 {
+			t.Fatalf("conn count = %d, want 1", connCount)
+		}
+	})
+
+	t.Run("transient read retries on fresh conn (conn=2)", func(t *testing.T) {
+		session := newAutocheckpointTestSession(t)
+		connCount := 0
+		session.acquireConn = func(c context.Context) (*sql.Conn, error) {
+			connCount++
+			return session.db.Conn(c)
+		}
+		call := 0
+		readErr := errors.New("simulated read error")
+		session.readAutocheckpoint = func(_ context.Context, _ *sql.Conn) (int, error) {
+			call++
+			if call == 1 {
+				return 0, &rehearsalAutocheckpointError{Stage: rehearsalAutocheckpointStageRead, Cause: readErr}
+			}
+			return 0, nil // second call succeeds
+		}
+
+		err := session.run(ctx, 1, func(_ *sql.Conn) error { return nil })
+		if err != nil {
+			t.Fatalf("run error after retry: %v", err)
+		}
+		if connCount != 2 {
+			t.Fatalf("conn count = %d, want 2", connCount)
+		}
+	})
+
+	t.Run("persistent non-zero aborts with value in message", func(t *testing.T) {
+		session := newAutocheckpointTestSession(t)
+		const observed = 1000
+		session.readAutocheckpoint = func(_ context.Context, _ *sql.Conn) (int, error) {
+			return observed, &rehearsalAutocheckpointError{Stage: rehearsalAutocheckpointStageValue, Observed: observed}
+		}
+
+		err := session.run(ctx, 1, func(_ *sql.Conn) error { return nil })
+		if err == nil {
+			t.Fatal("want error, got nil")
+		}
+		var cpErr *rehearsalAutocheckpointError
+		if !errors.As(err, &cpErr) {
+			t.Fatalf("want *rehearsalAutocheckpointError, got %T: %v", err, err)
+		}
+		if cpErr.Stage != rehearsalAutocheckpointStageValue {
+			t.Fatalf("stage = %q, want %q", cpErr.Stage, rehearsalAutocheckpointStageValue)
+		}
+		if !strings.Contains(err.Error(), fmt.Sprint(observed)) {
+			t.Fatalf("error message %q does not contain observed value %d", err.Error(), observed)
+		}
+	})
+
+	t.Run("exec failure twice wraps driver error", func(t *testing.T) {
+		session := newAutocheckpointTestSession(t)
+		driverErr := errors.New("simulated driver error")
+		call := 0
+		session.readAutocheckpoint = func(_ context.Context, _ *sql.Conn) (int, error) {
+			call++
+			return 0, &rehearsalAutocheckpointError{Stage: rehearsalAutocheckpointStageExec, Cause: driverErr}
+		}
+
+		err := session.run(ctx, 1, func(_ *sql.Conn) error { return nil })
+		if err == nil {
+			t.Fatal("want error, got nil")
+		}
+		if call != 2 {
+			t.Fatalf("readAutocheckpoint called %d times, want 2", call)
+		}
+		// must wrap the original driver error
+		if !errors.Is(err, driverErr) {
+			t.Fatalf("error does not wrap driver error: %v", err)
+		}
+		// must be distinguishable from the value case
+		var cpErr *rehearsalAutocheckpointError
+		if !errors.As(err, &cpErr) {
+			t.Fatalf("want *rehearsalAutocheckpointError, got %T: %v", err, err)
+		}
+		if cpErr.Stage == rehearsalAutocheckpointStageValue {
+			t.Fatalf("stage must not be %q for an exec failure", rehearsalAutocheckpointStageValue)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The rehearsal WAL autocheckpoint guard collapsed `err != nil || value != 0` into one opaque error. This PR:

- Extracts `disableRehearsalAutocheckpoint` with a typed `{stage: exec|read|value, observed, cause}` error
- Retries once on a fresh connection for exec/read failures
- Still aborts if the value is non-zero after the retry

The guard is not weakened. No `store gc` restore.

## Test plan

- [x] `go test ./infrastructure/sqlite/ -run 'Autocheckpoint|RehearsalWAL|disableRehearsal'`
  - transient read retries (fresh conn)
  - persistent non-zero still aborts with the observed value
  - exec failure is distinguishable from the value case

Closes #1780

Leaves parent #1968 open.