### PR TITLE
fix: bind retention apply recheck to the persisted plan cutoff

### DIFF
--- a/application/raw_body_retention.go
+++ b/application/raw_body_retention.go
@@ -15,6 +15,8 @@ type RawBodyRetentionPlanner interface {
 
 // RawBodyRetentionExecutor applies and restores exact reviewed body identities.
 type RawBodyRetentionExecutor interface {
-	ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate, appliedAt time.Time) (apptypes.RawBodyApplyResult, error)
+	// ApplyRawBodyPlan rechecks candidate eligibility against cutoffAt, the
+	// plan's persisted selection boundary, not the wall clock at apply time.
+	ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate, cutoffAt, appliedAt time.Time) (apptypes.RawBodyApplyResult, error)
 	RestoreRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, bodies []apptypes.RawBodyRecoveryBody, restoredAt time.Time) (apptypes.RawBodyRestoreResult, error)
 }

--- a/application/types/retention_plan.go
+++ b/application/types/retention_plan.go
@@ -12,6 +12,7 @@ type RetentionCanonicalPayload struct {
 	SchemaVersion        string                   `json:"schema_version"`
 	CreatedAt            string                   `json:"created_at"`
 	SnapshotAt           string                   `json:"snapshot_at"`
+	CutoffAt             string                   `json:"cutoff_at,omitempty"`
 	Source               RetentionPlanSource      `json:"source"`
 	Policy               RetentionPlanPolicy      `json:"policy"`
 	ClassResults         []RetentionClassResult   `json:"class_results"`

--- a/application/usecase/raw_body_retention_usecase.go
+++ b/application/usecase/raw_body_retention_usecase.go
@@ -92,6 +92,7 @@ func (u *rawBodyRetentionUsecase) CreatePlan(ctx context.Context, before time.Ti
 		CanonicalPayload: apptypes.RetentionCanonicalPayload{
 			SchemaVersion: retentionPlanSchemaVersion,
 			CreatedAt:     now.UTC().Format(time.RFC3339Nano), SnapshotAt: snapshot.SnapshotAt.UTC().Format(time.RFC3339Nano),
+			CutoffAt: before.UTC().Format(time.RFC3339Nano),
 			Source: apptypes.RetentionPlanSource{
 				DatabaseIdentity: snapshot.DatabaseIdentity, SQLiteUserVersion: snapshot.SQLiteUserVersion,
 				MigrationDigest: snapshot.MigrationDigest,
@@ -134,11 +135,29 @@ func (u *rawBodyRetentionUsecase) Apply(ctx context.Context, planData []byte, re
 		return apptypes.RawBodyApplyResult{}, err
 	}
 	_ = bodies
-	result, err := u.executor.ApplyRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.CanonicalPayload.Source.MigrationDigest, plan.PlanID, candidates, now.UTC())
+	cutoffAt, err := retentionPlanCutoff(plan)
+	if err != nil {
+		return apptypes.RawBodyApplyResult{}, err
+	}
+	result, err := u.executor.ApplyRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.CanonicalPayload.Source.MigrationDigest, plan.PlanID, candidates, cutoffAt, now.UTC())
 	if err != nil {
 		return apptypes.RawBodyApplyResult{}, xerrors.Errorf("apply reviewed raw-body plan: %w", err)
 	}
 	return result, nil
+}
+
+// retentionPlanCutoff resolves the plan's persisted selection boundary. Plans
+// written before cutoff_at existed omit it; apply falls back to created_at.
+func retentionPlanCutoff(plan apptypes.RetentionPlan) (time.Time, error) {
+	value := plan.CanonicalPayload.CutoffAt
+	if value == "" {
+		value = plan.CanonicalPayload.CreatedAt
+	}
+	cutoffAt, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, xerrors.Errorf("parse retention plan cutoff: %w", err)
+	}
+	return cutoffAt, nil
 }
 
 func (u *rawBodyRetentionUsecase) Restore(ctx context.Context, planData []byte, recoveryPath, confirmedPlanID string, now time.Time) (apptypes.RawBodyRestoreResult, error) {

--- a/application/usecase/raw_body_retention_usecase_test.go
+++ b/application/usecase/raw_body_retention_usecase_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -92,7 +93,68 @@ func TestRawBodyRetentionPlanStoresEncodedExtentsAndProjectedMarkers(t *testing.
 			if diff := cmp.Diff([]int{44, 9}, executor.candidates); diff != "" {
 				t.Fatalf("apply candidate extents mismatch (-want +got):\n%s", diff)
 			}
+			wantCutoff := createdAt.Add(time.Hour)
+			if !executor.cutoffAtSeen || !executor.cutoffAt.Equal(wantCutoff) {
+				t.Fatalf("apply cutoff = %s (seen=%t), want the plan's persisted cutoff %s, not the apply-time clock", executor.cutoffAt, executor.cutoffAtSeen, wantCutoff)
+			}
 		})
