### PR TITLE
fix: drain orphan memory-extract locks and aged temp files

### DIFF
--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -224,6 +224,8 @@ session end、turn boundary、subagent stop の hook は、主要な event を�
 
 `traceary doctor` は `hook-memory-extract` check で、未処理件数、以前失敗した件数、terminal（試行上限到達）件数、読めない件数、最古の経過時間を報告します。抽出内容や保存された条件は表示しません。後続 hook は同一 session に限らず oldest-first の bounded batch で queue 全体を drain し、`traceary doctor --fix` で大きめに drain できます。試行上限に達した job は terminal になり、retention 後に GC されます。terminal 以外の失敗が残る場合は debug log を確認してください。
 
+各 drain pass は、job 本体ではなく job から派生した sidecar file も掃除します: job 完了後に取り残される `.json.lock` flock sidecar（`.json` 本体は既に無い）と、writer が crash して残った `.memory-extract-*.tmp` write-temp です。どちらも同じ retention window を超えて古くなった場合のみ削除するため、作成途中の lock や temp を orphan と誤認することはありません。sweep は drain の bounded batch size を共有するので、大きな backlog でも 1 回のディレクトリ全走査ではなく複数 pass に分けて漸進的に drain されます。
+
 ## トラブルシュート
 
 hooks やローカル SQLite ストアの挙動がおかしいときは `traceary doctor --client <claude|codex|gemini|antigravity|grok>` を実行してください。Antigravity と Grok は既定の client 一覧に含まれないため、明示的な指定が必要です。

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -224,6 +224,8 @@ Session-end, turn-boundary, and subagent-stop hooks commit their primary event f
 
 `traceary doctor` reports the pending count, previously failed count, terminal (attempt-cap exhausted) count, unreadable count, and oldest age through `hook-memory-extract`. It never prints extracted content or the stored criteria. Later hooks drain a bounded oldest-first batch across sessions (not only the same session key), and `traceary doctor --fix` forces a larger drain. Jobs that exhaust the total attempt ceiling become terminal and are garbage-collected after a retention window; persistent non-terminal failures should be investigated through debug logs.
 
+Each drain pass also sweeps sidecar files derived from jobs rather than jobs themselves: `.json.lock` flock sidecars left behind once their job completes (the sibling `.json` is gone) and `.memory-extract-*.tmp` write-temps abandoned by a crashed writer. Both are only removed once older than the same retention window, so a lock or temp still mid-creation is never mistaken for an orphan; the sweep shares the drain's bounded batch size, so a large backlog drains incrementally across passes instead of a full directory scan.
+
 ## Troubleshooting
 
 Run `traceary doctor --client <claude|codex|gemini|antigravity|grok>` when hooks or the local SQLite store do not behave as expected. Antigravity and Grok must be selected explicitly because they are not in the default client list.

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -629,21 +629,14 @@ func sweepHookMemoryExtractSidecars(now time.Time, limit int) (removed int) {
 			continue
 		}
 		path := filepath.Join(dir, name)
+		if !hookMemoryExtractSidecarIsAgedOrphan(path, isLock, now, entry) {
+			continue
+		}
 		if isLock {
-			jsonPath := strings.TrimSuffix(path, ".lock")
-			if _, statErr := os.Stat(jsonPath); statErr == nil || !errors.Is(statErr, os.ErrNotExist) {
-				// Sibling exists (or is inspectable but not confirmed missing); not orphaned.
+			if !tryRemoveOrphanMemoryExtractLock(path) {
 				continue
 			}
-		}
-		info, infoErr := entry.Info()
-		if infoErr != nil {
-			continue
-		}
-		if now.Sub(info.ModTime()) < hookMemoryExtractTerminalRetention {
-			continue
-		}
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		} else if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			slog.Debug("hook memory extraction sidecar sweep failed", "path", path, "error", err)
 			continue
 		}
@@ -652,14 +645,115 @@ func sweepHookMemoryExtractSidecars(now time.Time, limit int) (removed int) {
 	return removed
 }
 
