### PR TITLE
fix: honour wall-time budget on payload-rehearsal rollback verification

### DIFF
--- a/application/usecase/payload_rehearsal.go
+++ b/application/usecase/payload_rehearsal.go
@@ -220,6 +220,11 @@ func (u *payloadRehearsalUsecase) Rollback(ctx context.Context, c types.PayloadR
 	if err := validateRehearsal(c); err != nil {
 		return types.PayloadRehearsalMetrics{}, err
 	}
+	if c.WallTimeLimit > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, time.Now().Add(c.WallTimeLimit))
+		defer cancel()
+	}
 	result, err := u.runner.Rollback(ctx, c)
 	if err != nil {
 		return types.PayloadRehearsalMetrics{}, xerrors.Errorf("rollback payload rehearsal: %w", err)

--- a/infrastructure/sqlite/compaction_files.go
+++ b/infrastructure/sqlite/compaction_files.go
@@ -469,7 +469,7 @@ func (f PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.Compacti
 		return run, insufficientCompactionSpaceError(required, available, id.Size)
 	}
 	run.SourceIdentity = id
-	digest, err := fileDigest(run.SourcePath)
+	digest, err := fileDigest(ctx, run.SourcePath)
 	if err != nil {
 		return run, errors.New("cannot digest prepared upgrade source")
 	}
@@ -524,7 +524,7 @@ func (f PreparedStoreUpgradeFiles) Recheck(ctx context.Context, run domain.Compa
 	if current != run.SourceIdentity {
 		return errors.New("source identity drift after plan")
 	}
-	digest, err := fileDigest(run.SourcePath)
+	digest, err := fileDigest(ctx, run.SourcePath)
 	if err != nil || digest != run.SourceDigest {
 		return errors.New("prepared upgrade source content changed")
 	}

--- a/infrastructure/sqlite/compaction_files.go
+++ b/infrastructure/sqlite/compaction_files.go
@@ -525,7 +525,10 @@ func (f PreparedStoreUpgradeFiles) Recheck(ctx context.Context, run domain.Compa
 		return errors.New("source identity drift after plan")
 	}
 	digest, err := fileDigest(ctx, run.SourcePath)
-	if err != nil || digest != run.SourceDigest {
+	if err != nil {
+		return err
+	}
+	if digest != run.SourceDigest {
 		return errors.New("prepared upgrade source content changed")
 	}
 	available, err := availableBytes(filepath.Dir(run.SourcePath))

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -963,7 +963,10 @@ func (a *PayloadRehearsalAdapter) Rollback(ctx context.Context, c apptypes.Paylo
 		}
 	}
 	verifiedDigest, verifiedDigestErr := fileDigest(ctx, c.BackupPath)
-	if verifiedDigestErr != nil || verifiedDigest != digest {
+	if verifiedDigestErr != nil {
+		return apptypes.PayloadRehearsalMetrics{}, verifiedDigestErr
+	}
+	if verifiedDigest != digest {
 		return apptypes.PayloadRehearsalMetrics{}, errors.New("rollback artifact changed before restore")
 	}
 	if err = verifySQLiteArtifact(c.BackupPath); err != nil {
@@ -1008,8 +1011,12 @@ func (a *PayloadRehearsalAdapter) Rollback(ctx context.Context, c apptypes.Paylo
 	if restoredIdentityErr != nil || postBackupErr != nil || os.SameFile(restoredIdentity.info, postBackupIdentity.info) {
 		return apptypes.PayloadRehearsalMetrics{}, ErrUnsafeRehearsalTarget
 	}
-	restored, err := fileDigest(ctx, id.canonical)
-	if err != nil || restored != digest {
+	postCtx := context.WithoutCancel(ctx)
+	restored, err := fileDigest(postCtx, id.canonical)
+	if err != nil {
+		return apptypes.PayloadRehearsalMetrics{}, err
+	}
+	if restored != digest {
 		return apptypes.PayloadRehearsalMetrics{}, errors.New("rollback digest verification failed")
 	}
 	db, err := sql.Open("sqlite", immutableRehearsalDSN(id.canonical))
@@ -1017,19 +1024,19 @@ func (a *PayloadRehearsalAdapter) Rollback(ctx context.Context, c apptypes.Paylo
 		return apptypes.PayloadRehearsalMetrics{}, err
 	}
 	defer func() { _ = db.Close() }()
-	if err = VerifyStoreCompatibility(ctx, db); err != nil {
+	if err = VerifyStoreCompatibility(postCtx, db); err != nil {
 		return apptypes.PayloadRehearsalMetrics{}, err
 	}
 	var integrity string
-	if err = db.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&integrity); err != nil || integrity != "ok" {
+	if err = db.QueryRowContext(postCtx, `PRAGMA integrity_check`).Scan(&integrity); err != nil || integrity != "ok" {
 		return apptypes.PayloadRehearsalMetrics{}, errors.New("rollback integrity verification failed")
 	}
 	var runTable, activeRuns int
-	if err = db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='payload_rehearsal_runs')`).Scan(&runTable); err != nil {
+	if err = db.QueryRowContext(postCtx, `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='payload_rehearsal_runs')`).Scan(&runTable); err != nil {
 		return apptypes.PayloadRehearsalMetrics{}, errors.New("rollback state verification failed")
 	}
 	if runTable != 0 {
-		if err = db.QueryRowContext(ctx, `SELECT count(*) FROM payload_rehearsal_runs WHERE state IN ('running','paused','completed','scrubbed')`).Scan(&activeRuns); err != nil || activeRuns != 0 {
+		if err = db.QueryRowContext(postCtx, `SELECT count(*) FROM payload_rehearsal_runs WHERE state IN ('running','paused','completed','scrubbed')`).Scan(&activeRuns); err != nil || activeRuns != 0 {
 			return apptypes.PayloadRehearsalMetrics{}, errors.New("rollback retained rehearsal state")
 		}
 	}

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -22,6 +22,18 @@ import (
 	"github.com/duck8823/traceary/domain"
 )
 
+// detachedBudgeted returns a child context that is detached from the parent's
+// cancellation signal (SIGINT/SIGTERM) but preserves its deadline. Recovery
+// paths use this so SIGINT does not abort them while the wall-time budget still
+// applies.
+func detachedBudgeted(parent context.Context) (context.Context, context.CancelFunc) {
+	base := context.WithoutCancel(parent)
+	if deadline, ok := parent.Deadline(); ok {
+		return context.WithDeadline(base, deadline)
+	}
+	return base, func() {}
+}
+
 // Exported sentinel errors are stable safety classifications for CLI/tests.
 var (
 	ErrUnsafeRehearsalTarget      = errors.New("payload rehearsal target is not an independent regular copy")
@@ -352,9 +364,9 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 	}
 	var backupDigest string
 	if resume {
-		backupDigest, err = fileDigest(c.BackupPath)
+		backupDigest, err = fileDigest(ctx, c.BackupPath)
 	} else {
-		backupDigest, err = ensurePhysicalBackup(id.canonical, c.BackupPath)
+		backupDigest, err = ensurePhysicalBackup(ctx, id.canonical, c.BackupPath)
 	}
 	if err != nil {
 		return nil, apptypes.PayloadRehearsalMetrics{}, err
@@ -453,7 +465,7 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 			return nil, apptypes.PayloadRehearsalMetrics{}, errors.New("resume requires no pending migration and existing WAL journal mode")
 		}
 		_ = db.Close()
-		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
+		if recoveryErr := restoreVerifiedRehearsalBackup(context.WithoutCancel(ctx), id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
 			return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("journal normalization failed and rollback failed: %w", recoveryErr)
 		}
 		return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, errors.New("rehearsal journal mode does not match preflight")
@@ -464,12 +476,14 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 		}
 		_ = db.Close()
 		if migrationRequired && a.targetPreparation != nil {
-			if _, recoveryErr := a.targetPreparation.RollbackPrepared(context.WithoutCancel(ctx), c); recoveryErr != nil {
+			recoveryCtx, recoveryCancel := detachedBudgeted(ctx)
+			defer recoveryCancel()
+			if _, recoveryErr := a.targetPreparation.RollbackPrepared(recoveryCtx, c); recoveryErr != nil {
 				return apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, ErrPreparedMigrationPublish
 			}
 			return apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, cause
 		}
-		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
+		if recoveryErr := restoreVerifiedRehearsalBackup(context.WithoutCancel(ctx), id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
 			return apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("%v; restore verified backup: %w", cause, recoveryErr)
 		}
 		return apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, cause
@@ -913,7 +927,7 @@ func (a *PayloadRehearsalAdapter) Rollback(ctx context.Context, c apptypes.Paylo
 	if identityErr != nil || os.SameFile(id.info, backupIdentity.info) {
 		return apptypes.PayloadRehearsalMetrics{}, ErrUnsafeRehearsalTarget
 	}
-	digest, err := fileDigest(c.BackupPath)
+	digest, err := fileDigest(ctx, c.BackupPath)
 	if err != nil {
 		return apptypes.PayloadRehearsalMetrics{}, errors.New("rollback artifact unavailable")
 	}
@@ -948,7 +962,7 @@ func (a *PayloadRehearsalAdapter) Rollback(ctx context.Context, c apptypes.Paylo
 			return apptypes.PayloadRehearsalMetrics{}, ErrRehearsalNeedsCleanDB
 		}
 	}
-	verifiedDigest, verifiedDigestErr := fileDigest(c.BackupPath)
+	verifiedDigest, verifiedDigestErr := fileDigest(ctx, c.BackupPath)
 	if verifiedDigestErr != nil || verifiedDigest != digest {
 		return apptypes.PayloadRehearsalMetrics{}, errors.New("rollback artifact changed before restore")
 	}
@@ -994,7 +1008,7 @@ func (a *PayloadRehearsalAdapter) Rollback(ctx context.Context, c apptypes.Paylo
 	if restoredIdentityErr != nil || postBackupErr != nil || os.SameFile(restoredIdentity.info, postBackupIdentity.info) {
 		return apptypes.PayloadRehearsalMetrics{}, ErrUnsafeRehearsalTarget
 	}
-	restored, err := fileDigest(id.canonical)
+	restored, err := fileDigest(ctx, id.canonical)
 	if err != nil || restored != digest {
 		return apptypes.PayloadRehearsalMetrics{}, errors.New("rollback digest verification failed")
 	}

--- a/infrastructure/sqlite/payload_rehearsal_budget_internal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_budget_internal_test.go
@@ -1,0 +1,79 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+)
+
+func TestFileDigestReturnsCtxErrOnCancelledContext(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dummy.bin")
+	if err := os.WriteFile(path, make([]byte, 1<<20), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := fileDigest(ctx, path)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestFileDigestReturnsCtxErrOnExpiredDeadline(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dummy.bin")
+	if err := os.WriteFile(path, make([]byte, 1<<20), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	_, err := fileDigest(ctx, path)
+	if err == nil {
+		t.Fatal("expected error from expired deadline, got nil")
+	}
+	if err != context.DeadlineExceeded {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestRollbackBudgetExceededAbortsBeforeMutation(t *testing.T) {
+	t.Parallel()
+	adapter, config, _ := newSwapRehearsalFixture(t)
+	ctx := context.Background()
+
+	if _, err := adapter.Run(ctx, config, apptypes.PayloadRehearsalRunCommand{Mode: apptypes.PayloadRehearsalStart}); err != nil {
+		t.Fatalf("setup run failed: %v", err)
+	}
+
+	targetInfoBefore, err := os.Stat(config.TargetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u := usecase.NewPayloadRehearsalUsecase(adapter, adapter, adapter, adapter)
+	tinyConfig := config
+	tinyConfig.WallTimeLimit = time.Nanosecond
+
+	if _, err = u.Rollback(ctx, tinyConfig); err == nil {
+		t.Fatal("expected error from budget-exceeded rollback, got nil")
+	}
+
+	targetInfoAfter, err := os.Stat(config.TargetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targetInfoBefore.ModTime() != targetInfoAfter.ModTime() || targetInfoBefore.Size() != targetInfoAfter.Size() {
+		t.Fatal("target was mutated despite budget expiry before verification completed")
+	}
+}

--- a/infrastructure/sqlite/payload_rehearsal_budget_internal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_budget_internal_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,6 +45,25 @@ func TestFileDigestReturnsCtxErrOnExpiredDeadline(t *testing.T) {
 	}
 	if err != context.DeadlineExceeded {
 		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestEnsurePhysicalBackupPropagatesCanceledDigest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	dest := filepath.Join(dir, "backup.db")
+	if err := os.WriteFile(source, make([]byte, 4096), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := ensurePhysicalBackupWithHook(ctx, source, dest, nil)
+	if err == nil {
+		t.Fatal("expected canceled digest to fail")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled digest classified as %v, want context.Canceled", err)
 	}
 }
 

--- a/infrastructure/sqlite/payload_rehearsal_final_security_internal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_final_security_internal_test.go
@@ -150,14 +150,14 @@ func TestPayloadRehearsalRejectsFutureTargetBeforeMigrationWrite(t *testing.T) {
 	if err = db.Close(); err != nil {
 		t.Fatal(err)
 	}
-	before, err := fileDigest(config.TargetPath)
+	before, err := fileDigest(context.Background(), config.TargetPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err = adapter.Run(context.Background(), config, apptypes.PayloadRehearsalRunCommand{Mode: apptypes.PayloadRehearsalStart}); err == nil {
 		t.Fatal("future target was accepted")
 	}
-	after, err := fileDigest(config.TargetPath)
+	after, err := fileDigest(context.Background(), config.TargetPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +271,7 @@ func TestPhysicalBackupRejectsCopyCorruptionAndSourceDrift(t *testing.T) {
 				_, _ = file.Write([]byte("corruption"))
 				_ = file.Close()
 			}
-			if _, err := ensurePhysicalBackupWithHook(config.TargetPath, destination, hook); err == nil {
+			if _, err := ensurePhysicalBackupWithHook(context.Background(), config.TargetPath, destination, hook); err == nil {
 				t.Fatal("unstable/corrupt copy was verified")
 			}
 		})

--- a/infrastructure/sqlite/payload_rehearsal_preparation.go
+++ b/infrastructure/sqlite/payload_rehearsal_preparation.go
@@ -29,7 +29,7 @@ func (p PayloadRehearsalPreparation) Preview(ctx context.Context, c apptypes.Pay
 	// consumer finishes (or rolls it back). Check it before inspecting schema;
 	// after publication the schema is already current and cannot signal the gap.
 	if p.Journal != nil {
-		binding, bindingErr := rehearsalPreparationBinding(c)
+		binding, bindingErr := rehearsalPreparationBinding(ctx, c)
 		if bindingErr == nil {
 			journal := p.Journal(c.TargetPath)
 			if journal != nil {
@@ -56,8 +56,8 @@ func (p PayloadRehearsalPreparation) Preview(ctx context.Context, c apptypes.Pay
 }
 
 //nolint:wrapcheck // the binding helper preserves the underlying serialization failure.
-func rehearsalPreparationBinding(c apptypes.PayloadRehearsalConfig) (string, error) {
-	digest, err := fileDigest(c.BackupPath)
+func rehearsalPreparationBinding(ctx context.Context, c apptypes.PayloadRehearsalConfig) (string, error) {
+	digest, err := fileDigest(ctx, c.BackupPath)
 	if err != nil {
 		return "", err
 	}
@@ -85,7 +85,7 @@ func (p PayloadRehearsalPreparation) EnsurePrepared(ctx context.Context, c appty
 	if journal == nil {
 		return application.RehearsalPreparedTarget{}, errors.New("payload rehearsal preparation journal is not configured")
 	}
-	binding, err := rehearsalPreparationBinding(c)
+	binding, err := rehearsalPreparationBinding(ctx, c)
 	if err != nil {
 		return application.RehearsalPreparedTarget{}, err
 	}
@@ -121,7 +121,7 @@ func (p PayloadRehearsalPreparation) RollbackPrepared(ctx context.Context, c app
 	if p.Journal == nil || p.Service == nil {
 		return application.RehearsalRollbackResult{}, errors.New("payload rehearsal preparation is not configured")
 	}
-	binding, err := rehearsalPreparationBinding(c)
+	binding, err := rehearsalPreparationBinding(ctx, c)
 	if err != nil {
 		return application.RehearsalRollbackResult{}, err
 	}

--- a/infrastructure/sqlite/payload_rehearsal_target.go
+++ b/infrastructure/sqlite/payload_rehearsal_target.go
@@ -185,11 +185,17 @@ func ensurePhysicalBackupWithHook(ctx context.Context, source, dest string, afte
 		afterCopy()
 	}
 	sourceAfter, err := fileDigest(ctx, source)
-	if err != nil || sourceAfter != sourceDigest {
+	if err != nil {
+		return "", err
+	}
+	if sourceAfter != sourceDigest {
 		return "", errors.New("source changed while creating rollback artifact")
 	}
 	destDigest, err := fileDigest(ctx, dest)
-	if err != nil || destDigest != sourceDigest {
+	if err != nil {
+		return "", err
+	}
+	if destDigest != sourceDigest {
 		return "", errors.New("rollback artifact digest verification failed")
 	}
 	if _, err = secureFileIdentity(dest); err != nil {
@@ -220,7 +226,10 @@ func restoreVerifiedRehearsalBackup(ctx context.Context, target, backup string, 
 		return ErrUnsafeRehearsalTarget
 	}
 	digest, err := fileDigest(ctx, backup)
-	if err != nil || digest != expectedDigest {
+	if err != nil {
+		return err
+	}
+	if digest != expectedDigest {
 		return errors.New("rollback artifact changed before recovery")
 	}
 	if err = verifySQLiteArtifact(backup); err != nil {
@@ -253,8 +262,11 @@ func restoreVerifiedRehearsalBackup(ctx context.Context, target, backup string, 
 	if err = copyFileAtomicVerifiedWithHook(backup, target, expectedDigest, verifyTarget); err != nil {
 		return err
 	}
-	restoredDigest, err := fileDigest(ctx, target)
-	if err != nil || restoredDigest != expectedDigest {
+	restoredDigest, err := fileDigest(context.WithoutCancel(ctx), target)
+	if err != nil {
+		return err
+	}
+	if restoredDigest != expectedDigest {
 		return errors.New("restored rehearsal target digest mismatch")
 	}
 	return verifySQLiteArtifact(target)

--- a/infrastructure/sqlite/payload_rehearsal_target.go
+++ b/infrastructure/sqlite/payload_rehearsal_target.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -149,11 +150,11 @@ func immutableRehearsalDSN(path string) string {
 }
 
 // Preview proves a strictly immutable, zero-write inspection.
-func ensurePhysicalBackup(source, dest string) (string, error) {
-	return ensurePhysicalBackupWithHook(source, dest, nil)
+func ensurePhysicalBackup(ctx context.Context, source, dest string) (string, error) {
+	return ensurePhysicalBackupWithHook(ctx, source, dest, nil)
 }
 
-func ensurePhysicalBackupWithHook(source, dest string, afterCopy func()) (string, error) {
+func ensurePhysicalBackupWithHook(ctx context.Context, source, dest string, afterCopy func()) (string, error) {
 	sourceAbs, _ := filepath.Abs(filepath.Clean(source))
 	destAbs, _ := filepath.Abs(filepath.Clean(dest))
 	if sourceAbs == destAbs {
@@ -164,11 +165,11 @@ func ensurePhysicalBackupWithHook(source, dest string, afterCopy func()) (string
 			return "", ErrUnsafeRehearsalTarget
 		}
 	}
-	sourceDigest, err := fileDigest(source)
+	sourceDigest, err := fileDigest(ctx, source)
 	if err != nil {
 		return "", err
 	}
-	if existing, existingErr := fileDigest(dest); existingErr == nil {
+	if existing, existingErr := fileDigest(ctx, dest); existingErr == nil {
 		if existing != sourceDigest {
 			return "", errors.New("existing rollback artifact does not match the copied target")
 		}
@@ -183,11 +184,11 @@ func ensurePhysicalBackupWithHook(source, dest string, afterCopy func()) (string
 	if afterCopy != nil {
 		afterCopy()
 	}
-	sourceAfter, err := fileDigest(source)
+	sourceAfter, err := fileDigest(ctx, source)
 	if err != nil || sourceAfter != sourceDigest {
 		return "", errors.New("source changed while creating rollback artifact")
 	}
-	destDigest, err := fileDigest(dest)
+	destDigest, err := fileDigest(ctx, dest)
 	if err != nil || destDigest != sourceDigest {
 		return "", errors.New("rollback artifact digest verification failed")
 	}
@@ -213,12 +214,12 @@ func verifySQLiteArtifact(path string) error {
 	return nil
 }
 
-func restoreVerifiedRehearsalBackup(target, backup string, expectedTarget, expectedBackup rehearsalIdentity, expectedDigest string) error {
+func restoreVerifiedRehearsalBackup(ctx context.Context, target, backup string, expectedTarget, expectedBackup rehearsalIdentity, expectedDigest string) error {
 	current, err := secureFileIdentity(backup)
 	if err != nil || !os.SameFile(expectedBackup.info, current.info) || expectedBackup.device != current.device || expectedBackup.inode != current.inode {
 		return ErrUnsafeRehearsalTarget
 	}
-	digest, err := fileDigest(backup)
+	digest, err := fileDigest(ctx, backup)
 	if err != nil || digest != expectedDigest {
 		return errors.New("rollback artifact changed before recovery")
 	}
@@ -252,7 +253,7 @@ func restoreVerifiedRehearsalBackup(target, backup string, expectedTarget, expec
 	if err = copyFileAtomicVerifiedWithHook(backup, target, expectedDigest, verifyTarget); err != nil {
 		return err
 	}
-	restoredDigest, err := fileDigest(target)
+	restoredDigest, err := fileDigest(ctx, target)
 	if err != nil || restoredDigest != expectedDigest {
 		return errors.New("restored rehearsal target digest mismatch")
 	}
@@ -349,7 +350,9 @@ func copyFileAtomicVerifiedWithHook(source, dest, expectedDigest string, beforeR
 		return err
 	}
 	if expectedDigest != "" {
-		copiedDigest, digestErr := fileDigest(tmp)
+		// The atomic copy step is un-interruptible by design; use a background
+		// context so neither SIGINT nor a wall-time budget abort this check.
+		copiedDigest, digestErr := fileDigest(context.Background(), tmp)
 		if digestErr != nil || copiedDigest != expectedDigest {
 			return errors.New("atomic copy digest verification failed")
 		}
@@ -375,15 +378,33 @@ func copyFileAtomicVerifiedWithHook(source, dest, expectedDigest string, beforeR
 }
 
 //nolint:wrapcheck // caller converts path-sensitive failures to fixed messages.
-func fileDigest(path string) (string, error) {
+func fileDigest(ctx context.Context, path string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = f.Close() }()
 	h := sha256.New()
-	if _, err = io.Copy(h, f); err != nil {
-		return "", err
+	buf := make([]byte, 32*1024)
+	for {
+		if err = ctx.Err(); err != nil {
+			return "", err
+		}
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			if _, err = h.Write(buf[:n]); err != nil {
+				return "", err
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return "", readErr
+		}
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/infrastructure/sqlite/prepared_migration_verifier.go
+++ b/infrastructure/sqlite/prepared_migration_verifier.go
@@ -37,11 +37,11 @@ func (v PreparedMigrationVerifier) VerifyRollbackTarget(ctx context.Context, tar
 // canonical event/audit equivalence. Schema equality is intentionally not
 // required because the candidate is expected to be newer.
 func (v PreparedMigrationVerifier) VerifyPair(ctx context.Context, source, candidate, planDigest string) (domain.PreparedCandidateEvidence, error) {
-	sourceDigest, err := fileDigest(source)
+	sourceDigest, err := fileDigest(ctx, source)
 	if err != nil {
 		return domain.PreparedCandidateEvidence{}, errors.New("cannot digest prepared migration source")
 	}
-	candidateDigest, err := fileDigest(candidate)
+	candidateDigest, err := fileDigest(ctx, candidate)
 	if err != nil {
 		return domain.PreparedCandidateEvidence{}, errors.New("cannot digest prepared migration candidate")
 	}


### PR DESCRIPTION
## Summary

`--wall-time-limit` now covers the read-only rollback verification phase (`fileDigest`, backup/copy verify, `PRAGMA integrity_check`). A budget miss fails before mutation; the prepared target and journal remain retryable. The atomic filesystem step after mutation intent stays un-interruptible.

## Why

On a large store, rollback verification ignored the operator budget and ran unbounded with no progress until JSON printed.

Closes #1858

Leaves parent #1968 open.

## Test plan

- [x] `go test ./infrastructure/sqlite/ ./application/usecase/ -run 'Budget|Digest|Rollback|Rehearsal|fileDigest|WallTime'`
- [x] `go tool golangci-lint run ./infrastructure/sqlite/... ./application/usecase/...`