+	}
+}
+
+func TestRawBodyRetentionApply_FallsBackToCreatedAtWhenCutoffAtMissing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		compressedID       = "retention-compressed"
+		legacyID           = "retention-legacy"
+		markerEncodedBytes = 37
+	)
+	compressedBody := strings.Repeat("compressible body ", 4096)
+	legacyBody := "日本語"
+	now := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	recoveryPath := filepath.Join(t.TempDir(), "recovery.archive")
+	candidates := retentionTestCandidates(compressedID, compressedBody, legacyID, legacyBody, createdAt)
+	writeRetentionTestRecovery(t, recoveryPath, candidates, compressedBody, legacyBody)
+	planner := &retentionPlannerStub{markerEncodedBytes: markerEncodedBytes, snapshot: apptypes.RawBodyRetentionSnapshot{
+		DatabaseIdentity: testDigest("db"), SQLiteUserVersion: 53, MigrationDigest: testDigest("migration"), SnapshotAt: now,
+		Candidates: candidates,
+	}}
+	executor := &retentionExecutorStub{}
+	workflow := NewRawBodyRetentionUsecase(planner, executor)
+
+	planData, err := workflow.CreatePlan(context.Background(), createdAt.Add(time.Hour), recoveryPath, now)
+	if err != nil {
+		t.Fatalf("CreatePlan() error = %v", err)
+	}
+	plan, err := decodeRetentionPlan(planData)
+	if err != nil {
+		t.Fatalf("decodeRetentionPlan() error = %v", err)
+	}
+
+	// Simulate a plan written before cutoff_at existed: strip it and re-sign,
+	// as an old plan on disk would already have no such field.
+	plan.CanonicalPayload.CutoffAt = ""
+	canonical, err := canonicalRetentionPayload(plan.CanonicalPayload)
+	if err != nil {
+		t.Fatalf("canonicalRetentionPayload() error = %v", err)
+	}
+	digest := sha256.Sum256(canonical)
+	plan.PlanID = hex.EncodeToString(digest[:])
+	legacyPlanData, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal legacy plan: %v", err)
+	}
+
+	if _, err := workflow.Apply(context.Background(), legacyPlanData, recoveryPath, plan.PlanID, now.Add(time.Hour)); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	// The plan's created_at is the fallback, not its selection cutoff (before)
+	// nor the apply-time clock: it is the only timestamp a pre-migration plan
+	// still carries.
+	wantCutoff := now
+	if !executor.cutoffAtSeen || !executor.cutoffAt.Equal(wantCutoff) {
+		t.Fatalf("apply cutoff = %s (seen=%t), want fallback to created_at %s", executor.cutoffAt, executor.cutoffAtSeen, wantCutoff)
 	}
 }
 
@@ -143,12 +205,18 @@ func (s *retentionPlannerStub) RetentionMarkerEncodedBytes() (int, error) {
 	return s.markerEncodedBytes, nil
 }
 