+func hookMemoryExtractSidecarIsAgedOrphan(path string, isLock bool, now time.Time, entry os.DirEntry) bool {
+	if isLock {
+		jsonPath := strings.TrimSuffix(path, ".lock")
+		if _, statErr := os.Stat(jsonPath); statErr == nil || !errors.Is(statErr, os.ErrNotExist) {
+			return false
+		}
+	}
+	info, infoErr := entry.Info()
+	if infoErr != nil {
+		return false
+	}
+	return now.Sub(info.ModTime()) >= hookMemoryExtractTerminalRetention
+}
+
+func tryRemoveOrphanMemoryExtractLock(path string) bool {
+	lock := flock.New(path)
+	ok, err := lock.TryLock()
+	if err != nil || !ok {
+		return false
+	}
+	defer func() { _ = lock.Unlock() }()
+	jsonPath := strings.TrimSuffix(path, ".lock")
+	if _, statErr := os.Stat(jsonPath); statErr == nil || !errors.Is(statErr, os.ErrNotExist) {
+		return false
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Debug("hook memory extraction sidecar sweep failed", "path", path, "error", err)
+		return false
+	}
+	return true
+}
+
+func countHookMemoryExtractSidecars(now time.Time) (locks, tmps int) {
+	dir, err := hookMemoryExtractQueueDir()
+	if err != nil {
+		return 0, 0
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, 0
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		isLock := strings.HasSuffix(name, ".json.lock")
+		isTmp := strings.HasPrefix(name, ".memory-extract-") && strings.HasSuffix(name, ".tmp")
+		if !isLock && !isTmp {
+			continue
+		}
+		if !hookMemoryExtractSidecarIsAgedOrphan(filepath.Join(dir, name), isLock, now, entry) {
+			continue
+		}
+		if isLock {
+			locks++
+		} else {
+			tmps++
+		}
+	}
+	return locks, tmps
+}
+
+func memoryExtractQueueFix(c *RootCLI, dryRun bool) (string, error) {
+	pending, _, err := scanHookMemoryExtractJobs()
+	if err != nil {
+		return "", err
+	}
+	locks, tmps := countHookMemoryExtractSidecars(time.Now().UTC())
+	if dryRun {
+		return localizef(
+			"would drain/GC up to %d pending memory extraction job(s) and sweep %d orphan lock(s) and %d aged temp file(s)",
+			"未処理 memory extraction job 最大 %d 件を drain/GC し、orphan lock %d 件と古い temp %d 件を sweep します",
+			min(len(pending), hookMemoryExtractDoctorFixLimit), locks, tmps,
+		), nil
+	}
+	launched, removed := c.drainHookMemoryExtractQueue(time.Now().UTC(), hookMemoryExtractDoctorFixLimit)
+	return localizef("drained memory extraction queue: launched=%d removed=%d", "memory extraction queue を drain しました: launched=%d removed=%d", launched, removed), nil
+}
+
 func (c *RootCLI) inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck {
 	const name = "hook-memory-extract"
 	jobs, unreadable, err := scanHookMemoryExtractJobs()
 	if err != nil {
 		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect memory extraction queue: %v", "memory extraction queue の検査に失敗しました: %v", err)}
 	}
-	if len(jobs) == 0 && len(unreadable) == 0 {
+	locks, tmps := countHookMemoryExtractSidecars(now)
+	if len(jobs) == 0 && len(unreadable) == 0 && locks == 0 && tmps == 0 {
 		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending hook memory extraction jobs found", "未処理の hook memory extraction job はありません")}
+	}
+	if len(jobs) == 0 && len(unreadable) == 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorStatusWarn,
+			Message: localizef(
+				"found 0 pending memory extraction jobs, %d orphan lock file(s), and %d aged temp file(s)",
+				"未処理 memory extraction job は 0 件ですが、orphan lock が %d 件、古い temp が %d 件あります",
+				locks, tmps,
+			),
+			Hint: Localize(
+				"completed jobs left flock sidecars or crash temps. Run `traceary doctor --fix` to sweep a bounded batch.",
+				"完了済み job の flock sidecar か crash temp が残っています。bounded batch で掃除するには `traceary doctor --fix` を実行してください。",
+			),
+			FixCommand:       "traceary doctor --fix",
+			AutoFixAvailable: true,
+			FixFunc: func(_ context.Context, dryRun bool) (string, error) {
+				return memoryExtractQueueFix(c, dryRun)
+			},
+		}
 	}
 	failed := 0
 	terminal := 0
