### PR TITLE
fix: classify and GC Claude SessionEnd hook diagnostics

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -466,7 +466,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			report.Checks = append(report.Checks, c.inspectClientEventCoverage(ctx, targetClient, outputPath, resolvedProjectDir, input.coverageThreshold))
 		}
 		if targetClient == "claude" {
-			report.Checks = append(report.Checks, c.inspectClaudeHookCancellationDiagnostics(ctx, resolvedProjectDir))
+			report.Checks = append(report.Checks, c.inspectClaudeHookCancellationDiagnostics(ctx, resolvedDBPath, resolvedProjectDir))
 		}
 		if globalCheck := c.inspectGlobalConfigForClient(targetClient); globalCheck != nil {
 			report.Checks = append(report.Checks, *globalCheck)

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -790,6 +790,110 @@ func TestRootCLI_DoctorCommand_ClaudeHookCancellationDiagnostics(t *testing.T) {
 			t.Fatalf("claude-hook-cancellations hint = %q, want actionable cancellation hint", check.Hint)
 		}
 	})
+
+	t.Run("marker from another store is unknown, not actionable", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("TRACEARY_LANG", "en")
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "doctor-other-store-key")
+		setTracearyPathToCurrentExecutable(t)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteClaudeProjectHookSettings(t, projectDir)
+
+		stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(state) error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(stateDir, "claude-doctor-other-store-key"), []byte("other-store-session"), 0o600); err != nil {
+			t.Fatalf("WriteFile(session state) error = %v", err)
+		}
+
+		// The hook records the marker against a scratch store, distinct from
+		// the store doctor below inspects (the default store under HOME).
+		otherStoreDBPath := filepath.Join(t.TempDir(), "scratch.db")
+		hookCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithSession(&sessionUsecaseStub{endErr: errors.New("simulated cancellation")}),
+		).Command()
+		hookCmd.SetOut(&bytes.Buffer{})
+		hookCmd.SetErr(&bytes.Buffer{})
+		hookCmd.SetIn(strings.NewReader(fmt.Sprintf(`{"cwd":%q}`, projectDir)))
+		hookCmd.SetArgs([]string{"hook", "session", "claude", "end", "--db-path", otherStoreDBPath})
+		if err := hookCmd.Execute(); err != nil {
+			t.Fatalf("hook Execute() error = %v", err)
+		}
+
+		report, err := executeDoctorJSON(t, []string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json", "--warnings-ok"})
+		if err != nil {
+			t.Fatalf("doctor Execute() error = %v", err)
+		}
+		check := statusByName(report, "claude-hook-cancellations")
+		if got, want := check.Status, "warn"; got != want {
+			t.Fatalf("claude-hook-cancellations status = %q, want %q (message=%q)", got, want, check.Message)
+		}
+		if strings.Contains(check.Message, "actionable") {
+			t.Fatalf("claude-hook-cancellations message = %q, must not report a cross-store marker as actionable", check.Message)
+		}
+		if !strings.Contains(check.Message, "unknown store") {
+			t.Fatalf("claude-hook-cancellations message = %q, want unknown-store wording", check.Message)
+		}
+		if check.AutoFixAvailable {
+			t.Fatalf("claude-hook-cancellations must not offer a fix for a fresh unknown-store marker (not yet aged): %+v", check)
+		}
+	})
+
+	t.Run("fix removes resolved and aged unknown-store markers", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("TRACEARY_LANG", "en")
+		setTracearyPathToCurrentExecutable(t)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteClaudeProjectHookSettings(t, projectDir)
+
+		stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+		diagnosticsDir := filepath.Join(stateDir, "diagnostics")
+		if err := os.MkdirAll(diagnosticsDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(diagnostics) error = %v", err)
+		}
+		agedUnknown := fmt.Sprintf(`{
+  "schema_version": 1,
+  "client": "claude",
+  "host_event": "SessionEnd",
+  "hook_command": "cmd",
+  "session_id": "aged-unknown-session",
+  "db_path": "/store/other.db",
+  "status": "started",
+  "started_at": %q
+}
+`, time.Now().UTC().Add(-8*24*time.Hour).Format(time.RFC3339Nano))
+		agedPath := filepath.Join(diagnosticsDir, "claude-SessionEnd-aged-unknown.json")
+		if err := os.WriteFile(agedPath, []byte(agedUnknown), 0o600); err != nil {
+			t.Fatalf("WriteFile(aged unknown marker) error = %v", err)
+		}
+
+		report, err := executeDoctorJSON(t, []string{"doctor", "--fix", "--dry-run", "--client", "claude", "--project-dir", projectDir, "--json", "--warnings-ok"})
+		if err != nil {
+			t.Fatalf("doctor --fix --dry-run Execute() error = %v", err)
+		}
+		check := statusByName(report, "claude-hook-cancellations")
+		if !check.AutoFixAvailable {
+			t.Fatalf("claude-hook-cancellations must offer a fix for an aged unknown-store marker: %+v", check)
+		}
+		if _, err := os.Stat(agedPath); err != nil {
+			t.Fatalf("dry-run must not remove the marker: %v", err)
+		}
+
+		if _, err := executeDoctorJSON(t, []string{"doctor", "--fix", "--client", "claude", "--project-dir", projectDir, "--json", "--warnings-ok"}); err != nil {
+			t.Fatalf("doctor --fix Execute() error = %v", err)
+		}
+		if _, err := os.Stat(agedPath); !os.IsNotExist(err) {
+			t.Fatalf("aged unknown-store marker survived --fix: err=%v", err)
+		}
+	})
 }
 
 func TestRootCLI_DoctorExitCodeMatrixAndJSONSections(t *testing.T) {

--- a/presentation/cli/hook_diagnostics.go
+++ b/presentation/cli/hook_diagnostics.go
@@ -26,6 +26,19 @@ const (
 	// characters (48 bits) make accidental collisions between distinct sessions
 	// in a single diagnostics directory negligible while staying short.
 	hookCancellationDiagnosticSessionHashLen = 12
+
+	hookCancellationDiagnosticPhaseWorkspaceResolved = "workspace_resolved"
+	hookCancellationDiagnosticPhaseStoreInitialized  = "store_initialized"
+
+	// hookCancellationDiagnosticRetentionWindow bounds how long a marker for a
+	// given (client, host_event) stays eligible for begin-time GC and how old
+	// an Unknown-store marker must be before `doctor --fix` removes it.
+	hookCancellationDiagnosticRetentionWindow = 7 * 24 * time.Hour
+	// hookCancellationDiagnosticRetentionCap bounds how many markers for a
+	// given (client, host_event) survive begin-time GC regardless of age, so
+	// the diagnostics directory cannot grow unbounded even under a tight
+	// begin/kill loop within the retention window.
+	hookCancellationDiagnosticRetentionCap = 20
 )
 
 type hookCancellationDiagnostic struct {
@@ -36,6 +49,8 @@ type hookCancellationDiagnostic struct {
 	HookPath      string    `json:"hook_path,omitempty"`
 	Workspace     string    `json:"workspace,omitempty"`
 	SessionID     string    `json:"session_id,omitempty"`
+	DBPath        string    `json:"db_path,omitempty"`
+	Phase         string    `json:"phase,omitempty"`
 	Status        string    `json:"status"`
 	StartedAt     time.Time `json:"started_at"`
 
@@ -51,12 +66,20 @@ type hookDiagnosticSessionLookup interface {
 	FindEndedSessionIDs(context.Context, []types.SessionID) (map[types.SessionID]struct{}, error)
 }
 
+// hookCancellationDiagnosticClassification splits scanned markers three ways.
+// Resolved: the session ended in the store currently being inspected.
+// Actionable: the session is known-active in that same store.
+// Unknown: the marker references a different store (or predates db_path
+// recording), so its session state cannot be determined here. Unknown is
+// never surfaced as Actionable — a scratch/other --db-path store must not
+// mark every historical marker as needing attention.
 type hookCancellationDiagnosticClassification struct {
 	Actionable []hookCancellationDiagnostic
 	Resolved   []hookCancellationDiagnostic
+	Unknown    []hookCancellationDiagnostic
 }
 
-func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, projectDir string) doctorCheck {
+func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, dbPath, projectDir string) doctorCheck {
 	const checkName = "claude-hook-cancellations"
 	workspace := resolveDoctorEventCoverageWorkspace(ctx, projectDir)
 	scan, err := scanHookCancellationDiagnostics("claude", "SessionEnd", workspace)
@@ -78,7 +101,7 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, 
 			),
 		}
 	}