-type retentionExecutorStub struct{ candidates []int }
+type retentionExecutorStub struct {
+	candidates   []int
+	cutoffAt     time.Time
+	cutoffAtSeen bool
+}
 
-func (s *retentionExecutorStub) ApplyRawBodyPlan(_ context.Context, _ string, _ int, _, _ string, candidates []apptypes.RawBodyCandidate, _ time.Time) (apptypes.RawBodyApplyResult, error) {
+func (s *retentionExecutorStub) ApplyRawBodyPlan(_ context.Context, _ string, _ int, _, _ string, candidates []apptypes.RawBodyCandidate, cutoffAt, _ time.Time) (apptypes.RawBodyApplyResult, error) {
 	for _, candidate := range candidates {
 		s.candidates = append(s.candidates, candidate.EncodedBytes)
 	}
+	s.cutoffAt = cutoffAt
+	s.cutoffAtSeen = true
 	return apptypes.RawBodyApplyResult{}, nil
 }
 

--- a/application/usecase/retention_plan_codec.go
+++ b/application/usecase/retention_plan_codec.go
@@ -230,6 +230,22 @@ func validateRetentionPlan(plan apptypes.RetentionPlan) error {
 	if err := validateUTCInstant(payload.SnapshotAt); err != nil {
 		return xerrors.Errorf("invalid retention plan snapshot_at: %w", err)
 	}
+	if payload.CutoffAt != "" {
+		if err := validateUTCInstant(payload.CutoffAt); err != nil {
+			return xerrors.Errorf("invalid retention plan cutoff_at: %w", err)
+		}
+		cutoffAt, err := time.Parse(time.RFC3339Nano, payload.CutoffAt)
+		if err != nil {
+			return xerrors.Errorf("parse retention plan cutoff_at: %w", err)
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, payload.CreatedAt)
+		if err != nil {
+			return xerrors.Errorf("parse retention plan created_at: %w", err)
+		}
+		if !cutoffAt.Before(createdAt) {
+			return xerrors.Errorf("retention plan cutoff_at must be before created_at")
+		}
+	}
 	if payload.Source.SQLiteUserVersion < 0 || !lowerHexDigest.MatchString(payload.Source.MigrationDigest) {
 		return xerrors.Errorf("retention plan source and timestamps are required")
 	}

--- a/docs/operations/payload-retention.ja.md
+++ b/docs/operations/payload-retention.ja.md
@@ -130,7 +130,9 @@ JSON plan は次を含みます。
 
 plan JSON に event body、command input/output、archive passphrase、credential、absolute home path、file content を含めません。
 
-canonical hash は normative `canonical_payload` に RFC 8785 JSON canonicalization を適用します。top-level plan は `plan_id`、`canonical_payload`、任意 `display` だけです。apply は `canonical_payload` だけを解釈し、未知 canonical field を拒否し、`display` を無視します。`canonical_payload` は `schema_version`, `created_at`, `snapshot_at`, `source`, `policy`, `class_results`, `candidates`, `exclusions`, `recovery_requirements`, `phases` を含み、ほかの field を hash から除外しません。
+canonical hash は normative `canonical_payload` に RFC 8785 JSON canonicalization を適用します。top-level plan は `plan_id`、`canonical_payload`、任意 `display` だけです。apply は `canonical_payload` だけを解釈し、未知 canonical field を拒否し、`display` を無視します。`canonical_payload` は `schema_version`, `created_at`, `snapshot_at`, `source`, `policy`, `class_results`, `candidates`, `exclusions`, `recovery_requirements`, `phases` に加え、任意の `cutoff_at` を含み、ほかの field を hash から除外しません。
+
+`cutoff_at` は plan の候補選定を評価した UTC instant です。apply はこの永続化された値を eligibility recheck に束縛し、wall clock は使いません。そのため plan 作成後 apply までの間に clock が巻き戻っても（NTP step、snapshot restore、container の clock skew）、すでにレビュー済みの候補が誤って ineligible と判定されることはありません。この field が存在しない旧 plan では空文字ではなく省略され、apply は `created_at` にフォールバックします。
 
 任意 canonical field は省略し、場合によって `null` にしません。byte と nanosecond duration は leading zero のない unsigned base-10 string（zero は `"0"`）です。count は 0〜9,007,199,254,740,991 の JSON integer、時刻は UTC RFC3339Nano、relative path は `/` separator で `.`/`..`/empty segment を禁止します。
 

--- a/docs/operations/payload-retention.md
+++ b/docs/operations/payload-retention.md
@@ -130,7 +130,9 @@ The JSON plan includes:
 
 Plan JSON never includes event body, command input/output, archive passphrase, credentials, absolute home paths, or file contents.
 
-Canonical hashing follows RFC 8785 JSON canonicalization over a normative `canonical_payload`. The top-level plan has exactly `plan_id`, `canonical_payload`, and optional `display`; apply parses only `canonical_payload`, rejects unknown canonical fields, and ignores `display`. `canonical_payload` contains `schema_version`, `created_at`, `snapshot_at`, `source`, `policy`, `class_results`, `candidates`, `exclusions`, `recovery_requirements`, and `phases`. No other field is excluded from the hash.
+Canonical hashing follows RFC 8785 JSON canonicalization over a normative `canonical_payload`. The top-level plan has exactly `plan_id`, `canonical_payload`, and optional `display`; apply parses only `canonical_payload`, rejects unknown canonical fields, and ignores `display`. `canonical_payload` contains `schema_version`, `created_at`, `snapshot_at`, `source`, `policy`, `class_results`, `candidates`, `exclusions`, `recovery_requirements`, and `phases`, plus an optional `cutoff_at`. No other field is excluded from the hash.
+
+`cutoff_at` is the UTC instant the plan's candidate selection was evaluated against. Apply binds this persisted value into its eligibility recheck instead of the wall clock, so a clock that moves backwards between plan and apply (NTP step, snapshot restore, container skew) cannot make an already-reviewed candidate look ineligible. It is omitted, not encoded as an empty string, for plans written before this field existed; apply falls back to `created_at` for those.
 
 Optional canonical fields are omitted, never encoded sometimes as `null`. All byte values and nanosecond durations are unsigned base-10 strings without leading zeroes (except `"0"`), avoiding RFC 8785/IEEE-754 safe-integer ambiguity. Counts are JSON integers constrained to 0 through 9,007,199,254,740,991. Instants are UTC RFC3339Nano. Root-relative paths use slash separators without `.`, `..`, or empty segments.
 

--- a/infrastructure/sqlite/payload_codec_call_sites_test.go
+++ b/infrastructure/sqlite/payload_codec_call_sites_test.go
@@ -201,7 +201,7 @@ func TestRawBodyRestore_UsesCanonicalPayloadCodec(t *testing.T) {
 		t.Fatalf("candidate count = %d, want 1", len(snapshot.Candidates))
 	}
 	planID := "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-	if _, err := store.ApplyRawBodyPlan(ctx, snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)); err != nil {
+	if _, err := store.ApplyRawBodyPlan(ctx, snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)); err != nil {
 		t.Fatalf("ApplyRawBodyPlan() error = %v", err)
 	}
 

--- a/infrastructure/sqlite/raw_body_retention_datasource.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource.go
@@ -142,7 +142,10 @@ func (d *StoreManagementDatasource) RetentionMarkerEncodedBytes() (int, error) {
 }
 
 // ApplyRawBodyPlan prunes exact candidate versions in durable, resumable batches.
-func (d *StoreManagementDatasource) ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate, appliedAt time.Time) (apptypes.RawBodyApplyResult, error) {
+// The eligibility recheck binds cutoffAt, the plan's persisted selection
+// boundary; appliedAt only stamps the audit trail (started_at, pruned_at,
+// completed_at) and never gates whether a candidate remains eligible.
+func (d *StoreManagementDatasource) ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate, cutoffAt, appliedAt time.Time) (apptypes.RawBodyApplyResult, error) {
 	result := apptypes.RawBodyApplyResult{PlanID: planID, CandidateCount: len(candidates)}
 	sourcePath := d.db.Path()
 	db, err := d.db.openAt(ctx, sourcePath)
@@ -151,14 +154,15 @@ func (d *StoreManagementDatasource) ApplyRawBodyPlan(ctx context.Context, databa
 	}
 	defer closeRawBodyResource(db)
 	stamp := formatTimestamp(appliedAt)
-	if err := preflightRawBodyCandidates(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, candidates, stamp); err != nil {
+	cutoffStamp := formatTimestamp(cutoffAt)
+	if err := preflightRawBodyCandidates(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, candidates, cutoffStamp); err != nil {
 		return result, err
 	}
 	if err := startRawBodyExecution(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, len(candidates), stamp); err != nil {
 		return result, err
 	}
 	for index, candidate := range candidates {
-		pruned, err := applyRawBodyCandidate(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, candidate, stamp)
+		pruned, err := applyRawBodyCandidate(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, candidate, cutoffStamp, stamp)
 		if err != nil {
 			return result, err
 		}
@@ -215,7 +219,7 @@ VALUES (?, 'running', ?, 0, ?)
 	return nil
 }
 
-func applyRawBodyCandidate(ctx context.Context, db *sql.DB, sourcePath, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidate apptypes.RawBodyCandidate, stamp string) (bool, error) {
+func applyRawBodyCandidate(ctx context.Context, db *sql.DB, sourcePath, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidate apptypes.RawBodyCandidate, cutoffStamp, stamp string) (bool, error) {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, xerrors.Errorf("failed to begin raw-body batch: %w", err)
@@ -240,7 +244,7 @@ func applyRawBodyCandidate(ctx context.Context, db *sql.DB, sourcePath, database
 	} else if executionStatus != "completed" {
 		return false, xerrors.Errorf("raw-body execution cannot apply from status %s", executionStatus)
 	}
-	body, alreadyPruned, err := verifyRawBodyCandidateState(ctx, tx, planID, candidate, stamp)
+	body, alreadyPruned, err := verifyRawBodyCandidateState(ctx, tx, planID, candidate, cutoffStamp)
 	if err != nil {
 		return false, err
 	}
@@ -297,7 +301,7 @@ SET pruned_count = (SELECT COUNT(*) FROM raw_body_retention_entries WHERE plan_i
 	return true, nil
 }
 
-func preflightRawBodyCandidates(ctx context.Context, db *sql.DB, sourcePath, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate, appliedAt string) error {
+func preflightRawBodyCandidates(ctx context.Context, db *sql.DB, sourcePath, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate, cutoffAt string) error {
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return xerrors.Errorf("failed to begin raw-body preflight: %w", err)
@@ -307,7 +311,7 @@ func preflightRawBodyCandidates(ctx context.Context, db *sql.DB, sourcePath, dat
 		return err
 	}
 	for _, candidate := range candidates {
-		if _, _, err := verifyRawBodyCandidateState(ctx, tx, planID, candidate, appliedAt); err != nil {
+		if _, _, err := verifyRawBodyCandidateState(ctx, tx, planID, candidate, cutoffAt); err != nil {
 			return err
 		}
 	}
@@ -317,7 +321,7 @@ func preflightRawBodyCandidates(ctx context.Context, db *sql.DB, sourcePath, dat
 	return nil
 }
 
-func verifyRawBodyCandidateState(ctx context.Context, tx *sql.Tx, planID string, candidate apptypes.RawBodyCandidate, appliedAt string) (string, bool, error) {
+func verifyRawBodyCandidateState(ctx context.Context, tx *sql.Tx, planID string, candidate apptypes.RawBodyCandidate, cutoffAt string) (string, bool, error) {
 	var body, createdAt, availability string
 	var stored, encoded int
 	var prunedPlan sql.NullString
@@ -326,8 +330,10 @@ func verifyRawBodyCandidateState(ctx context.Context, tx *sql.Tx, planID string,
 	if err != nil {
 		return "", false, err
 	}
-	// An event old enough when planned remains old enough at apply time.
-	err = tx.QueryRowContext(ctx, verifyQuery, appliedAt, candidate.EventID, candidate.EventID).Scan(&body, &createdAt, &availability, &stored, &encoded, &prunedPlan, &eligible)
+	// cutoffAt is the plan's persisted selection boundary, not time.Now(): an
+	// event old enough when planned remains old enough at apply time
+	// regardless of when apply runs or the wall clock's state at that moment.
+	err = tx.QueryRowContext(ctx, verifyQuery, cutoffAt, candidate.EventID, candidate.EventID).Scan(&body, &createdAt, &availability, &stored, &encoded, &prunedPlan, &eligible)
 	if err != nil {
 		return "", false, xerrors.Errorf("failed to verify raw-body candidate %s: %w", candidate.EventID, err)
 	}

--- a/infrastructure/sqlite/raw_body_retention_datasource_test.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource_test.go
@@ -127,7 +127,7 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 		t.Fatalf("candidate count = %d, want 1", len(snapshot.Candidates))
 	}
 	planID := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC))
+	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("ApplyRawBodyPlan() error = %v", err)
 	}
@@ -152,7 +152,7 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 		t.Fatalf("Search(retention marker) returned %d pruned events, want 0", len(matches))
 	}
 
-	retry, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 2, 1, 0, 0, 0, time.UTC))
+	retry, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 2, 1, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("retry ApplyRawBodyPlan() error = %v", err)
 	}
@@ -167,7 +167,7 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 		t.Fatalf("activate session before retry: %v", err)
 	}
 	_ = db.Close()
-	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 2, 2, 0, 0, 0, time.UTC)); err != nil {
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 2, 2, 0, 0, 0, time.UTC)); err != nil {
 		t.Fatalf("retry ApplyRawBodyPlan() error = %v", err)
 	}
 	db, err = sql.Open("sqlite", "file:"+dbPath)
