### PR TITLE
fix: preserve event_content_dedupe_archive across compact

### DIFF
--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -44,6 +44,9 @@ compact は拒否しません。詳細は
 [`search-retirement.ja.md`](../operations/search-retirement.ja.md) を参照して
 ください。
 
+compact は `event_content_dedupe_archive`（content-event dedupe の隔離監査証跡）
+を 90 日の retention window 内で保持し、それより古い行は compact 時に破棄します。
+
 DarwinとLinuxでは通常のphysical
 SQLite connectionが、隣接するstableな `<database>.traceary.lock` にshared
 advisory lockを保持します。compact はjournalや向きの

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -52,6 +52,10 @@ The retired search index family is dropped on the work copy. Compact no longer
 refuses a source that still carries it. See
 [`search-retirement.md`](../operations/search-retirement.md).
 
+Compact preserves `event_content_dedupe_archive` (the content-event dedupe
+quarantine audit trail) within a 90-day retention window; rows older than that
+are discarded at compact.
+
 On Darwin and Linux, every normal physical
 SQLite connection holds a shared advisory lock on the stable adjacent
 `<database>.traceary.lock` file. Compact holds the

--- a/infrastructure/sqlite/compaction_copy_filter.go
+++ b/infrastructure/sqlite/compaction_copy_filter.go
@@ -66,8 +66,8 @@ func applyCopyFilters(ctx context.Context, work string, filter application.Compa
 	if err := dropUnreadRecentFTSOn(ctx, db); err != nil {
 		return err
 	}
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS event_content_dedupe_archive`); err != nil {
-		return fmt.Errorf("drop dedupe archive on work copy: %w", err)
+	if err := trimDedupeArchive(ctx, db, time.Now().UTC()); err != nil {
+		return err
 	}
 
 	hasEvents, err := tableExists(ctx, db, "events")
@@ -161,8 +161,34 @@ func deleteNonCanonicalDuplicateEvents(ctx context.Context, db *sql.DB, datasour
 	if err := datasource.applyDedupeGroups(ctx, db, plan, params); err != nil {
 		return &apptypes.ContentEventDedupeApplyError{RunID: runID, Err: fmt.Errorf("delete work-copy duplicates: %w", err)}
 	}
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS event_content_dedupe_archive`); err != nil {
-		return &apptypes.ContentEventDedupeApplyError{RunID: runID, Err: fmt.Errorf("drop work-copy dedupe archive after apply: %w", err)}
+	return nil
+}
+
+// dedupeArchiveRetention bounds how long event_content_dedupe_archive rows
+// survive a compact. There is no dedupe-specific retention constant
+// elsewhere in the codebase; this matches the 90-day window already used as
+// the project's general staleness/retention default (see
+// application/usecase/memory_hygiene.go's defaultStalenessThreshold).
+const dedupeArchiveRetention = 90 * 24 * time.Hour
+
+// trimDedupeArchive deletes event_content_dedupe_archive rows older than
+// dedupeArchiveRetention from the compact work copy, in place. The work copy
+// is already a full byte copy of the source database (see copyRegularFile),
+// so the table and its rows are present before this runs; trimming by
+// archived_at (rather than dropping and recopying) keeps the operation
+// agnostic to the archive's column set, including any future codec columns.
+// A store that predates the archive table is a no-op.
+func trimDedupeArchive(ctx context.Context, db *sql.DB, now time.Time) error {
+	exists, err := tableExists(ctx, db, "event_content_dedupe_archive")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	cutoff := formatTimestamp(now.Add(-dedupeArchiveRetention))
+	if _, err := db.ExecContext(ctx, `DELETE FROM event_content_dedupe_archive WHERE archived_at < ?`, cutoff); err != nil {
+		return fmt.Errorf("trim dedupe archive on work copy: %w", err)
 	}
 	return nil
 }