-	classification, err := classifyHookCancellationDiagnostics(ctx, scan.Records, c.session)
+	classification, err := classifyHookCancellationDiagnostics(ctx, scan.Records, c.session, dbPath)
 	if err != nil {
 		return doctorCheck{
 			Name:    checkName,
@@ -87,7 +110,7 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, 
 		}
 	}
 
-	if len(classification.Actionable) == 0 && len(classification.Resolved) == 0 {
+	if len(classification.Actionable) == 0 && len(classification.Resolved) == 0 && len(classification.Unknown) == 0 {
 		return doctorCheck{
 			Name:   checkName,
 			Status: doctorStatusWarn,
@@ -102,23 +125,69 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, 
 			),
 		}
 	}
-	fix := resolvedHookCancellationDiagnosticFix(classification.Resolved)
+
+	agedUnknown := agedHookCancellationDiagnostics(classification.Unknown, time.Now().UTC().Add(-hookCancellationDiagnosticRetentionWindow))
+	fixRecords := append(append([]hookCancellationDiagnostic{}, classification.Resolved...), agedUnknown...)
 	fixCommand := ""
-	if len(classification.Resolved) > 0 {
+	var fix doctorFixFunc
+	if len(fixRecords) > 0 {
 		fixCommand = fmt.Sprintf("traceary doctor --client claude --project-dir %s --fix --dry-run", shellQuote(projectDir))
+		fix = resolvedHookCancellationDiagnosticFix(fixRecords)
 	}
-	if len(classification.Actionable) == 0 && len(scan.Unreadable) == 0 {
+
+	if len(classification.Actionable) == 0 {
+		if len(fixRecords) > 0 {
+			return doctorCheck{
+				Name:   checkName,
+				Status: doctorStatusWarn,
+				Hint: Localize(
+					"the referenced sessions have ended, or the markers reference another store and have aged past the retention window; preview the safe marker cleanup with the fix command",
+					"参照先 session は終了済みか、marker が別ストアを参照したまま retention window を超えています。fix command で安全な marker cleanup を preview してください",
+				),
+				Message: localizef(
+					"found %d resolved and %d aged unknown-store Claude SessionEnd hook cancellation diagnostic(s) eligible for cleanup%s",
+					"cleanup 可能な解決済み Claude SessionEnd hook cancellation diagnostic が %d 件、別ストア参照で retention window を超えた marker が %d 件あります%s",
+					len(classification.Resolved),
+					len(agedUnknown),
+					formatUnreadableHookDiagnosticsSuffix(scan.Unreadable),
+				),
+				FixCommand:       fixCommand,
+				AutoFixAvailable: true,
+				FixFunc:          fix,
+			}
+		}
+		if len(classification.Unknown) > 0 && len(scan.Unreadable) == 0 {
+			return doctorCheck{
+				Name:   checkName,
+				Status: doctorStatusWarn,
+				Hint: Localize(
+					"these markers reference a different store than the one currently inspected, or predate db_path recording; they are not evidence of an actionable cancellation in this store",
+					"これらの marker は現在検査中のストアとは別のストアを参照しているか、db_path 記録より前のものです。このストアで対応が必要な cancellation の証拠にはなりません",
+				),
+				Message: localizef(
+					"found %d Claude SessionEnd hook cancellation diagnostic(s) of unknown store affinity",
+					"ストアの対応関係が不明な Claude SessionEnd hook cancellation diagnostic が %d 件あります",
+					len(classification.Unknown),
+				),
+			}
+		}
 		return doctorCheck{
-			Name:             checkName,
-			Status:           doctorStatusWarn,
-			Hint:             Localize("the referenced sessions have ended; preview the safe marker cleanup with the fix command", "参照先 session は終了済みです。fix command で安全な marker cleanup を preview してください"),
-			Message:          localizef("found %d resolved Claude SessionEnd hook cancellation diagnostic(s) eligible for cleanup", "cleanup 可能な解決済み Claude SessionEnd hook cancellation diagnostic が %d 件あります", len(classification.Resolved)),
-			FixCommand:       fixCommand,
-			AutoFixAvailable: true,
-			FixFunc:          fix,
+			Name:   checkName,
+			Status: doctorStatusWarn,
+			Hint: Localize(
+				"inspect the unreadable diagnostic file(s); absence of readable diagnostics is not proof that Claude never cancelled a hook before Traceary started",
+				"読めない diagnostic file を確認してください。読める diagnostic が無いことは、Claude が Traceary 起動前に hook を cancel していない証明にはなりません",
+			),
+			Message: localizef(
+				"found %d unknown-store Claude SessionEnd hook cancellation diagnostic(s) and unreadable diagnostic file(s): %s",
+				"ストアの対応関係が不明な Claude SessionEnd hook cancellation diagnostic が %d 件、読めない diagnostic file があります: %s",
+				len(classification.Unknown),
+				strings.Join(scan.Unreadable, ", "),
+			),
 		}
 	}
 
+	latest := classification.Actionable[0]
 	check := doctorCheck{
 		Name:   checkName,
 		Status: doctorStatusWarn,
@@ -126,15 +195,13 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, 
 			"the marker means Traceary reached Claude SessionEnd but did not complete cleanly; inspect the file and recent `traceary list --agent claude` output, then remove the marker after confirming it is stale. If Claude cancels before Traceary starts, no marker can be written.",
 			"この marker は Traceary が Claude SessionEnd まで到達したものの正常完了していないことを示します。file と最近の `traceary list --agent claude` を確認し、stale と判断できたら marker を削除してください。Claude が Traceary 起動前に cancel した場合、marker は書けません。",
 		),
-		Message: localizef("found unreadable Claude hook cancellation diagnostic file(s): %s", "読めない Claude hook cancellation diagnostic file があります: %s", strings.Join(scan.Unreadable, ", ")),
-	}
-	if len(classification.Actionable) > 0 {
-		latest := classification.Actionable[0]
-		check.Message = localizef(
-			"found %d actionable Claude SessionEnd hook cancellation diagnostic(s) and %d resolved marker(s); latest host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
-			"対応が必要な Claude SessionEnd hook cancellation diagnostic が %d 件、解決済み marker が %d 件あります。latest host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
+		Message: localizef(
+			"found %d actionable Claude SessionEnd hook cancellation diagnostic(s), %d resolved, %d unknown-store; latest phase=%s host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
+			"対応が必要な Claude SessionEnd hook cancellation diagnostic が %d 件、解決済みが %d 件、ストア不明が %d 件あります。latest phase=%s host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
 			len(classification.Actionable),
 			len(classification.Resolved),
+			len(classification.Unknown),
+			emptyAsDash(latest.Phase),
 			emptyAsDash(latest.HostEvent),
 			emptyAsDash(latest.HookCommand),
 			emptyAsDash(latest.HookPath),
@@ -143,16 +210,9 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, 
 			formatHookDiagnosticTime(latest.StartedAt),
 			latest.Path,
 			formatUnreadableHookDiagnosticsSuffix(scan.Unreadable),
-		)
-	} else if len(classification.Resolved) > 0 && len(scan.Unreadable) > 0 {
-		check.Message = localizef(
-			"found %d resolved Claude SessionEnd hook cancellation diagnostic(s) eligible for cleanup and unreadable diagnostic file(s): %s",
-			"cleanup 可能な解決済み Claude SessionEnd hook cancellation diagnostic が %d 件、読めない diagnostic file があります: %s",
-			len(classification.Resolved),
-			strings.Join(scan.Unreadable, ", "),
-		)
+		),
 	}
-	if len(classification.Resolved) > 0 {
+	if len(fixRecords) > 0 {
 		check.FixCommand = fixCommand
 		check.AutoFixAvailable = true
 		check.FixFunc = fix
@@ -164,14 +224,33 @@ func classifyHookCancellationDiagnostics(
 	ctx context.Context,
 	records []hookCancellationDiagnostic,
 	sessions hookDiagnosticSessionLookup,
+	currentDBPath string,
 ) (hookCancellationDiagnosticClassification, error) {
 	classification := hookCancellationDiagnosticClassification{}
-	if sessions == nil {
-		classification.Actionable = append(classification.Actionable, records...)
+	currentDBPath = strings.TrimSpace(currentDBPath)
+
+	// A marker only speaks to the store it was written against. Comparing it
+	// to any other store — including "we don't know which store" — is not
+	// evidence either way, so it is never Actionable and never Resolved.
+	sameStore := make([]hookCancellationDiagnostic, 0, len(records))
+	for _, record := range records {
+		recordDBPath := strings.TrimSpace(record.DBPath)
+		if currentDBPath == "" || recordDBPath == "" || recordDBPath != currentDBPath {
+			classification.Unknown = append(classification.Unknown, record)
+			continue
+		}
+		sameStore = append(sameStore, record)
+	}
+	if len(sameStore) == 0 {
 		return classification, nil
 	}
-	ids := make([]types.SessionID, 0, len(records))
-	for _, record := range records {
+
+	if sessions == nil {
+		classification.Actionable = append(classification.Actionable, sameStore...)
+		return classification, nil
+	}
+	ids := make([]types.SessionID, 0, len(sameStore))
+	for _, record := range sameStore {
 		if strings.TrimSpace(record.SessionID) != "" {
 			ids = append(ids, types.SessionID(record.SessionID))
 		}
@@ -180,7 +259,7 @@ func classifyHookCancellationDiagnostics(
 	if err != nil {
 		return hookCancellationDiagnosticClassification{}, xerrors.Errorf("failed to inspect ended sessions: %w", err)
 	}
-	for _, record := range records {
+	for _, record := range sameStore {
 		if strings.TrimSpace(record.SessionID) == "" {
 			classification.Actionable = append(classification.Actionable, record)
 			continue
@@ -192,6 +271,18 @@ func classifyHookCancellationDiagnostics(
 		classification.Actionable = append(classification.Actionable, record)
 	}
 	return classification, nil
+}
+
+// agedHookCancellationDiagnostics returns the subset of records started
+// before cutoff, preserving order.
+func agedHookCancellationDiagnostics(records []hookCancellationDiagnostic, cutoff time.Time) []hookCancellationDiagnostic {
+	aged := make([]hookCancellationDiagnostic, 0, len(records))
+	for _, record := range records {
+		if record.StartedAt.Before(cutoff) {
+			aged = append(aged, record)
+		}
+	}
+	return aged
 }
 
 func resolvedHookCancellationDiagnosticFix(records []hookCancellationDiagnostic) doctorFixFunc {
@@ -212,7 +303,7 @@ func resolvedHookCancellationDiagnosticFix(records []hookCancellationDiagnostic)
 	}
 }
 
-func beginHookCancellationDiagnostic(client, hostEvent, hookCommand string, sessionID types.SessionID, workspace types.Workspace) (string, error) {
+func beginHookCancellationDiagnostic(client, hostEvent, hookCommand string, sessionID types.SessionID, workspace types.Workspace, dbPath string) (string, error) {
 	startedAt := time.Now().UTC()
 	diagnosticsDir, err := hookDiagnosticsDir()
 	if err != nil {
@@ -221,6 +312,7 @@ func beginHookCancellationDiagnostic(client, hostEvent, hookCommand string, sess
 	if err := os.MkdirAll(diagnosticsDir, 0o755); err != nil {
 		return "", xerrors.Errorf("failed to create hook diagnostics directory: %w", err)
 	}
+	gcHookCancellationDiagnostics(client, hostEvent, startedAt)
 
 	hookPath := ""
 	if executablePath, err := os.Executable(); err == nil {
@@ -234,6 +326,7 @@ func beginHookCancellationDiagnostic(client, hostEvent, hookCommand string, sess
 		HookPath:      hookPath,
 		Workspace:     workspace.String(),
 		SessionID:     sessionID.String(),
+		DBPath:        strings.TrimSpace(dbPath),
 		Status:        hookCancellationDiagnosticStatusStarted,
 		StartedAt:     startedAt,
 	}
@@ -251,6 +344,30 @@ func beginHookCancellationDiagnostic(client, hostEvent, hookCommand string, sess
 	return path, nil
 }
 
+// gcHookCancellationDiagnostics removes stale markers for the same
+// (client, host_event) before a new one is written, so a host that keeps
+// killing SessionEnd before it completes cannot grow the diagnostics
+// directory without bound. Markers within the retention window and cap are
+// left alone; scan failures are treated as "nothing to GC" since begin must
+// still write the new marker.
+func gcHookCancellationDiagnostics(client, hostEvent string, now time.Time) {
+	scan, err := scanHookCancellationDiagnostics(client, hostEvent, "")
+	if err != nil {
+		return
+	}
+	cutoff := now.Add(-hookCancellationDiagnosticRetentionWindow)
+	// Reserve one cap slot for the marker this call is about to write, so a
+	// steady stream of begin calls converges on the cap instead of settling
+	// one marker over it.
+	keepWithinCap := hookCancellationDiagnosticRetentionCap - 1
+	for i, record := range scan.Records {
+		if i < keepWithinCap && !record.StartedAt.Before(cutoff) {
+			continue
+		}
+		_ = clearHookCancellationDiagnostic(record.Path)
+	}
+}
+
 func clearHookCancellationDiagnostic(path string) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -263,6 +380,22 @@ func clearHookCancellationDiagnostic(path string) error {
 }
 
 func updateHookCancellationDiagnosticWorkspace(path string, workspace types.Workspace) error {
+	return mutateHookCancellationDiagnostic(path, func(record *hookCancellationDiagnostic) {
+		record.Workspace = workspace.String()
+	})
+}
+
+// updateHookCancellationDiagnosticPhase records a cheap breadcrumb of how far
+// SessionEnd progressed before a possible kill: workspace resolution and
+// store initialize are the two points most likely to hang against a large
+// store, so those are the only phases recorded (#1972).
+func updateHookCancellationDiagnosticPhase(path, phase string) error {
+	return mutateHookCancellationDiagnostic(path, func(record *hookCancellationDiagnostic) {
+		record.Phase = phase
+	})
+}
+
+func mutateHookCancellationDiagnostic(path string, mutate func(*hookCancellationDiagnostic)) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return nil
@@ -278,7 +411,7 @@ func updateHookCancellationDiagnosticWorkspace(path string, workspace types.Work
 	if err := json.Unmarshal(data, &record); err != nil {
 		return xerrors.Errorf("failed to decode hook cancellation diagnostic: %w", err)
 	}
-	record.Workspace = workspace.String()
+	mutate(&record)
 	encoded, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
 		return xerrors.Errorf("failed to encode hook cancellation diagnostic: %w", err)

--- a/presentation/cli/hook_diagnostics_test.go
+++ b/presentation/cli/hook_diagnostics_test.go
@@ -2,9 +2,12 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -26,17 +29,18 @@ func (s *hookDiagnosticSessionLookupStub) FindEndedSessionIDs(_ context.Context,
 }
 
 func TestClassifyHookCancellationDiagnostics(t *testing.T) {
+	const currentDBPath = "/store/current.db"
 	endedID := types.SessionID("ended-session")
 	activeID := types.SessionID("active-session")
 	missingID := types.SessionID("missing-session")
 	records := []hookCancellationDiagnostic{
-		{SessionID: endedID.String(), Path: "ended.json"},
-		{SessionID: activeID.String(), Path: "active.json"},
-		{SessionID: missingID.String(), Path: "missing.json"},
+		{SessionID: endedID.String(), DBPath: currentDBPath, Path: "ended.json"},
+		{SessionID: activeID.String(), DBPath: currentDBPath, Path: "active.json"},
+		{SessionID: missingID.String(), DBPath: currentDBPath, Path: "missing.json"},
 	}
 	lookup := &hookDiagnosticSessionLookupStub{ended: map[types.SessionID]struct{}{endedID: {}}}
 
-	got, err := classifyHookCancellationDiagnostics(context.Background(), records, lookup)
+	got, err := classifyHookCancellationDiagnostics(context.Background(), records, lookup, currentDBPath)
 	if err != nil {
 		t.Fatalf("classifyHookCancellationDiagnostics() error = %v", err)
 	}
@@ -46,8 +50,62 @@ func TestClassifyHookCancellationDiagnostics(t *testing.T) {
 	if diff := cmp.Diff([]string{"ended.json"}, diagnosticPaths(got.Resolved)); diff != "" {
 		t.Fatalf("resolved paths mismatch (-want +got):\n%s", diff)
 	}
+	if len(got.Unknown) != 0 {
+		t.Fatalf("unknown paths = %v, want none", diagnosticPaths(got.Unknown))
+	}
 	if lookup.calls != 1 {
 		t.Fatalf("FindEndedSessionIDs() calls = %d, want 1", lookup.calls)
+	}
+}
+
+func TestClassifyHookCancellationDiagnosticsUnknownStore(t *testing.T) {
+	const currentDBPath = "/store/current.db"
+	endedID := types.SessionID("ended-session")
+	records := []hookCancellationDiagnostic{
+		// Marker written against a different --db-path store: the session
+		// lookup below would happily report it "ended" if queried, but it
+		// must never be classified from the wrong store's evidence.
+		{SessionID: endedID.String(), DBPath: "/store/other.db", Path: "other-store.json"},
+		// Marker predating db_path recording: also unknown, never actionable.
+		{SessionID: "legacy-session", DBPath: "", Path: "legacy.json"},
+	}
+	lookup := &hookDiagnosticSessionLookupStub{ended: map[types.SessionID]struct{}{endedID: {}}}
+
+	got, err := classifyHookCancellationDiagnostics(context.Background(), records, lookup, currentDBPath)
+	if err != nil {
+		t.Fatalf("classifyHookCancellationDiagnostics() error = %v", err)
+	}
+	if len(got.Actionable) != 0 {
+		t.Fatalf("actionable paths = %v, want none", diagnosticPaths(got.Actionable))
+	}
+	if len(got.Resolved) != 0 {
+		t.Fatalf("resolved paths = %v, want none", diagnosticPaths(got.Resolved))
+	}
+	if diff := cmp.Diff([]string{"other-store.json", "legacy.json"}, diagnosticPaths(got.Unknown)); diff != "" {
+		t.Fatalf("unknown paths mismatch (-want +got):\n%s", diff)
+	}
+	// Records with no bearing on the current store never need a session
+	// lookup at all.
+	if lookup.calls != 0 {
+		t.Fatalf("FindEndedSessionIDs() calls = %d, want 0", lookup.calls)
+	}
+}
+
+func TestClassifyHookCancellationDiagnosticsCurrentDBPathEmpty(t *testing.T) {
+	records := []hookCancellationDiagnostic{
+		{SessionID: "some-session", DBPath: "/store/a.db", Path: "a.json"},
+	}
+	lookup := &hookDiagnosticSessionLookupStub{}
+
+	got, err := classifyHookCancellationDiagnostics(context.Background(), records, lookup, "")
+	if err != nil {
+		t.Fatalf("classifyHookCancellationDiagnostics() error = %v", err)
+	}
+	if len(got.Actionable) != 0 || len(got.Resolved) != 0 {
+		t.Fatalf("expected everything unknown when current db path is unresolved, got actionable=%v resolved=%v", got.Actionable, got.Resolved)
+	}
+	if diff := cmp.Diff([]string{"a.json"}, diagnosticPaths(got.Unknown)); diff != "" {
+		t.Fatalf("unknown paths mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -82,10 +140,151 @@ func TestResolvedHookCancellationDiagnosticFix(t *testing.T) {
 	}
 }
 
+func TestAgedHookCancellationDiagnostics(t *testing.T) {
+	cutoff := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	records := []hookCancellationDiagnostic{
+		{Path: "old.json", StartedAt: cutoff.Add(-time.Hour)},
+		{Path: "new.json", StartedAt: cutoff.Add(time.Hour)},
+	}
+	got := agedHookCancellationDiagnostics(records, cutoff)
+	if diff := cmp.Diff([]string{"old.json"}, diagnosticPaths(got)); diff != "" {
+		t.Fatalf("aged paths mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBeginHookCancellationDiagnosticRecordsDBPathAndPhase(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+
+	path, err := beginHookCancellationDiagnostic("claude", "SessionEnd", "cmd", types.SessionID("session-a"), "", "/store/current.db")
+	if err != nil {
+		t.Fatalf("beginHookCancellationDiagnostic() error = %v", err)
+	}
+	record := readHookCancellationDiagnosticForTest(t, path)
+	if record.DBPath != "/store/current.db" {
+		t.Fatalf("db_path = %q, want /store/current.db", record.DBPath)
+	}
+	if record.Phase != "" {
+		t.Fatalf("phase = %q, want empty before any update", record.Phase)
+	}
+	if record.Status != hookCancellationDiagnosticStatusStarted {
+		t.Fatalf("status = %q, want started", record.Status)
+	}
+
+	if err := updateHookCancellationDiagnosticPhase(path, hookCancellationDiagnosticPhaseWorkspaceResolved); err != nil {
+		t.Fatalf("updateHookCancellationDiagnosticPhase(workspace_resolved) error = %v", err)
+	}
+	record = readHookCancellationDiagnosticForTest(t, path)
+	if record.Phase != hookCancellationDiagnosticPhaseWorkspaceResolved {
+		t.Fatalf("phase = %q, want %q", record.Phase, hookCancellationDiagnosticPhaseWorkspaceResolved)
+	}
+
+	if err := updateHookCancellationDiagnosticPhase(path, hookCancellationDiagnosticPhaseStoreInitialized); err != nil {
+		t.Fatalf("updateHookCancellationDiagnosticPhase(store_initialized) error = %v", err)
+	}
+	record = readHookCancellationDiagnosticForTest(t, path)
+	if record.Phase != hookCancellationDiagnosticPhaseStoreInitialized {
+		t.Fatalf("phase = %q, want %q", record.Phase, hookCancellationDiagnosticPhaseStoreInitialized)
+	}
+	if record.DBPath != "/store/current.db" {
+		t.Fatalf("db_path after phase update = %q, want unchanged /store/current.db", record.DBPath)
+	}
+}
+
+func TestBeginHookCancellationDiagnosticGCByCap(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+
+	var paths []string
+	for i := 0; i < hookCancellationDiagnosticRetentionCap+5; i++ {
+		sessionID := types.SessionID(fmt.Sprintf("session-%02d", i))
+		path, err := beginHookCancellationDiagnostic("claude", "SessionEnd", "cmd", sessionID, "", "/store/current.db")
+		if err != nil {
+			t.Fatalf("beginHookCancellationDiagnostic() iteration %d error = %v", i, err)
+		}
+		paths = append(paths, path)
+	}
+
+	scan, err := scanHookCancellationDiagnostics("claude", "SessionEnd", "")
+	if err != nil {
+		t.Fatalf("scanHookCancellationDiagnostics() error = %v", err)
+	}
+	if len(scan.Records) != hookCancellationDiagnosticRetentionCap {
+		t.Fatalf("markers remaining = %d, want cap %d", len(scan.Records), hookCancellationDiagnosticRetentionCap)
+	}
+	// The most recently written marker must survive GC.
+	if _, err := os.Stat(paths[len(paths)-1]); err != nil {
+		t.Fatalf("latest marker missing after GC: %v", err)
+	}
+	// The earliest marker must have been GC'd once the cap is exceeded.
+	if _, err := os.Stat(paths[0]); !os.IsNotExist(err) {
+		t.Fatalf("earliest marker survived GC beyond cap: err=%v", err)
+	}
+}
+
+func TestBeginHookCancellationDiagnosticGCByWindow(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+
+	diagnosticsDir := filepath.Join(stateDir, hookDiagnosticsDirName)
+	if err := os.MkdirAll(diagnosticsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	staleRecord := hookCancellationDiagnostic{
+		SchemaVersion: hookCancellationDiagnosticSchemaVersion,
+		Client:        "claude",
+		HostEvent:     "SessionEnd",
+		SessionID:     "stale-session",
+		DBPath:        "/store/current.db",
+		Status:        hookCancellationDiagnosticStatusStarted,
+		StartedAt:     time.Now().UTC().Add(-hookCancellationDiagnosticRetentionWindow - time.Hour),
+	}
+	stalePath := filepath.Join(diagnosticsDir, "stale-marker.json")
+	writeHookCancellationDiagnosticForTest(t, stalePath, staleRecord)
+
+	if _, err := beginHookCancellationDiagnostic("claude", "SessionEnd", "cmd", types.SessionID("fresh-session"), "", "/store/current.db"); err != nil {
+		t.Fatalf("beginHookCancellationDiagnostic() error = %v", err)
+	}
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale marker survived begin-time GC: err=%v", err)
+	}
+	scan, err := scanHookCancellationDiagnostics("claude", "SessionEnd", "")
+	if err != nil {
+		t.Fatalf("scanHookCancellationDiagnostics() error = %v", err)
+	}
+	if len(scan.Records) != 1 {
+		t.Fatalf("markers remaining = %d, want 1 (only the fresh marker)", len(scan.Records))
+	}
+}
+
 func diagnosticPaths(records []hookCancellationDiagnostic) []string {
 	paths := make([]string, 0, len(records))
 	for _, record := range records {
 		paths = append(paths, record.Path)
 	}
 	return paths
+}
+
+func readHookCancellationDiagnosticForTest(t *testing.T, path string) hookCancellationDiagnostic {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	var record hookCancellationDiagnostic
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("Unmarshal(%s) error = %v", path, err)
+	}
+	return record
+}
+
+func writeHookCancellationDiagnosticForTest(t *testing.T, path string, record hookCancellationDiagnostic) {
+	t.Helper()
+	encoded, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
 }

--- a/presentation/cli/hook_session.go
+++ b/presentation/cli/hook_session.go
@@ -188,6 +188,10 @@ func (c *RootCLI) runHookSession(
 			return err
 		}
 
+		resolvedDBPath, err := resolveDBPath(dbPath)
+		if err != nil {
+			return err
+		}
 		hookCancellationDiagnosticPath := ""
 		shouldTrackClaudeCancellation := strings.TrimSpace(client) == "claude"
 		if shouldTrackClaudeCancellation {
@@ -197,6 +201,7 @@ func (c *RootCLI) runHookSession(
 				"'traceary' 'hook' 'session' 'claude' 'end'",
 				sessionID,
 				"",
+				resolvedDBPath,
 			); err != nil {
 				slog.Debug("hook session-end cancellation diagnostic failed", "client", client, "session_id", sessionID, "error", err)
 			} else {
@@ -211,14 +216,18 @@ func (c *RootCLI) runHookSession(
 			if err := updateHookCancellationDiagnosticWorkspace(hookCancellationDiagnosticPath, workspace); err != nil {
 				slog.Debug("hook session-end cancellation diagnostic workspace update failed", "client", client, "session_id", sessionID, "path", hookCancellationDiagnosticPath, "error", err)
 			}
-		}
-		resolvedDBPath, err := resolveDBPath(dbPath)
-		if err != nil {
-			return err
+			if err := updateHookCancellationDiagnosticPhase(hookCancellationDiagnosticPath, hookCancellationDiagnosticPhaseWorkspaceResolved); err != nil {
+				slog.Debug("hook session-end cancellation diagnostic phase update failed", "client", client, "session_id", sessionID, "path", hookCancellationDiagnosticPath, "error", err)
+			}
 		}
 		c.applyDatabasePath(resolvedDBPath)
 		if err := c.storeManagement.Initialize(ctx); err != nil {
 			return xerrors.Errorf("failed to initialize store: %w", err)
+		}
+		if shouldTrackClaudeCancellation {
+			if err := updateHookCancellationDiagnosticPhase(hookCancellationDiagnosticPath, hookCancellationDiagnosticPhaseStoreInitialized); err != nil {
+				slog.Debug("hook session-end cancellation diagnostic phase update failed", "client", client, "session_id", sessionID, "path", hookCancellationDiagnosticPath, "error", err)
+			}
 		}
 		if _, err := c.session.End(ctx, types.Client("hook"), agent, sessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to record hook session end: %w", err)

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -284,27 +284,28 @@ func (s *eventUsecaseStub) HydrateCommandAudits(_ context.Context, events []*mod
 
 // sessionUsecaseStub implements usecase.SessionUsecase for testing.
 type sessionUsecaseStub struct {
-	startEvent     *model.Event
-	startErr       error
-	endEvent       *model.Event
-	endErr         error
-	labelErr       error
-	listResult     []apptypes.SessionSummary
-	listErr        error
-	listCriteria   apptypes.SessionListCriteria
-	treeResult     []apptypes.SessionSummary
-	treeErr        error
-	lineageResult  []apptypes.SessionSummary
-	lineageErr     error
-	activeEvent    *model.Event
-	activeErr      error
-	activeCriteria apptypes.SessionLookupCriteria
-	latestEvent    *model.Event
-	latestErr      error
-	latestCriteria apptypes.SessionLookupCriteria
-	handoff        types.Optional[apptypes.HandoffSummary]
-	handoffErr     error
-	setModelCalls  map[types.SessionID]string
+	startEvent      *model.Event
+	startErr        error
+	endEvent        *model.Event
+	endErr          error
+	labelErr        error
+	listResult      []apptypes.SessionSummary
+	listErr         error
+	listCriteria    apptypes.SessionListCriteria
+	treeResult      []apptypes.SessionSummary
+	treeErr         error
+	lineageResult   []apptypes.SessionSummary
+	lineageErr      error
+	activeEvent     *model.Event
+	activeErr       error
+	activeCriteria  apptypes.SessionLookupCriteria
+	latestEvent     *model.Event
+	latestErr       error
+	latestCriteria  apptypes.SessionLookupCriteria
+	handoff         types.Optional[apptypes.HandoffSummary]
+	handoffErr      error
+	setModelCalls   map[types.SessionID]string
+	endedSessionIDs map[types.SessionID]struct{}
 
 	startCall struct {
 		client          types.Client
@@ -429,6 +430,9 @@ func (s *sessionUsecaseStub) List(_ context.Context, criteria apptypes.SessionLi
 	return s.listResult, s.listErr
 }
 func (s *sessionUsecaseStub) FindEndedSessionIDs(_ context.Context, _ []types.SessionID) (map[types.SessionID]struct{}, error) {
+	if s.endedSessionIDs != nil {
+		return s.endedSessionIDs, nil
+	}
 	return map[types.SessionID]struct{}{}, nil
 }
 func (s *sessionUsecaseStub) Tree(_ context.Context, _ types.Workspace, _ types.SessionID, _ int) ([]apptypes.SessionSummary, error) {


### PR DESCRIPTION
## Summary

SessionEnd diagnostics now record `db_path` and a phase breadcrumb. Classification is three-way (`Resolved` / `Actionable` / `Unknown`); `Unknown` is never treated as actionable. `beginHookCancellationDiagnostic` GCs same-(client, host_event) markers past a retention cap. `doctor --fix` removes Resolved and aged Unknown markers.

## Why

Dogfood 0.39.0 left thousands of `status=started` SessionEnd markers. Scratch `--db-path` doctor marked every historical file Actionable.

Closes #1972

Leaves parent #1968 open.

## Test plan

- [x] `go test ./presentation/cli/ -run 'HookCancellation|SessionEnd|Diagnostic|classifyHook'`
- [x] `go tool golangci-lint run ./presentation/cli/...`