@@ -194,8 +194,115 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 	if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != event.Body() {
 		t.Fatalf("restored event availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
 	}
-	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)); err == nil {
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)); err == nil {
 		t.Fatal("ApplyRawBodyPlan() after restore error = nil, want terminal-plan rejection")
+	}
+}
+
+// TestRawBodyRetention_applyRecheckBindsPersistedCutoffNotWallClock covers
+// #1763: the apply-time eligibility recheck binds the plan's persisted
+// cutoff, not the wall clock. A clock that rewinds after the plan was built
+// (NTP step, snapshot restore, container skew) must not make an
+// already-reviewed candidate look ineligible.
+func TestRawBodyRetention_applyRecheckBindsPersistedCutoffNotWallClock(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := rawBodyRetentionEvent(t, "clock-rewind-event", "body", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	makeRawBodyRetentionEligible(t, dbPath, event.EventID().String())
+
+	planCutoff := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), planCutoff)
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	if len(snapshot.Candidates) != 1 {
+		t.Fatalf("candidate count = %d, want 1", len(snapshot.Candidates))
+	}
+
+	// The host clock rewinds to 90 days before the plan cutoff before apply
+	// runs (or resumes). The persisted cutoff must still govern the recheck.
+	rewoundClock := planCutoff.AddDate(0, 0, -90)
+	planID := "1111111111111111111111111111111111111111111111111111111111111111"
+	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, planCutoff, rewoundClock)
+	if err != nil {
+		t.Fatalf("ApplyRawBodyPlan() error = %v", err)
+	}
+	if result.PrunedCount != 1 || result.AlreadyPruned != 0 {
+		t.Fatalf("apply result = %+v, want the candidate discarded despite the clock rewind", result)
+	}
+	details, err := events.GetDetails(context.Background(), event.EventID())
+	if err != nil {
+		t.Fatalf("GetDetails() error = %v", err)
+	}
+	if details.Event().BodyAvailability() != types.BodyAvailabilityUnavailableRetention {
+		t.Fatalf("availability = %q, want unavailable_retention", details.Event().BodyAvailability())
+	}
+}
+
+// TestRawBodyRetention_resumeAfterInterruptionBindsPersistedCutoff covers
+// #1763's resumability requirement: a partially-applied run that crashes and
+// resumes under a rewound clock must still honor remaining candidates
+// against the persisted cutoff, not reject them as "no longer eligible".
+func TestRawBodyRetention_resumeAfterInterruptionBindsPersistedCutoff(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	for index, id := range []string{"resume-a", "resume-b"} {
+		event := rawBodyRetentionEvent(t, id, "payload-"+id, time.Date(2026, 5, 1, index, 0, 0, 0, time.UTC))
+		if err := events.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", id, err)
+		}
+	}
+	makeRawBodyRetentionEligible(t, dbPath, "resume-a", "resume-b")
+
+	planCutoff := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), planCutoff)
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	if len(snapshot.Candidates) != 2 {
+		t.Fatalf("candidate count = %d, want 2", len(snapshot.Candidates))
+	}
+
+	planID := "2222222222222222222222222222222222222222222222222222222222222222"
+	store.SetRawBodyPrunedHookForTest(func(int) error { return errors.New("injected interruption") })
+	rewoundClock := planCutoff.AddDate(0, 0, -90)
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, planCutoff, rewoundClock); err == nil {
+		t.Fatal("ApplyRawBodyPlan() error = nil, want interruption")
+	}
+	store.SetRawBodyPrunedHookForTest(nil)
+
+	// Resume after the crash under an even further rewound clock. Only the
+	// persisted cutoff, not this resumption's wall clock, governs whether the
+	// remaining candidate is still eligible.
+	resumeClock := rewoundClock.AddDate(0, 0, -30)
+	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, planCutoff, resumeClock)
+	if err != nil {
+		t.Fatalf("resume ApplyRawBodyPlan() error = %v", err)
+	}
+	if result.PrunedCount != 1 || result.AlreadyPruned != 1 {
+		t.Fatalf("resume result = %+v, want one newly discarded and one already durable", result)
+	}
+	for _, candidate := range snapshot.Candidates {
+		details, err := events.GetDetails(context.Background(), types.EventID(candidate.EventID))
+		if err != nil {
+			t.Fatalf("GetDetails(%s) error = %v", candidate.EventID, err)
+		}
+		if details.Event().BodyAvailability() != types.BodyAvailabilityUnavailableRetention {
+			t.Fatalf("event %s availability = %q, want unavailable_retention after resume", candidate.EventID, details.Event().BodyAvailability())
+		}
 	}
 }
 