--- a/infrastructure/sqlite/compaction_dedupe_archive_test.go
+++ b/infrastructure/sqlite/compaction_dedupe_archive_test.go
@@ -1,0 +1,170 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const createDedupeArchiveTableSQL = `
+CREATE TABLE event_content_dedupe_archive (
+    id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    client TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    workspace TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    source_hook TEXT,
+    kept_event_id TEXT NOT NULL,
+    dedupe_run_id TEXT NOT NULL,
+    archived_at TEXT NOT NULL,
+    group_key TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    PRIMARY KEY (dedupe_run_id, id)
+)`
+
+func insertDedupeArchiveRow(t *testing.T, db *sql.DB, id string, archivedAt time.Time) {
+	t.Helper()
+	if _, err := db.Exec(`
+INSERT INTO event_content_dedupe_archive
+    (id, kind, client, agent, session_id, workspace, body, created_at, source_hook, kept_event_id, dedupe_run_id, archived_at, group_key, reason)
+VALUES (?, 'transcript', 'claude', 'claude', 'session-1', 'workspace-1', 'body', ?, NULL, 'kept-1', 'run-1', ?, 'group-1', 'duplicate')`,
+		id, formatTimestamp(archivedAt), formatTimestamp(archivedAt)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func openCandidateArchiveIDs(t *testing.T, candidate string) []string {
+	t.Helper()
+	db, err := sql.Open("sqlite", directSQLiteRWDSN(candidate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	rows, err := db.Query(`SELECT id FROM event_content_dedupe_archive ORDER BY id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return ids
+}
+
+func TestSQLiteCompactionBuildPreservesRecentDedupeArchive(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	candidate := filepath.Join(dir, "candidate.db")
+
+	db, err := sql.Open("sqlite", directSQLiteRWDSNCreate(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(createDedupeArchiveTableSQL); err != nil {
+		t.Fatal(err)
+	}
+	insertDedupeArchiveRow(t, db, "recent-1", time.Now().UTC().Add(-24*time.Hour))
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(candidate, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	builder := SQLiteCompactionBuilder{}
+	if err := builder.Build(ctx, source, candidate); err != nil {
+		t.Fatal(err)
+	}
+
+	got := openCandidateArchiveIDs(t, candidate)
+	if len(got) != 1 || got[0] != "recent-1" {
+		t.Fatalf("expected recent archive row to survive compact, got %v", got)
+	}
+}
+
+func TestSQLiteCompactionBuildDiscardsOverRetentionDedupeArchive(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	candidate := filepath.Join(dir, "candidate.db")
+
+	db, err := sql.Open("sqlite", directSQLiteRWDSNCreate(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(createDedupeArchiveTableSQL); err != nil {
+		t.Fatal(err)
+	}
+	insertDedupeArchiveRow(t, db, "recent-1", time.Now().UTC().Add(-24*time.Hour))
+	insertDedupeArchiveRow(t, db, "old-1", time.Now().UTC().Add(-dedupeArchiveRetention-24*time.Hour))
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(candidate, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	builder := SQLiteCompactionBuilder{}
+	if err := builder.Build(ctx, source, candidate); err != nil {
+		t.Fatal(err)
+	}
+
+	got := openCandidateArchiveIDs(t, candidate)
+	if len(got) != 1 || got[0] != "recent-1" {
+		t.Fatalf("expected only the recent archive row to survive compact, got %v", got)
+	}
+}
+
+func TestSQLiteCompactionBuildArchiveAbsentNoOp(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	candidate := filepath.Join(dir, "candidate.db")
+
+	db, err := sql.Open("sqlite", directSQLiteRWDSNCreate(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE sample(id TEXT PRIMARY KEY, body BLOB)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(candidate, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	builder := SQLiteCompactionBuilder{}
+	if err := builder.Build(ctx, source, candidate); err != nil {
+		t.Fatal(err)
+	}
+
+	candidateDB, err := sql.Open("sqlite", directSQLiteRWDSN(candidate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = candidateDB.Close() }()
+	exists, err := tableExists(ctx, candidateDB, "event_content_dedupe_archive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("expected no dedupe archive table when source predates it")
+	}
+}

--- a/infrastructure/sqlite/content_event_dedupe_apply_failure_internal_test.go
+++ b/infrastructure/sqlite/content_event_dedupe_apply_failure_internal_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
@@ -217,26 +219,54 @@ func TestDeleteNonCanonicalDuplicateEvents_WrapsFailureWithRunID(t *testing.T) {
 		t.Fatalf("sql.Open() error = %v", err)
 	}
 	defer func() { _ = db.Close() }()
-	for _, stmt := range []struct{ id, createdAt string }{
-		{"evt-1", "2026-04-10T00:00:00Z"},
-		{"evt-2", "2026-04-10T00:00:01Z"},
-	} {
-		if _, err := db.Exec(
-			`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client)
-			 VALUES (?, 'prompt', 'codex', 's1', 'w1', 'hi', ?, 'user_prompt_submit', 'hook')`,
-			stmt.id, stmt.createdAt,
-		); err != nil {
-			t.Fatalf("insert %s error = %v", stmt.id, err)
+
+	// Two proximity clusters in distinct sessions, sized so partitioning at
+	// the default batch size (1000, apptypes.DefaultContentEventDedupeBatchSize)
+	// splits them into two transactions: cluster "s1" alone (1000 duplicates)
+	// fills the first batch exactly, so adding cluster "s2" (1 duplicate)
+	// overflows it and forces a flush. That gives the hook a real second
+	// BeginTx to fail on when it cancels the context after the first batch
+	// commits — the same wrap path a mid-batch failure exercises elsewhere,
+	// now that compact-copy-filter no longer runs a DROP TABLE after a
+	// successful apply (compact preserves event_content_dedupe_archive).
+	base := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("db.Begin() error = %v", err)
+	}
+	stmt, err := tx.Prepare(
+		`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client)
+		 VALUES (?, 'prompt', 'codex', ?, 'w1', 'hi', ?, 'user_prompt_submit', 'hook')`)
+	if err != nil {
+		t.Fatalf("tx.Prepare() error = %v", err)
+	}
+	for i := 0; i <= 1000; i++ {
+		createdAt := base.Add(time.Duration(i) * time.Second).Format(time.RFC3339)
+		if _, err := stmt.Exec(fmt.Sprintf("evt-s1-%d", i), "s1", createdAt); err != nil {
+			t.Fatalf("insert evt-s1-%d error = %v", i, err)
 		}
+	}
+	for i := 0; i <= 1; i++ {
+		createdAt := base.Add(time.Duration(i) * time.Second).Format(time.RFC3339)
+		if _, err := stmt.Exec(fmt.Sprintf("evt-s2-%d", i), "s2", createdAt); err != nil {
+			t.Fatalf("insert evt-s2-%d error = %v", i, err)
+		}
+	}
+	if err := stmt.Close(); err != nil {
+		t.Fatalf("stmt.Close() error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("tx.Commit() error = %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Identification runs to completion (it is read-only, ahead of the
-	// cancellation), the single batch commits, and the hook then cancels the
-	// context — so the DROP TABLE that follows a successful apply is what
-	// fails, exercising the same wrap path a mid-batch failure would.
+	// cancellation). The first batch (cluster "s1", 1000 duplicates) commits
+	// and the hook cancels the context; the second batch (cluster "s2", 1
+	// duplicate) then fails to begin its transaction, exercising the wrap
+	// path.
 	datasource := &StoreManagementDatasource{onAfterDedupeBatchCommit: func() { cancel() }}
 	err = deleteNonCanonicalDuplicateEvents(ctx, db, datasource)
 	if err == nil {


### PR DESCRIPTION
## Summary

Copy-filter compact no longer `DROP`s `event_content_dedupe_archive`. The work copy already contains the table; compact trims rows older than a 90-day `archived_at` window. A store without the table is a no-op.

## Why

Compact was the only shipped apply path after #1872, and an unconditional DROP destroyed the quarantine that a run id is supposed to recover.

Closes #1982

Leaves parent #1968 open.

## Test plan

- [x] `go test ./infrastructure/sqlite/ -run 'DedupeArchive|CopyFilter|DeleteNonCanonical|Preserve'`
- [x] `go tool golangci-lint run ./infrastructure/sqlite/...`