@@ -693,15 +787,7 @@ func (c *RootCLI) inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck
 		FixCommand:       "traceary doctor --fix",
 		AutoFixAvailable: true,
 		FixFunc: func(_ context.Context, dryRun bool) (string, error) {
-			pending, _, err := scanHookMemoryExtractJobs()
-			if err != nil {
-				return "", err
-			}
-			if dryRun {
-				return localizef("would drain/GC up to %d pending memory extraction job(s)", "未処理 memory extraction job 最大 %d 件を drain/GC します", min(len(pending), hookMemoryExtractDoctorFixLimit)), nil
-			}
-			launched, removed := c.drainHookMemoryExtractQueue(time.Now().UTC(), hookMemoryExtractDoctorFixLimit)
-			return localizef("drained memory extraction queue: launched=%d removed=%d", "memory extraction queue を drain しました: launched=%d removed=%d", launched, removed), nil
+			return memoryExtractQueueFix(c, dryRun)
 		},
 	}
 }

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -535,11 +535,15 @@ func hookMemoryExtractJobReadyForGC(job hookMemoryExtractJob, now time.Time) boo
 	return !job.LastAttemptAt.Add(hookMemoryExtractTerminalRetention).After(now)
 }
 
-// drainHookMemoryExtractQueue relaunches pending jobs (oldest first) and
-// garbage-collects terminally failed jobs past the retention window. It never
-// re-extracts inline: each relaunch goes through the detached worker so host
-// hook budgets stay small. skipPaths are ignored (e.g. a job just launched by
-// scheduleHookMemoryExtract). Returns launch and remove counts.
+// drainHookMemoryExtractQueue relaunches pending jobs (oldest first),
+// garbage-collects terminally failed jobs past the retention window, and
+// sweeps orphaned sidecar files (locks with no job sibling, aged write-temps)
+// left behind by completed jobs and crashed workers. It never re-extracts
+// inline: each relaunch goes through the detached worker so host hook
+// budgets stay small. skipPaths are ignored (e.g. a job just launched by
+// scheduleHookMemoryExtract). Returns launch and remove counts; removed
+// includes both GC'd jobs and swept sidecar files, so the whole pass stays
+// bounded by limit regardless of directory size.
 func (c *RootCLI) drainHookMemoryExtractQueue(now time.Time, limit int, skipPaths ...string) (launched, removed int) {
 	if limit <= 0 {
 		return 0, 0
@@ -551,42 +555,101 @@ func (c *RootCLI) drainHookMemoryExtractQueue(now time.Time, limit int, skipPath
 		}
 	}
 	jobs, _, err := scanHookMemoryExtractJobs()
-	if err != nil || len(jobs) == 0 {
-		return 0, 0
-	}
-	// scan already returns oldest first.
-	for _, job := range jobs {
-		if launched+removed >= limit {
-			break
-		}
-		if strings.TrimSpace(job.Path) == "" {
-			continue
-		}
-		if _, ok := skip[job.Path]; ok {
-			continue
-		}
-		if hookMemoryExtractJobReadyForGC(job, now) {
-			if err := os.Remove(job.Path); err != nil && !os.IsNotExist(err) {
-				slog.Debug("hook memory extraction terminal GC failed", "job", job.Path, "error", err)
+	if err == nil {
+		// scan already returns oldest first.
+		for _, job := range jobs {
+			if launched+removed >= limit {
+				break
+			}
+			if strings.TrimSpace(job.Path) == "" {
 				continue
 			}
-			// Best-effort cleanup of sidecar files.
-			_ = os.Remove(job.Path + ".lock")
-			_ = os.Remove(job.Path + ".rerun")
-			removed++
-			continue
+			if _, ok := skip[job.Path]; ok {
+				continue
+			}
+			if hookMemoryExtractJobReadyForGC(job, now) {
+				if err := os.Remove(job.Path); err != nil && !os.IsNotExist(err) {
+					slog.Debug("hook memory extraction terminal GC failed", "job", job.Path, "error", err)
+					continue
+				}
+				// Best-effort cleanup of sidecar files.
+				_ = os.Remove(job.Path + ".lock")
+				_ = os.Remove(job.Path + ".rerun")
+				removed++
+				continue
+			}
+			if hookMemoryExtractJobIsTerminal(job) {
+				// Still within retention; leave visible for doctor.
+				continue
+			}
+			if err := c.launchHookMemoryExtractWorker(job.Path); err != nil {
+				slog.Debug("hook memory extraction drain launch failed", "job", job.Path, "error", err)
+				continue
+			}
+			launched++
 		}
-		if hookMemoryExtractJobIsTerminal(job) {
-			// Still within retention; leave visible for doctor.
-			continue
-		}
-		if err := c.launchHookMemoryExtractWorker(job.Path); err != nil {
-			slog.Debug("hook memory extraction drain launch failed", "job", job.Path, "error", err)
-			continue
-		}
-		launched++
+	}
+	if remaining := limit - (launched + removed); remaining > 0 {
+		removed += sweepHookMemoryExtractSidecars(now, remaining)
 	}
 	return launched, removed
+}
+
+// sweepHookMemoryExtractSidecars removes files derived from jobs rather than
+// jobs themselves: (a) ".json.lock" files whose ".json" sibling no longer
+// exists (the common leak — a completed job removes its job.json but not its
+// flock sidecar) and (b) ".memory-extract-*.tmp" write-temps abandoned by a
+// crashed writer. Both are only removed once aged past the terminal
+// retention window, so a lock or temp mid-creation by a concurrent process is
+// never mistaken for an orphan. Bounded by limit so a directory with a large
+// backlog is swept incrementally across passes rather than scanned in full.
+func sweepHookMemoryExtractSidecars(now time.Time, limit int) (removed int) {
+	if limit <= 0 {
+		return 0
+	}
+	dir, err := hookMemoryExtractQueueDir()
+	if err != nil {
+		return 0
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	for _, entry := range entries {
+		if removed >= limit {
+			break
+		}
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		isLock := strings.HasSuffix(name, ".json.lock")
+		isTmp := strings.HasPrefix(name, ".memory-extract-") && strings.HasSuffix(name, ".tmp")
+		if !isLock && !isTmp {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if isLock {
+			jsonPath := strings.TrimSuffix(path, ".lock")
+			if _, statErr := os.Stat(jsonPath); statErr == nil || !errors.Is(statErr, os.ErrNotExist) {
+				// Sibling exists (or is inspectable but not confirmed missing); not orphaned.
+				continue
+			}
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) < hookMemoryExtractTerminalRetention {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			slog.Debug("hook memory extraction sidecar sweep failed", "path", path, "error", err)
+			continue
+		}
+		removed++
+	}
+	return removed
 }
 
 func (c *RootCLI) inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck {

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -178,6 +179,154 @@ func TestDrainHookMemoryExtractQueue_RetainsTerminalWithinRetention(t *testing.T
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("must retain for doctor visibility: %v", err)
+	}
+}
+
+func TestDrainHookMemoryExtractQueue_RemovesOrphanLocksPastRetention(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	queueDir := filepath.Join(stateDir, "memory-extract")
+	if err := os.MkdirAll(queueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	orphanLock := filepath.Join(queueDir, "orphan.json.lock")
+	if err := os.WriteFile(orphanLock, []byte{}, 0o600); err != nil {
+		t.Fatalf("WriteFile(orphan lock): %v", err)
+	}
+	aged := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	if err := os.Chtimes(orphanLock, aged, aged); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	root := NewRootCLI(WithHookMemoryExtractLauncher(func(string) error {
+		t.Fatal("no job to launch")
+		return nil
+	}))
+	launched, removed := root.drainHookMemoryExtractQueue(now, 5)
+	if launched != 0 || removed != 1 {
+		t.Fatalf("launched=%d removed=%d want 0/1", launched, removed)
+	}
+	if _, err := os.Stat(orphanLock); !os.IsNotExist(err) {
+		t.Fatalf("orphan lock must be removed, stat err=%v", err)
+	}
+}
+
+func TestDrainHookMemoryExtractQueue_RetainsRecentOrphanLock(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	queueDir := filepath.Join(stateDir, "memory-extract")
+	if err := os.MkdirAll(queueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	orphanLock := filepath.Join(queueDir, "fresh.json.lock")
+	if err := os.WriteFile(orphanLock, []byte{}, 0o600); err != nil {
+		t.Fatalf("WriteFile(orphan lock): %v", err)
+	}
+	recent := now.Add(-time.Minute)
+	if err := os.Chtimes(orphanLock, recent, recent); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	root := &RootCLI{}
+	launched, removed := root.drainHookMemoryExtractQueue(now, 5)
+	if launched != 0 || removed != 0 {
+		t.Fatalf("launched=%d removed=%d want 0/0", launched, removed)
+	}
+	if _, err := os.Stat(orphanLock); err != nil {
+		t.Fatalf("recent orphan lock must survive a mid-creation race: %v", err)
+	}
+}
+
+func TestDrainHookMemoryExtractQueue_SweepsAgedTmpFiles(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	queueDir := filepath.Join(stateDir, "memory-extract")
+	if err := os.MkdirAll(queueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	tmp := filepath.Join(queueDir, ".memory-extract-crashed123.tmp")
+	if err := os.WriteFile(tmp, []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile(tmp): %v", err)
+	}
+	aged := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	if err := os.Chtimes(tmp, aged, aged); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	root := &RootCLI{}
+	launched, removed := root.drainHookMemoryExtractQueue(now, 5)
+	if launched != 0 || removed != 1 {
+		t.Fatalf("launched=%d removed=%d want 0/1", launched, removed)
+	}
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Fatalf("aged tmp must be removed, stat err=%v", err)
+	}
+}
+
+func TestDrainHookMemoryExtractQueue_KeepsLockWithLiveJobSibling(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("live-sibling"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "session_end",
+	}
+	path, err := enqueueHookMemoryExtract(request, now.Add(-48*time.Hour))
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	lockPath := path + ".lock"
+	aged := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	if err := os.Chtimes(lockPath, aged, aged); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	root := NewRootCLI(WithHookMemoryExtractLauncher(func(string) error { return nil }))
+	if _, removed := root.drainHookMemoryExtractQueue(now, 5); removed != 0 {
+		t.Fatalf("removed = %d, want 0: pending job's lock has a live sibling", removed)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock with live job sibling must survive: %v", err)
+	}
+}
+
+func TestDrainHookMemoryExtractQueue_SidecarSweepIsBounded(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	queueDir := filepath.Join(stateDir, "memory-extract")
+	if err := os.MkdirAll(queueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	aged := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	const orphanCount = 20
+	for i := 0; i < orphanCount; i++ {
+		lockPath := filepath.Join(queueDir, fmt.Sprintf("orphan-%02d.json.lock", i))
+		if err := os.WriteFile(lockPath, []byte{}, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.Chtimes(lockPath, aged, aged); err != nil {
+			t.Fatalf("Chtimes: %v", err)
+		}
+	}
+
+	root := &RootCLI{}
+	const limit = 5
+	_, removed := root.drainHookMemoryExtractQueue(now, limit)
+	if removed != limit {
+		t.Fatalf("removed = %d, want bounded to limit=%d", removed, limit)
+	}
+	entries, err := os.ReadDir(queueDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != orphanCount-limit {
+		t.Fatalf("remaining entries = %d, want %d (one pass must not drain the whole directory)", len(entries), orphanCount-limit)
 	}
 }
 

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -67,6 +67,82 @@ func TestInspectHookMemoryExtractDiagnosticsPassesWithoutJobs(t *testing.T) {
 	}
 }
 
+func TestInspectHookMemoryExtractDiagnosticsWarnsOnOrphanSidecarsOnly(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	queueDir := filepath.Join(stateDir, "memory-extract")
+	if err := os.MkdirAll(queueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	orphanLock := filepath.Join(queueDir, "orphan.json.lock")
+	if err := os.WriteFile(orphanLock, []byte{}, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	aged := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	if err := os.Chtimes(orphanLock, aged, aged); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	root := &RootCLI{}
+	check := root.inspectHookMemoryExtractDiagnostics(now)
+	if check.Status != doctorStatusWarn || !check.AutoFixAvailable || check.FixFunc == nil {
+		t.Fatalf("check = %+v, want warn with FixFunc", check)
+	}
+	if !strings.Contains(check.Message, "1 orphan lock") {
+		t.Fatalf("message = %q", check.Message)
+	}
+	dry, err := check.FixFunc(context.Background(), true)
+	if err != nil {
+		t.Fatalf("FixFunc(dry-run) error = %v", err)
+	}
+	if !strings.Contains(dry, "1 orphan lock") {
+		t.Fatalf("dry-run = %q", dry)
+	}
+	applied, err := check.FixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("FixFunc() error = %v", err)
+	}
+	if !strings.Contains(applied, "removed=1") {
+		t.Fatalf("applied = %q", applied)
+	}
+	if _, err := os.Stat(orphanLock); !os.IsNotExist(err) {
+		t.Fatalf("orphan lock must be removed by doctor --fix, stat err=%v", err)
+	}
+}
+
+func TestSweepHookMemoryExtractSidecarsSkipsHeldLock(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	queueDir := filepath.Join(stateDir, "memory-extract")
+	if err := os.MkdirAll(queueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	held := filepath.Join(queueDir, "held.json.lock")
+	if err := os.WriteFile(held, []byte{}, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	aged := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	if err := os.Chtimes(held, aged, aged); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	lock := flock.New(held)
+	ok, err := lock.TryLock()
+	if err != nil || !ok {
+		t.Fatalf("TryLock() ok=%v err=%v", ok, err)
+	}
+	t.Cleanup(func() { _ = lock.Unlock() })
+
+	removed := sweepHookMemoryExtractSidecars(now, 5)
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0 while lock is held", removed)
+	}
+	if _, err := os.Stat(held); err != nil {
+		t.Fatalf("held lock must survive sweep: %v", err)
+	}
+}
+
 func TestDrainHookMemoryExtractQueue_LaunchesOtherSessionJobs(t *testing.T) {
 	t.Setenv(hookStateDirEnvKey, t.TempDir())
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

`drainHookMemoryExtractQueue` now sweeps orphan `*.json.lock` files and aged `.memory-extract-*.tmp` write temps, using the existing terminal retention window and the drain's bounded batch limit. `doctor --fix` already calls this drain.

## Why

After the 0.39.0 refresh, `~/.config/traceary/hooks/memory-extract/` still held ~19k leftover lock/tmp files. Completed jobs removed `job.json` but left the flock sidecar.

Closes #1981

Leaves parent #1968 open.

## Test plan

- [x] `go test ./presentation/cli/ -run 'MemoryExtract|HookMemoryExtract|drainHookMemory'`
- [x] `go tool golangci-lint run ./presentation/cli/...`