@@ -264,7 +371,7 @@ func TestRawBodyRetention_rejectsStaleCandidateWithoutPruning(t *testing.T) {
 	}
 	_ = db.Close()
 
-	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", snapshot.Candidates, time.Now().UTC())
+	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC())
 	if err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want stale-plan rejection")
 	}
@@ -312,7 +419,7 @@ func TestRawBodyRetention_rejectsReencodedCandidate(t *testing.T) {
 			}
 			_ = db.Close()
 
-			_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", snapshot.Candidates, time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC))
+			_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC))
 			if err == nil {
 				t.Fatal("ApplyRawBodyPlan() error = nil, want encoded-extent stale-plan rejection")
 			}
@@ -349,7 +456,7 @@ func TestRawBodyRetention_rejectsSchemaDriftWithoutPruning(t *testing.T) {
 	}
 	_ = db.Close()
 
-	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", snapshot.Candidates, time.Now().UTC())
+	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC())
 	if err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want schema-drift rejection")
 	}
@@ -417,7 +524,7 @@ func TestRawBodyRetention_rejectsSessionActivatedAfterPlan(t *testing.T) {
 	}
 	_ = db.Close()
 
-	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", snapshot.Candidates, time.Now().UTC())
+	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC())
 	if err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want active-session stale-plan rejection")
 	}
