### PR TITLE
fix: retry Grok transcript jobs instead of terminal unavailable

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -385,7 +385,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 	)
 	report.Checks = append(report.Checks, c.inspectHookMemoryExtractDiagnostics(time.Now().UTC()))
 	report.Checks = append(report.Checks, c.inspectMemoryInboxSaturation(ctx))
-	report.Checks = append(report.Checks, inspectHookGrokTranscriptDiagnostics(time.Now().UTC()))
+	report.Checks = append(report.Checks, c.inspectHookGrokTranscriptDiagnostics(time.Now().UTC()))
 
 	for _, targetClient := range resolvedClients {
 		if targetClient == "kimi" {

--- a/presentation/cli/hook_grok_test.go
+++ b/presentation/cli/hook_grok_test.go
@@ -529,6 +529,78 @@ func TestRootCLI_HookGrokTranscriptWorkerRecordsDelayedFinalTurnExactlyOnce(t *t
 	}
 }
 
+func TestRootCLI_HookGrokTranscriptWorkerRequeuesAfterDelayedWindowThenRecordsOnRelaunch(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-requeue-delayed")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	transcriptPath := filepath.Join(t.TempDir(), "updates.jsonl")
+	initial := `{"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"prompt"}},"_meta":{"promptId":"prompt-contract-probe-1"}}}` + "\n"
+	if err := os.WriteFile(transcriptPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial transcript: %v", err)
+	}
+	payload := grokFixtureWithField(t, "stop.json", "transcriptPath", transcriptPath)
+	eventStub := &eventUsecaseStub{}
+	jobPath := ""
+	runGrokHook(t, "stop", payload, eventStub, &sessionUsecaseStub{}, cli.WithHookGrokTranscriptLauncher(func(path string) error {
+		jobPath = path
+		return nil
+	}))
+	if jobPath == "" {
+		t.Fatal("Stop did not enqueue transcript job")
+	}
+
+	// The first worker run exhausts the in-process delayed window (the
+	// transcript never becomes ready) and must requeue rather than finalize
+	// unavailable (#1973).
+	worker := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{}), cli.WithEvent(eventStub)).Command()
+	worker.SetOut(&bytes.Buffer{})
+	worker.SetErr(&bytes.Buffer{})
+	worker.SetArgs([]string{"hook", "grok", "transcript-worker", "--job", jobPath})
+	if err := worker.Execute(); err == nil {
+		t.Fatal("Execute(delayed-exhausted worker) error = nil, want a pending-requeue error")
+	}
+	if _, err := os.Stat(jobPath); err != nil {
+		t.Fatalf("requeued job missing after delayed-window exhaustion: %v", err)
+	}
+	terminals, err := filepath.Glob(filepath.Join(stateDir, "grok-transcript-terminal", "*.json"))
+	if err != nil || len(terminals) != 0 {
+		t.Fatalf("terminal disposition files = %v, %v; want none after a requeue", terminals, err)
+	}
+
+	// The host later appends the final message; a second worker run (as a
+	// later drain/relaunch would trigger) now records it.
+	final := `{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"final answer"}},"_meta":{"promptId":"prompt-contract-probe-1"}}}` + "\n"
+	file, err := os.OpenFile(transcriptPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	if _, err := file.WriteString(final); err != nil {
+		t.Fatalf("append final transcript: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close transcript: %v", err)
+	}
+
+	worker2 := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{}), cli.WithEvent(eventStub)).Command()
+	worker2.SetOut(&bytes.Buffer{})
+	worker2.SetErr(&bytes.Buffer{})
+	worker2.SetArgs([]string{"hook", "grok", "transcript-worker", "--job", jobPath})
+	if err := worker2.Execute(); err != nil {
+		t.Fatalf("Execute(relaunched worker) error = %v", err)
+	}
+	if got, want := apptypes.ExtractPlainBody(eventStub.logCall.message), "final answer"; got != want {
+		t.Fatalf("transcript body = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(jobPath); !os.IsNotExist(err) {
+		t.Fatalf("recorded job still exists: %v", err)
+	}
+	terminals, err = filepath.Glob(filepath.Join(stateDir, "grok-transcript-terminal", "*.json"))
+	if err != nil || len(terminals) != 1 {
+		t.Fatalf("terminal disposition files after recording = %v, %v; want one", terminals, err)
+	}
+}
+
 func TestRootCLI_HookGrokStopDoesNotRelaunchTerminalTranscriptDelivery(t *testing.T) {
 	for _, disposition := range []string{"recorded", "unavailable", "malformed", "cancelled"} {
 		t.Run(disposition, func(t *testing.T) {
@@ -541,8 +613,15 @@ func TestRootCLI_HookGrokStopDoesNotRelaunchTerminalTranscriptDelivery(t *testin
 			if disposition == "malformed" {
 				transcript = "not-json\n"
 			}
-			if err := os.WriteFile(transcriptPath, []byte(transcript), 0o600); err != nil {
-				t.Fatalf("write transcript: %v", err)
+			// "unavailable" must stay a genuinely non-retryable, immediate
+			// terminal classification (unopenable path), not a transcript
+			// that simply never reaches a final agent message: exhausting the
+			// in-process delayed window now requeues instead of finalizing
+			// unavailable (#1973).
+			if disposition != "unavailable" {
+				if err := os.WriteFile(transcriptPath, []byte(transcript), 0o600); err != nil {
+					t.Fatalf("write transcript: %v", err)
+				}
 			}
 			payload := grokFixtureWithField(t, "stop.json", "transcriptPath", transcriptPath)
 			jobPath := ""

--- a/presentation/cli/hook_grok_transcript_queue.go
+++ b/presentation/cli/hook_grok_transcript_queue.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,6 +26,23 @@ const (
 	hookGrokTranscriptTerminalSchemaVersion = 1
 	hookGrokTranscriptRetryCount            = 20
 	hookGrokTranscriptRetryInterval         = 100 * time.Millisecond
+	// hookGrokTranscriptMaxAttempts is the total worker-run ceiling across
+	// relaunches. Exhausting the in-process delayed window bumps Attempts and
+	// requeues rather than finalizing; only reaching this ceiling (or a
+	// genuinely non-retryable classification) is terminal (#1973).
+	hookGrokTranscriptMaxAttempts = 10
+	// hookGrokTranscriptTerminalRetention is how long a terminal disposition
+	// marker remains visible to doctor before opportunistic GC removes it.
+	hookGrokTranscriptTerminalRetention = 24 * time.Hour
+	// hookGrokTranscriptRequeueBackoff avoids relaunching a job the drain just
+	// attempted moments ago.
+	hookGrokTranscriptRequeueBackoff = 2 * time.Second
+	// hookGrokTranscriptDrainBatchLimit caps how many other-session jobs and
+	// terminal markers a later hook may launch or GC per opportunistic drain.
+	hookGrokTranscriptDrainBatchLimit = 3
+	// hookGrokTranscriptDoctorFixLimit is the larger batch used by doctor --fix.
+	hookGrokTranscriptDoctorFixLimit = 50
+	hookGrokTranscriptErrorLimit     = 1024
 )
 
 type hookGrokTranscriptJob struct {
@@ -34,6 +53,7 @@ type hookGrokTranscriptJob struct {
 	Attempts      int       `json:"attempts,omitempty"`
 	LastAttemptAt time.Time `json:"last_attempt_at,omitempty"`
 	LastError     string    `json:"last_error,omitempty"`
+	Path          string    `json:"-"`
 }
 
 type hookGrokTranscriptTerminal struct {
@@ -73,7 +93,7 @@ func scanHookGrokTranscriptJobs() ([]hookGrokTranscriptJob, []string, error) {
 	return jobs, unreadable, nil
 }
 
-func inspectHookGrokTranscriptDiagnostics(now time.Time) doctorCheck {
+func (c *RootCLI) inspectHookGrokTranscriptDiagnostics(now time.Time) doctorCheck {
 	const name = "hook-grok-transcript"
 	jobs, unreadable, err := scanHookGrokTranscriptJobs()
 	if err != nil {
@@ -98,6 +118,11 @@ func inspectHookGrokTranscriptDiagnostics(now time.Time) doctorCheck {
 	}
 	terminalCounts := map[string]int{}
 	for _, terminal := range terminals {
+		// A terminal marker past retention is already GC-eligible; it is not
+		// outstanding work an operator needs to act on.
+		if hookGrokTranscriptTerminalReadyForGC(terminal, now) {
+			continue
+		}
 		terminalCounts[terminal.Disposition]++
 	}
 	partial := terminalCounts["unavailable"] + terminalCounts["malformed"] + terminalCounts["cancelled"]
@@ -122,8 +147,121 @@ func inspectHookGrokTranscriptDiagnostics(now time.Time) doctorCheck {
 			"未処理の Grok transcript job が %d 件、以前失敗した job が %d 件、読めない job が %d 件、partial final-turn disposition が %d 件（unavailable %d 件、malformed %d 件、cancelled %d 件、読めない disposition marker %d 件）あります。最古の経過時間は %s です",
 			len(jobs), failed, len(unreadable), partial, terminalCounts["unavailable"], terminalCounts["malformed"], terminalCounts["cancelled"], terminalUnreadable, oldestAge.Round(time.Second),
 		),
-		Hint: Localize("a terminal final-turn disposition is partial coverage and has no retry job; enable TRACEARY_HOOK_DEBUG for the next turn. Remove a pending job only after confirming it is stale", "終端 final-turn disposition は partial coverage であり retry job はありません。次の turn で TRACEARY_HOOK_DEBUG を有効にしてください。未処理 job は不要と確認してからだけ削除してください"),
+		Hint: Localize("later hooks drain a bounded oldest-first batch across sessions and GC terminal dispositions past retention. Run `traceary doctor --fix` to force a larger drain, or enable TRACEARY_HOOK_DEBUG for the next turn", "後続 hook は oldest-first の bounded batch で queue 全体を drain し、retention を過ぎた終端 disposition を GC します。大きめに drain するには `traceary doctor --fix` を使い、次の turn で TRACEARY_HOOK_DEBUG を有効にしてください"),
+		FixCommand:       "traceary doctor --fix",
+		AutoFixAvailable: true,
+		FixFunc: func(_ context.Context, dryRun bool) (string, error) {
+			if dryRun {
+				pending, _, scanErr := scanHookGrokTranscriptJobs()
+				if scanErr != nil {
+					return "", scanErr
+				}
+				return localizef("would drain/GC up to %d pending Grok transcript job(s)/terminal marker(s)", "未処理 Grok transcript job/terminal marker 最大 %d 件を drain/GC します", min(len(pending)+len(terminals), hookGrokTranscriptDoctorFixLimit)), nil
+			}
+			launched, removed := c.drainHookGrokTranscriptQueue(time.Now().UTC(), hookGrokTranscriptDoctorFixLimit)
+			return localizef("drained Grok transcript queue: launched=%d removed=%d", "Grok transcript queue を drain しました: launched=%d removed=%d", launched, removed), nil
+		},
 	}
+}
+
+// drainHookGrokTranscriptQueue relaunches pending jobs (oldest first) that are
+// not within the requeue backoff window, and garbage-collects terminal
+// disposition markers past retention plus their leftover `.lock` sidecars.
+// skipPaths are ignored (e.g. a job just launched by scheduleHookGrokTranscript).
+// Returns launch and removal counts.
+func (c *RootCLI) drainHookGrokTranscriptQueue(now time.Time, limit int, skipPaths ...string) (launched, removed int) {
+	if limit <= 0 {
+		return 0, 0
+	}
+	removed = gcHookGrokTranscriptTerminals(now, limit)
+	if removed >= limit {
+		return 0, removed
+	}
+	skip := make(map[string]struct{}, len(skipPaths))
+	for _, p := range skipPaths {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			skip[trimmed] = struct{}{}
+		}
+	}
+	jobs, _, err := scanHookGrokTranscriptJobs()
+	if err != nil || len(jobs) == 0 {
+		return 0, removed
+	}
+	launcher := c.hookGrokTranscriptLauncher
+	if launcher == nil {
+		launcher = launchDetachedHookGrokTranscriptWorker
+	}
+	// scanHookGrokTranscriptJobs already returns oldest first.
+	for _, job := range jobs {
+		if launched+removed >= limit {
+			break
+		}
+		if strings.TrimSpace(job.Path) == "" {
+			continue
+		}
+		if _, ok := skip[job.Path]; ok {
+			continue
+		}
+		if !job.LastAttemptAt.IsZero() && now.Sub(job.LastAttemptAt) < hookGrokTranscriptRequeueBackoff {
+			continue
+		}
+		if err := launcher(job.Path); err != nil {
+			slog.Debug("hook Grok transcript drain launch failed", "job", job.Path, "error", err)
+			continue
+		}
+		launched++
+	}
+	return launched, removed
+}
+
+func gcHookGrokTranscriptTerminals(now time.Time, limit int) int {
+	dir, err := hookGrokTranscriptTerminalDir()
+	if err != nil {
+		return 0
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		return 0
+	}
+	queueDir, err := hookGrokTranscriptQueueDir()
+	if err != nil {
+		return 0
+	}
+	removed := 0
+	for _, entry := range entries {
+		if removed >= limit {
+			break
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		terminalPath := filepath.Join(dir, entry.Name())
+		terminal, readErr := readHookGrokTranscriptTerminal(terminalPath)
+		if readErr != nil {
+			continue
+		}
+		if !hookGrokTranscriptTerminalReadyForGC(terminal, now) {
+			continue
+		}
+		if err := os.Remove(terminalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			slog.Debug("hook Grok transcript terminal GC failed", "terminal", terminalPath, "error", err)
+			continue
+		}
+		_ = os.Remove(filepath.Join(queueDir, entry.Name()+".lock"))
+		removed++
+	}
+	return removed
+}
+
+func hookGrokTranscriptJobIsTerminal(job hookGrokTranscriptJob) bool {
+	return job.Attempts >= hookGrokTranscriptMaxAttempts
+}
+
+func hookGrokTranscriptTerminalReadyForGC(terminal hookGrokTranscriptTerminal, now time.Time) bool {
+	return !terminal.OccurredAt.Add(hookGrokTranscriptTerminalRetention).After(now)
 }
 
 func (c *RootCLI) newHookGrokTranscriptWorkerCommand() *cobra.Command {
@@ -143,19 +281,25 @@ func (c *RootCLI) newHookGrokTranscriptWorkerCommand() *cobra.Command {
 }
 
 func (c *RootCLI) scheduleHookGrokTranscript(payload []byte, dbPath string) error {
-	jobPath, shouldLaunch, err := enqueueHookGrokTranscript(payload, dbPath, time.Now().UTC())
+	now := time.Now().UTC()
+	jobPath, shouldLaunch, err := enqueueHookGrokTranscript(payload, dbPath, now)
 	if err != nil {
 		return err
 	}
-	if !shouldLaunch {
-		return nil
+	if shouldLaunch {
+		launcher := c.hookGrokTranscriptLauncher
+		if launcher == nil {
+			launcher = launchDetachedHookGrokTranscriptWorker
+		}
+		if err := launcher(jobPath); err != nil {
+			return xerrors.Errorf("failed to launch Grok transcript worker: %w", err)
+		}
 	}
-	launcher := c.hookGrokTranscriptLauncher
-	if launcher == nil {
-		launcher = launchDetachedHookGrokTranscriptWorker
-	}
-	if err := launcher(jobPath); err != nil {
-		return xerrors.Errorf("failed to launch Grok transcript worker: %w", err)
+	// Queue-wide drain: relaunch/GC jobs and terminal markers for *other*
+	// sessions. A durable job that never becomes terminal (e.g. its session
+	// ended) otherwise has no later trigger; this is the recovery path.
+	if launched, removed := c.drainHookGrokTranscriptQueue(now, hookGrokTranscriptDrainBatchLimit, jobPath); launched > 0 || removed > 0 {
+		slog.Debug("hook Grok transcript queue drain", "launched", launched, "removed", removed)
 	}
 	return nil
 }
@@ -269,13 +413,16 @@ func (c *RootCLI) runHookGrokTranscriptWorker(ctx context.Context, jobPath strin
 			// log changes; err==nil is not a write (#1713 / #1681).
 			recorded, _, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), grokHookClient, job.DBPath, blocks)
 			if err != nil {
-				return c.failHookGrokTranscriptJob(resolvedJobPath, job, err)
+				return c.requeueHookGrokTranscriptJob(resolvedJobPath, job, err)
 			}
 			if recorded {
 				return finalizeHookGrokTranscriptJob(resolvedJobPath, "recorded")
 			}
-			return c.failHookGrokTranscriptJob(resolvedJobPath, job, xerrors.Errorf("Grok transcript was ready but was not persisted"))
+			return c.requeueHookGrokTranscriptJob(resolvedJobPath, job, xerrors.Errorf("Grok transcript was ready but was not persisted"))
 		}
+		// unavailable/malformed here means the queue path is empty/unopenable
+		// or the wire log itself failed to parse — genuinely non-retryable
+		// classifications, not "still delayed" (#1973).
 		if disposition == grokTranscriptUnavailable || disposition == grokTranscriptMalformed {
 			return finalizeHookGrokTranscriptJob(resolvedJobPath, string(disposition))
 		}
@@ -285,7 +432,10 @@ func (c *RootCLI) runHookGrokTranscriptWorker(ctx context.Context, jobPath strin
 		case <-time.After(hookGrokTranscriptRetryInterval):
 		}
 	}
-	return finalizeHookGrokTranscriptJob(resolvedJobPath, "unavailable")
+	// Exhausted the in-process delayed window without the transcript becoming
+	// ready. This is not evidence of a permanent failure, so requeue instead
+	// of finalizing unavailable; a later drain or Stop relaunches the worker.
+	return c.requeueHookGrokTranscriptJob(resolvedJobPath, job, xerrors.Errorf("Grok transcript remained delayed after %d attempts", hookGrokTranscriptRetryCount))
 }
 
 func finalizeHookGrokTranscriptJob(jobPath, disposition string) error {
@@ -340,6 +490,7 @@ func readHookGrokTranscriptJob(path string) (hookGrokTranscriptJob, error) {
 	if job.SchemaVersion != hookGrokTranscriptJobSchemaVersion || strings.TrimSpace(job.Payload) == "" || job.RequestedAt.IsZero() || job.Attempts < 0 {
 		return hookGrokTranscriptJob{}, xerrors.Errorf("Grok transcript job has an unsupported shape")
 	}
+	job.Path = path
 	return job, nil
 }
 
@@ -484,14 +635,31 @@ func writeHookGrokTranscriptJob(path string, job hookGrokTranscriptJob) error {
 	return nil
 }
 
-func (c *RootCLI) failHookGrokTranscriptJob(path string, job hookGrokTranscriptJob, cause error) error {
+// requeueHookGrokTranscriptJob bumps Attempts and leaves the job pending for a
+// later drain to relaunch, unless the attempt ceiling is now reached, in
+// which case it finalizes the job as terminal unavailable.
+func (c *RootCLI) requeueHookGrokTranscriptJob(path string, job hookGrokTranscriptJob, cause error) error {
 	job.Attempts++
 	job.LastAttemptAt = time.Now().UTC()
-	job.LastError = "transcript unavailable"
+	job.LastError = truncateHookGrokTranscriptError(cause.Error())
+	if hookGrokTranscriptJobIsTerminal(job) {
+		if err := finalizeHookGrokTranscriptJob(path, "unavailable"); err != nil {
+			return errors.Join(cause, err)
+		}
+		return xerrors.Errorf("Grok transcript job exhausted retry attempts: %w", cause)
+	}
 	if err := writeHookGrokTranscriptJob(path, job); err != nil {
 		return errors.Join(cause, err)
 	}
 	return xerrors.Errorf("Grok transcript job remains pending: %w", cause)
+}
+
+func truncateHookGrokTranscriptError(message string) string {
+	message = strings.TrimSpace(message)
+	if len(message) <= hookGrokTranscriptErrorLimit {
+		return message
+	}
+	return fmt.Sprintf("%s...", message[:hookGrokTranscriptErrorLimit-3])
 }
 
 func launchDetachedHookGrokTranscriptWorker(jobPath string) error {

--- a/presentation/cli/hook_grok_transcript_queue_internal_test.go
+++ b/presentation/cli/hook_grok_transcript_queue_internal_test.go
@@ -1,11 +1,14 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/xerrors"
 )
 
 func TestInspectHookGrokTranscriptDiagnosticsReportsPendingFailureMetadata(t *testing.T) {
@@ -33,7 +36,7 @@ func TestInspectHookGrokTranscriptDiagnosticsReportsPendingFailureMetadata(t *te
 		t.Fatalf("WriteFile(broken job) error = %v", err)
 	}
 
-	check := inspectHookGrokTranscriptDiagnostics(now)
+	check := (&RootCLI{}).inspectHookGrokTranscriptDiagnostics(now)
 	if check.Name != "hook-grok-transcript" || check.Status != doctorStatusWarn {
 		t.Fatalf("check = %+v, want warning", check)
 	}
@@ -51,7 +54,7 @@ func TestInspectHookGrokTranscriptDiagnosticsReportsPendingFailureMetadata(t *te
 
 func TestInspectHookGrokTranscriptDiagnosticsPassesWithoutJobs(t *testing.T) {
 	t.Setenv(hookStateDirEnvKey, t.TempDir())
-	check := inspectHookGrokTranscriptDiagnostics(time.Now().UTC())
+	check := (&RootCLI{}).inspectHookGrokTranscriptDiagnostics(time.Now().UTC())
 	if check.Status != doctorStatusPass {
 		t.Fatalf("check = %+v, want pass", check)
 	}
@@ -73,7 +76,7 @@ func TestInspectHookGrokTranscriptDiagnosticsReportsBodyFreeTerminalPartialState
 		t.Fatalf("WriteFile(broken terminal) error = %v", err)
 	}
 
-	check := inspectHookGrokTranscriptDiagnostics(now)
+	check := (&RootCLI{}).inspectHookGrokTranscriptDiagnostics(now)
 	if check.Status != doctorStatusWarn {
 		t.Fatalf("check = %+v, want warning", check)
 	}
@@ -98,7 +101,7 @@ func TestInspectHookGrokTranscriptDiagnosticsPassesWithRecordedTerminalOnly(t *t
 		t.Fatalf("writeHookGrokTranscriptTerminal() error = %v", err)
 	}
 
-	check := inspectHookGrokTranscriptDiagnostics(now)
+	check := (&RootCLI{}).inspectHookGrokTranscriptDiagnostics(now)
 	if check.Status != doctorStatusPass {
 		t.Fatalf("check = %+v, want pass for recorded-only terminal", check)
 	}
@@ -131,5 +134,211 @@ func TestScanHookGrokTranscriptJobsRejectsInvalidMetadata(t *testing.T) {
 	}
 	if len(jobs) != 0 || len(unreadable) != 2 {
 		t.Fatalf("jobs=%d unreadable=%d, want zero jobs and two unreadable", len(jobs), len(unreadable))
+	}
+}
+
+func TestRequeueHookGrokTranscriptJobRequeuesBeforeMaxAttempts(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	payload := []byte(`{"session_id":"session-a","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
+	path, _, err := enqueueHookGrokTranscript(payload, "", now)
+	if err != nil {
+		t.Fatalf("enqueueHookGrokTranscript() error = %v", err)
+	}
+	job, err := readHookGrokTranscriptJob(path)
+	if err != nil {
+		t.Fatalf("readHookGrokTranscriptJob() error = %v", err)
+	}
+
+	c := &RootCLI{}
+	if err := c.requeueHookGrokTranscriptJob(path, job, xerrors.New("transcript remained delayed")); err == nil {
+		t.Fatal("requeueHookGrokTranscriptJob() error = nil, want pending-requeue error")
+	}
+
+	requeued, err := readHookGrokTranscriptJob(path)
+	if err != nil {
+		t.Fatalf("readHookGrokTranscriptJob(requeued) error = %v", err)
+	}
+	if requeued.Attempts != 1 {
+		t.Fatalf("requeued.Attempts = %d, want 1", requeued.Attempts)
+	}
+	if requeued.LastAttemptAt.IsZero() {
+		t.Fatal("requeued.LastAttemptAt is zero, want set")
+	}
+	terminals, err := filepath.Glob(filepath.Join(stateDir, "grok-transcript-terminal", "*.json"))
+	if err != nil || len(terminals) != 0 {
+		t.Fatalf("terminal disposition files = %v, %v; want none while below the attempt ceiling", terminals, err)
+	}
+}
+
+func TestRequeueHookGrokTranscriptJobFinalizesAtMaxAttempts(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	payload := []byte(`{"session_id":"session-b","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
+	path, _, err := enqueueHookGrokTranscript(payload, "", now)
+	if err != nil {
+		t.Fatalf("enqueueHookGrokTranscript() error = %v", err)
+	}
+	job, err := readHookGrokTranscriptJob(path)
+	if err != nil {
+		t.Fatalf("readHookGrokTranscriptJob() error = %v", err)
+	}
+	job.Attempts = hookGrokTranscriptMaxAttempts - 1
+	if err := writeHookGrokTranscriptJob(path, job); err != nil {
+		t.Fatalf("writeHookGrokTranscriptJob() error = %v", err)
+	}
+
+	c := &RootCLI{}
+	if err := c.requeueHookGrokTranscriptJob(path, job, xerrors.New("transcript remained delayed")); err == nil {
+		t.Fatal("requeueHookGrokTranscriptJob() error = nil, want exhausted-attempts error")
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("job at attempt ceiling still exists: %v", err)
+	}
+	terminals, err := filepath.Glob(filepath.Join(stateDir, "grok-transcript-terminal", "*.json"))
+	if err != nil || len(terminals) != 1 {
+		t.Fatalf("terminal disposition files = %v, %v; want one", terminals, err)
+	}
+	terminal, err := readHookGrokTranscriptTerminal(terminals[0])
+	if err != nil {
+		t.Fatalf("readHookGrokTranscriptTerminal() error = %v", err)
+	}
+	if terminal.Disposition != "unavailable" {
+		t.Fatalf("terminal.Disposition = %q, want unavailable", terminal.Disposition)
+	}
+}
+
+func TestDrainHookGrokTranscriptQueueGCsTerminalsPastRetentionWithLockSidecars(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	name := strings.Repeat("a", 64) + ".json"
+	jobPath := filepath.Join(stateDir, "grok-transcript", name)
+	if err := writeHookGrokTranscriptTerminal(jobPath, "unavailable", now.Add(-hookGrokTranscriptTerminalRetention-time.Hour)); err != nil {
+		t.Fatalf("writeHookGrokTranscriptTerminal() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(jobPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(jobPath+".lock", []byte{}, 0o600); err != nil {
+		t.Fatalf("WriteFile(lock sidecar) error = %v", err)
+	}
+
+	c := &RootCLI{}
+	launched, removed := c.drainHookGrokTranscriptQueue(now, hookGrokTranscriptDoctorFixLimit)
+	if launched != 0 || removed != 1 {
+		t.Fatalf("drainHookGrokTranscriptQueue() = (%d, %d), want (0, 1)", launched, removed)
+	}
+	if _, err := os.Stat(jobPath + ".lock"); !os.IsNotExist(err) {
+		t.Fatalf("leftover .lock sidecar still exists: %v", err)
+	}
+	terminalDir, err := hookGrokTranscriptTerminalDir()
+	if err != nil {
+		t.Fatalf("hookGrokTranscriptTerminalDir() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(terminalDir, name)); !os.IsNotExist(err) {
+		t.Fatalf("terminal disposition marker still exists: %v", err)
+	}
+}
+
+func TestDrainHookGrokTranscriptQueueRelaunchesDueJobsAndSkipsBackoffAndSkipPaths(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+	dueJobPayload := []byte(`{"session_id":"due-session","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
+	duePath, _, err := enqueueHookGrokTranscript(dueJobPayload, "", now.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("enqueueHookGrokTranscript(due) error = %v", err)
+	}
+
+	skippedPayload := []byte(`{"session_id":"skipped-session","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
+	skippedPath, _, err := enqueueHookGrokTranscript(skippedPayload, "", now.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("enqueueHookGrokTranscript(skipped) error = %v", err)
+	}
+
+	backedOffPayload := []byte(`{"session_id":"backed-off-session","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
+	backedOffPath, _, err := enqueueHookGrokTranscript(backedOffPayload, "", now.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("enqueueHookGrokTranscript(backed off) error = %v", err)
+	}
+	backedOffJob, err := readHookGrokTranscriptJob(backedOffPath)
+	if err != nil {
+		t.Fatalf("readHookGrokTranscriptJob(backed off) error = %v", err)
+	}
+	backedOffJob.Attempts = 1
+	backedOffJob.LastAttemptAt = now.Add(-time.Second)
+	if err := writeHookGrokTranscriptJob(backedOffPath, backedOffJob); err != nil {
+		t.Fatalf("writeHookGrokTranscriptJob(backed off) error = %v", err)
+	}
+
+	var launchedPaths []string
+	c := &RootCLI{}
+	c.hookGrokTranscriptLauncher = func(path string) error {
+		launchedPaths = append(launchedPaths, path)
+		return nil
+	}
+
+	launched, removed := c.drainHookGrokTranscriptQueue(now, hookGrokTranscriptDoctorFixLimit, skippedPath)
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0", removed)
+	}
+	if launched != 1 {
+		t.Fatalf("launched = %d, want 1", launched)
+	}
+	if len(launchedPaths) != 1 || launchedPaths[0] != duePath {
+		t.Fatalf("launchedPaths = %v, want only the due job %q", launchedPaths, duePath)
+	}
+}
+
+func TestInspectHookGrokTranscriptDiagnosticsFixFuncDrainsAndGCs(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+	payload := []byte(`{"session_id":"fix-session","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
+	if _, _, err := enqueueHookGrokTranscript(payload, "", now.Add(-time.Minute)); err != nil {
+		t.Fatalf("enqueueHookGrokTranscript() error = %v", err)
+	}
+
+	var launched []string
+	c := &RootCLI{}
+	c.hookGrokTranscriptLauncher = func(path string) error {
+		launched = append(launched, path)
+		return nil
+	}
+
+	check := c.inspectHookGrokTranscriptDiagnostics(now)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("check = %+v, want warning", check)
+	}
+	if !check.AutoFixAvailable || check.FixFunc == nil || check.FixCommand != "traceary doctor --fix" {
+		t.Fatalf("check = %+v, want an auto-fixable check with the doctor --fix command", check)
+	}
+
+	dryRunMessage, err := check.FixFunc(context.Background(), true)
+	if err != nil {
+		t.Fatalf("FixFunc(dryRun) error = %v", err)
+	}
+	if !strings.Contains(dryRunMessage, "would drain") {
+		t.Fatalf("dryRunMessage = %q, want a would-drain preview", dryRunMessage)
+	}
+	if len(launched) != 0 {
+		t.Fatalf("dry run launched %d worker(s), want zero", len(launched))
+	}
+
+	fixMessage, err := check.FixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("FixFunc(apply) error = %v", err)
+	}
+	if !strings.Contains(fixMessage, "launched=1") {
+		t.Fatalf("fixMessage = %q, want launched=1", fixMessage)
+	}
+	if len(launched) != 1 {
+		t.Fatalf("launched = %v, want exactly one relaunch", launched)
 	}
 }


### PR DESCRIPTION
## Summary

Exhausting the in-process delayed window requeues a Grok transcript job (`attempts++`) instead of writing a terminal `unavailable`. `unavailable` stays terminal only for a genuinely unopenable/empty path (or exhausted attempts). `drainHookGrokTranscriptQueue` relaunches due jobs and GCs terminal markers plus `.lock` sidecars after retention. `doctor --fix` uses the same drain.

## Why

Dogfood 0.39.0 left 50 pending / 50 failed / 74 unavailable Grok transcript jobs with no retry.

Closes #1973

Leaves parent #1968 open.

## Test plan

- [x] `go test ./presentation/cli/ -run 'GrokTranscript|HookGrok|drainHookGrok'`
- [x] `go tool golangci-lint run ./presentation/cli/...`