@@ -455,7 +562,7 @@ func TestRawBodyRetention_rejectsPlanWhenRefinementIsRemoved(t *testing.T) {
 		t.Fatalf("delete refinement: %v", err)
 	}
 	_ = db.Close()
-	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "abababababababababababababababababababababababababababababababab", snapshot.Candidates, time.Now().UTC()); err == nil {
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "abababababababababababababababababababababababababababababababab", snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC()); err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want stale-plan rejection")
 	}
 	details, err := events.GetDetails(context.Background(), event.EventID())
@@ -488,7 +595,7 @@ func TestRawBodyRetention_interruptionResumesFromDurableBatch(t *testing.T) {
 	}
 	planID := "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	store.SetRawBodyPrunedHookForTest(func(int) error { return errors.New("injected interruption") })
-	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Now().UTC()); err == nil {
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC()); err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want interruption")
 	}
 	for index, candidate := range snapshot.Candidates {
@@ -502,7 +609,7 @@ func TestRawBodyRetention_interruptionResumesFromDurableBatch(t *testing.T) {
 		}
 	}
 	store.SetRawBodyPrunedHookForTest(nil)
-	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Now().UTC())
+	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC())
 	if err != nil {
 		t.Fatalf("retry ApplyRawBodyPlan() error = %v", err)
 	}
@@ -532,7 +639,7 @@ func TestRawBodyRetention_partialExecutionCanBeRestored(t *testing.T) {
 	}
 	planID := "abababababababababababababababababababababababababababababababab"
 	store.SetRawBodyPrunedHookForTest(func(int) error { return errors.New("injected interruption") })
-	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Now().UTC()); err == nil {
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC()); err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want interruption")
 	}
 	store.SetRawBodyPrunedHookForTest(nil)
@@ -600,7 +707,7 @@ func TestRawBodyRetention_restoreBetweenBatchesStopsFurtherApply(t *testing.T) {
 		_, restoreErr = store.RestoreRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, recovery, time.Now().UTC())
 		return nil
 	})
-	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Now().UTC()); err == nil {
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC()); err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want restored-state stop")
 	}
 	if restoreErr != nil {
@@ -647,7 +754,7 @@ func TestRawBodyRetention_planIsBoundToCopiedStorePath(t *testing.T) {
 	if err := copiedStore.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize(copy) error = %v", err)
 	}
-	if _, err := copiedStore.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", snapshot.Candidates, time.Now().UTC()); err == nil {
+	if _, err := copiedStore.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", snapshot.Candidates, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Now().UTC()); err == nil {
 		t.Fatal("ApplyRawBodyPlan(copy) error = nil, want source-path mismatch")
 	}
 }

--- a/schema/retention-plan.schema.json
+++ b/schema/retention-plan.schema.json
@@ -183,6 +183,7 @@
         "schema_version": {"const": "retention-plan/v2"},
         "created_at": {"$ref": "#/$defs/instant"},
         "snapshot_at": {"$ref": "#/$defs/instant"},
+        "cutoff_at": {"$ref": "#/$defs/instant"},
         "source": {"$ref": "#/$defs/source"},
         "policy": {"$ref": "#/$defs/policy"},
         "class_results": {"type": "array", "items": {"$ref": "#/$defs/classResult"}},


### PR DESCRIPTION
## Summary

The plan now persists `cutoff_at`. Apply-time eligibility recheck binds that value, not `time.Now()`. Older plans fall back to `created_at`. Selection SQL is unchanged.

## Why

A clock that moves backwards between plan and apply made remaining candidates look ineligible, so a partially-applied run could not resume.

Closes #1763

Leaves parent #1968 open.

## Test plan

- [x] `go test ./infrastructure/sqlite/ ./application/usecase/ -run 'RawBodyRetention|RetentionPlan|cutoff|Cutoff'`
- [x] `go tool golangci-lint run ./infrastructure/sqlite/... ./application/usecase/...`