### PR TITLE
fix: count the Codex usage hook in doctor's expected hook set

### DIFF
--- a/examples/hooks/codex.hooks.json
+++ b/examples/hooks/codex.hooks.json
@@ -65,6 +65,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "'traceary' 'hook' 'usage' 'codex'"
+          },
+          {
+            "type": "command",
             "command": "'traceary' 'hook' 'transcript' 'codex'"
           },
           {

--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -489,6 +489,12 @@ func parseTracearyDirectManagedCommand(commandValue string) (directManagedComman
 		}
 		directCommand.managedKey = managedKeyOf("traceary-transcript.sh", tokens[3])
 		return directCommand, true
+	case "usage":
+		if len(tokens) != 4 {
+			return directManagedCommand{}, false
+		}
+		directCommand.managedKey = managedKeyOf("traceary-usage.sh", tokens[3])
+		return directCommand, true
 	case "subagent-stop":
 		if len(tokens) != 4 {
 			return directManagedCommand{}, false

--- a/infrastructure/filesystem/hooks_merge_test.go
+++ b/infrastructure/filesystem/hooks_merge_test.go
@@ -457,6 +457,11 @@ func TestExtractTracearyManagedKey(t *testing.T) {
 			want:  "traceary-prompt.sh:claude",
 		},
 		{
+			name:  "direct hook usage",
+			input: "'traceary' 'hook' 'usage' 'codex'",
+			want:  "traceary-usage.sh:codex",
+		},
+		{
 			name:  "direct hook with apostrophe in binary path",
 			input: "'/Users/O'\"'\"'Connor/bin/traceary' 'hook' 'session' 'claude' 'start'",
 			want:  "traceary-session.sh:claude:start",

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -439,7 +439,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 				Status:    codexPluginHookTrustAbsent,
 			}
 			if pluginState.PluginEnabled {
-				trust = codexPluginHookTrustProbeFunc(ctx, resolvedProjectDir, pluginState.PluginKey)
+				trust = codexPluginHookTrustProbeFunc(ctx, resolvedProjectDir, pluginState.PluginKey, c.hooksInspector.ExtractManagedKeyFromEntry)
 				report.Checks = append(report.Checks, codexPluginHookTrustCheck(trust))
 				check = c.inspectCodexConfigWithHookTrust(ctx, outputPath, resolvedProjectDir, trust)
 			} else {

--- a/presentation/cli/doctor_codex_hook_trust.go
+++ b/presentation/cli/doctor_codex_hook_trust.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 )
@@ -26,16 +27,19 @@ const (
 )
 
 type codexPluginHookTrustResult struct {
-	PluginKey string
-	Status    codexPluginHookTrustStatus
-	HookCount int
-	Reason    string
+	PluginKey       string
+	Status          codexPluginHookTrustStatus
+	HookCount       int
+	Reason          string
+	ExtraCommands   []string
+	MissingCommands []string
 }
 
 type codexHookListMetadata struct {
 	PluginID   string `json:"pluginId"`
 	Enabled    bool   `json:"enabled"`
 	TrustState string `json:"trustStatus"`
+	Command    string `json:"command"`
 }
 
 type codexHookErrorInfo struct {
@@ -57,9 +61,15 @@ type codexAppServerEnvelope struct {
 	Error  json.RawMessage        `json:"error"`
 }
 
+// codexManagedKeyExtractorFunc normalizes a hook entry's name/command pair
+// into a stable Traceary-managed key, or "" when the entry is not
+// Traceary-managed. Callers pass application.HooksInspector.ExtractManagedKeyFromEntry
+// so this package does not import the infrastructure layer directly.
+type codexManagedKeyExtractorFunc func(name, command string) string
+
 var codexPluginHookTrustProbeFunc = probeCodexPluginHookTrust
 
-func probeCodexPluginHookTrust(ctx context.Context, projectDir, pluginKey string) codexPluginHookTrustResult {
+func probeCodexPluginHookTrust(ctx context.Context, projectDir, pluginKey string, extractManagedKey codexManagedKeyExtractorFunc) codexPluginHookTrustResult {
 	result := codexPluginHookTrustResult{PluginKey: pluginKey, Status: codexPluginHookTrustUndetectable}
 	if strings.TrimSpace(pluginKey) == "" {
 		result.Status = codexPluginHookTrustAbsent
@@ -149,7 +159,7 @@ func probeCodexPluginHookTrust(ctx context.Context, projectDir, pluginKey string
 		}
 		return result
 	}
-	return classifyCodexPluginHookTrust(pluginKey, *hooksResponse)
+	return classifyCodexPluginHookTrust(pluginKey, *hooksResponse, extractManagedKey)
 }
 
 func jsonRPCErrorPresent(raw json.RawMessage) bool {
@@ -157,7 +167,7 @@ func jsonRPCErrorPresent(raw json.RawMessage) bool {
 	return trimmed != "" && trimmed != "null"
 }
 
-func classifyCodexPluginHookTrust(pluginKey string, response codexHooksListResponse) codexPluginHookTrustResult {
+func classifyCodexPluginHookTrust(pluginKey string, response codexHooksListResponse, extractManagedKey codexManagedKeyExtractorFunc) codexPluginHookTrustResult {
 	result := codexPluginHookTrustResult{PluginKey: pluginKey, Status: codexPluginHookTrustUndetectable}
 	var matched []codexHookListMetadata
 	for _, entry := range response.Data {
@@ -202,6 +212,7 @@ func classifyCodexPluginHookTrust(pluginKey string, response codexHooksListRespo
 	}
 	if result.Status == codexPluginHookTrustTrusted && result.HookCount != expectedCodexPluginHookCount() {
 		result.Status = codexPluginHookTrustIncomplete
+		result.ExtraCommands, result.MissingCommands = diffCodexPluginHookCommands(matched, extractManagedKey)
 		result.Reason = fmt.Sprintf(
 			"Codex returned %d Traceary plugin hook commands; the current package requires exactly %d",
 			result.HookCount,
@@ -209,6 +220,57 @@ func classifyCodexPluginHookTrust(pluginKey string, response codexHooksListRespo
 		)
 	}
 	return result
+}
+
+// diffCodexPluginHookCommands compares the managed keys Codex reports as
+// trusted for the Traceary plugin against expectedCodexPluginHookCommands(),
+// naming which commands are unexpected surplus (for example a stale
+// generation's command Codex still trusts) and which expected commands are
+// absent. Hooks whose command does not normalize to a Traceary-managed key
+// (extractManagedKey returns "") are ignored rather than reported as extra,
+// since they are not attributable to a specific package generation.
+func diffCodexPluginHookCommands(matched []codexHookListMetadata, extractManagedKey codexManagedKeyExtractorFunc) (extra, missing []string) {
+	if extractManagedKey == nil {
+		return nil, nil
+	}
+	actual := map[string]struct{}{}
+	for _, hook := range matched {
+		if key := extractManagedKey("", hook.Command); key != "" {
+			actual[key] = struct{}{}
+		}
+	}
+	expected := map[string]struct{}{}
+	for _, key := range expectedCodexPluginHookCommands() {
+		expected[key] = struct{}{}
+		if _, ok := actual[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	for key := range actual {
+		if _, ok := expected[key]; !ok {
+			extra = append(extra, key)
+		}
+	}
+	sort.Strings(extra)
+	sort.Strings(missing)
+	return extra, missing
+}
+
+// formatCodexPluginHookCommandDiff renders the named extra/missing commands
+// from a codexPluginHookTrustIncomplete result as a message suffix, so the
+// doctor warning names the drift instead of only reporting a count mismatch.
+func formatCodexPluginHookCommandDiff(result codexPluginHookTrustResult) string {
+	var parts []string
+	if len(result.ExtraCommands) > 0 {
+		parts = append(parts, fmt.Sprintf("extra: %s", strings.Join(result.ExtraCommands, ", ")))
+	}
+	if len(result.MissingCommands) > 0 {
+		parts = append(parts, fmt.Sprintf("missing: %s", strings.Join(result.MissingCommands, ", ")))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, "; ") + ")"
 }
 
 func codexPluginHookTrustCheck(result codexPluginHookTrustResult) doctorCheck {
@@ -226,13 +288,13 @@ func codexPluginHookTrustCheck(result codexPluginHookTrustResult) doctorCheck {
 		return doctorCheck{
 			Name: name, Status: doctorStatusWarn, FixCommand: "codex",
 			Hint: Localize(
-				"update the Traceary Codex plugin, open `/hooks`, then review and trust every current hook before removing the manual fallback",
-				"Traceary Codex plugin を更新し、`/hooks` を開いて現在の hook をすべて確認・trust してから手動 fallback を削除してください",
+				"update the Traceary Codex plugin, open `/hooks`, then review and trust every current hook before removing the manual fallback; if a surplus command persists after updating, run `codex plugins refresh --purge-trust traceary@traceary-marketplace` to drop the stale generation's trust entries",
+				"Traceary Codex plugin を更新し、`/hooks` を開いて現在の hook をすべて確認・trust してから手動 fallback を削除してください。更新後も余剰 command が残る場合は `codex plugins refresh --purge-trust traceary@traceary-marketplace` で前世代の trust entry を破棄してください",
 			),
 			Message: localizef(
-				"Traceary plugin hook coverage is incomplete: Codex reports %d command(s), but the current package requires exactly %d; manual fallback hooks will be preserved: %s",
-				"Traceary plugin hook の coverage が不完全です。Codex は %d command を報告していますが、現在の package には正確に %d 件必要です。手動 fallback hook は保持されます: %s",
-				result.HookCount, expectedCodexPluginHookCount(), result.PluginKey,
+				"Traceary plugin hook coverage is incomplete: Codex reports %d command(s), but the current package requires exactly %d; manual fallback hooks will be preserved: %s%s",
+				"Traceary plugin hook の coverage が不完全です。Codex は %d command を報告していますが、現在の package には正確に %d 件必要です。手動 fallback hook は保持されます: %s%s",
+				result.HookCount, expectedCodexPluginHookCount(), result.PluginKey, formatCodexPluginHookCommandDiff(result),
 			),
 		}
 	case codexPluginHookTrustUntrusted, codexPluginHookTrustModified, codexPluginHookTrustDisabled:

--- a/presentation/cli/doctor_codex_hook_trust_test.go
+++ b/presentation/cli/doctor_codex_hook_trust_test.go
@@ -6,10 +6,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/duck8823/traceary/infrastructure/filesystem"
 )
+
+var testCodexManagedKeyExtractor = filesystem.NewHooksInspector().ExtractManagedKeyFromEntry
 
 func TestProbeCodexPluginHookTrustUsesHooksList(t *testing.T) {
 	binDir := t.TempDir()
@@ -39,7 +44,7 @@ print(json.dumps({"id": 1, "result": {"data": [{
 	}
 	t.Setenv("PATH", binDir)
 
-	got := probeCodexPluginHookTrust(context.Background(), "/tmp/project", "traceary@market")
+	got := probeCodexPluginHookTrust(context.Background(), "/tmp/project", "traceary@market", testCodexManagedKeyExtractor)
 	if got.Status != codexPluginHookTrustTrusted || got.HookCount != expectedCodexPluginHookCount() {
 		t.Fatalf("probeCodexPluginHookTrust() = %+v, want trusted hook", got)
 	}
@@ -139,11 +144,140 @@ func TestClassifyCodexPluginHookTrust(t *testing.T) {
 			if err := json.Unmarshal([]byte(tt.hooksJSON), &response); err != nil {
 				t.Fatalf("Unmarshal() error = %v", err)
 			}
-			got := classifyCodexPluginHookTrust("traceary@market", response)
+			got := classifyCodexPluginHookTrust("traceary@market", response, testCodexManagedKeyExtractor)
 			if got.Status != tt.wantStatus || got.HookCount != tt.wantCount {
 				t.Fatalf("classifyCodexPluginHookTrust() = status %q count %d, want status %q count %d", got.Status, got.HookCount, tt.wantStatus, tt.wantCount)
 			}
 		})
+	}
+}
+
+// TestClassifyCodexPluginHookTrust_NamesExtraCommand covers the case that
+// motivated this diagnostic: Codex still trusts a command from a previous
+// package generation (here, an old `traceary-compact.sh` phase name no
+// package generation ships anymore) alongside every currently-expected
+// command. Doctor should name the surplus command, not just report a count
+// mismatch.
+func TestClassifyCodexPluginHookTrust_NamesExtraCommand(t *testing.T) {
+	response := codexHooksListResponse{}
+	response.Data = append(response.Data, struct {
+		Hooks    []codexHookListMetadata `json:"hooks"`
+		Warnings []string                `json:"warnings"`
+		Errors   []codexHookErrorInfo    `json:"errors"`
+	}{Hooks: currentCodexHooks("traceary@market")})
+	response.Data[0].Hooks = append(response.Data[0].Hooks, codexHookListMetadata{
+		PluginID:   "traceary@market",
+		Enabled:    true,
+		TrustState: "trusted",
+		Command:    "TRACEARY_BIN='traceary' bash '/scripts/traceary-compact.sh' 'codex' 'legacy-phase'",
+	})
+
+	got := classifyCodexPluginHookTrust("traceary@market", response, testCodexManagedKeyExtractor)
+
+	if got.Status != codexPluginHookTrustIncomplete {
+		t.Fatalf("Status = %q, want %q", got.Status, codexPluginHookTrustIncomplete)
+	}
+	want := []string{"traceary-compact.sh:codex:legacy-phase"}
+	if diff := cmpDiffStrings(got.ExtraCommands, want); diff != "" {
+		t.Fatalf("ExtraCommands mismatch (-got +want):\n%s", diff)
+	}
+	if len(got.MissingCommands) != 0 {
+		t.Fatalf("MissingCommands = %v, want empty", got.MissingCommands)
+	}
+}
+
+// TestClassifyCodexPluginHookTrust_NamesMissingCommand covers an obsolete
+// hook set (fewer commands than the package expects) naming which specific
+// expected command is absent, not just the count.
+func TestClassifyCodexPluginHookTrust_NamesMissingCommand(t *testing.T) {
+	hooks := currentCodexHooks("traceary@market")
+	var withoutUsage []codexHookListMetadata
+	for _, hook := range hooks {
+		if strings.Contains(hook.Command, "'usage'") {
+			continue
+		}
+		withoutUsage = append(withoutUsage, hook)
+	}
+	response := codexHooksListResponse{}
+	response.Data = append(response.Data, struct {
+		Hooks    []codexHookListMetadata `json:"hooks"`
+		Warnings []string                `json:"warnings"`
+		Errors   []codexHookErrorInfo    `json:"errors"`
+	}{Hooks: withoutUsage})
+
+	got := classifyCodexPluginHookTrust("traceary@market", response, testCodexManagedKeyExtractor)
+
+	if got.Status != codexPluginHookTrustIncomplete {
+		t.Fatalf("Status = %q, want %q", got.Status, codexPluginHookTrustIncomplete)
+	}
+	want := []string{"traceary-usage.sh:codex"}
+	if diff := cmpDiffStrings(got.MissingCommands, want); diff != "" {
+		t.Fatalf("MissingCommands mismatch (-got +want):\n%s", diff)
+	}
+	if len(got.ExtraCommands) != 0 {
+		t.Fatalf("ExtraCommands = %v, want empty", got.ExtraCommands)
+	}
+}
+
+// currentCodexHooks builds one enabled+trusted codexHookListMetadata entry
+// per command in the current packaged Codex contract, with literal command
+// text matching what Codex's hooks/list reports for the shipped
+// plugins/traceary/hooks.json (verified against a live `codex app-server`
+// probe during investigation of issue 1975).
+func currentCodexHooks(pluginKey string) []codexHookListMetadata {
+	commands := []string{
+		"'traceary' 'hook' 'session' 'codex' 'start'",
+		"'traceary' 'hook' 'subagent-start' 'codex'",
+		"'traceary' 'hook' 'subagent-stop' 'codex'",
+		"'traceary' 'hook' 'compact' 'codex' 'pre-compact'",
+		"'traceary' 'hook' 'compact' 'codex' 'post-compact'",
+		"'traceary' 'hook' 'prompt' 'codex'",
+		"'traceary' 'hook' 'usage' 'codex'",
+		"'traceary' 'hook' 'transcript' 'codex'",
+		"'traceary' 'hook' 'session' 'codex' 'stop'",
+		"'traceary' 'hook' 'audit' 'codex'",
+	}
+	hooks := make([]codexHookListMetadata, 0, len(commands))
+	for _, command := range commands {
+		hooks = append(hooks, codexHookListMetadata{
+			PluginID:   pluginKey,
+			Enabled:    true,
+			TrustState: "trusted",
+			Command:    command,
+		})
+	}
+	return hooks
+}
+
+func cmpDiffStrings(got, want []string) string {
+	sortedGot := append([]string(nil), got...)
+	sortedWant := append([]string(nil), want...)
+	sort.Strings(sortedGot)
+	sort.Strings(sortedWant)
+	if len(sortedGot) != len(sortedWant) {
+		return fmt.Sprintf("got %v, want %v", sortedGot, sortedWant)
+	}
+	for i := range sortedGot {
+		if sortedGot[i] != sortedWant[i] {
+			return fmt.Sprintf("got %v, want %v", sortedGot, sortedWant)
+		}
+	}
+	return ""
+}
+
+// TestCodexPluginHookTrustCheck_NamesCommandDiff verifies the incomplete
+// message names the specific extra/missing commands (issue 1975) rather than
+// only reporting a bare count mismatch.
+func TestCodexPluginHookTrustCheck_NamesCommandDiff(t *testing.T) {
+	check := codexPluginHookTrustCheck(codexPluginHookTrustResult{
+		PluginKey:       "traceary@market",
+		Status:          codexPluginHookTrustIncomplete,
+		HookCount:       11,
+		ExtraCommands:   []string{"traceary-compact.sh:codex:legacy-phase"},
+		MissingCommands: nil,
+	})
+	if !strings.Contains(check.Message, "extra: traceary-compact.sh:codex:legacy-phase") {
+		t.Fatalf("Message = %q, want it to name the extra command", check.Message)
 	}
 }
 

--- a/presentation/cli/doctor_config_inspect.go
+++ b/presentation/cli/doctor_config_inspect.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -683,21 +684,33 @@ var codexManagedEventKeys = map[string][]string{
 	"PreCompact":       []string{"traceary-compact.sh:codex:pre-compact"},
 	"PostCompact":      []string{"traceary-compact.sh:codex:post-compact"},
 	"UserPromptSubmit": []string{"traceary-prompt.sh:codex"},
-	"Stop":             []string{"traceary-transcript.sh:codex", "traceary-session.sh:codex:stop"},
+	"Stop":             []string{"traceary-usage.sh:codex", "traceary-transcript.sh:codex", "traceary-session.sh:codex:stop"},
 	"PostToolUse":      []string{"traceary-audit.sh:codex"},
 }
 
 // expectedCodexPluginHookCount returns the number of command hooks in the
-// current packaged Codex contract. Codex app-server currently exposes plugin
-// identity and trust state per command, but not the event or command identity,
-// so exact cardinality is the fail-closed completeness boundary available to
-// doctor before it permits removal of the manual fallback.
+// current packaged Codex contract, derived from codexManagedEventKeys so the
+// cardinality check and the per-command diagnostics in
+// expectedCodexPluginHookCommands stay in sync with a single source of truth.
 func expectedCodexPluginHookCount() int {
 	count := 0
 	for _, keys := range codexManagedEventKeys {
 		count += len(keys)
 	}
 	return count
+}
+
+// expectedCodexPluginHookCommands returns the sorted, stable managed keys for
+// every command hook in the current packaged Codex contract. It is the same
+// data as expectedCodexPluginHookCount, flattened for per-command diffing
+// against what Codex actually reports as trusted (doctor_codex_hook_trust.go).
+func expectedCodexPluginHookCommands() []string {
+	commands := make([]string, 0, expectedCodexPluginHookCount())
+	for _, keys := range codexManagedEventKeys {
+		commands = append(commands, keys...)
+	}
+	sort.Strings(commands)
+	return commands
 }
 
 // missingTracearyManagedCodexEvents returns the subset of Traceary-managed

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -333,6 +333,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 				"PostCompact": [{"hooks": [{"type": "command", "command": "'traceary' 'hook' 'compact' 'codex' 'post-compact'"}]}],
 				"UserPromptSubmit": [{"hooks": [{"type": "command", "command": "'traceary' 'hook' 'prompt' 'codex'"}]}],
 				"Stop": [{"hooks": [
+					{"type": "command", "command": "'traceary' 'hook' 'usage' 'codex'"},
 					{"type": "command", "command": "'traceary' 'hook' 'transcript' 'codex'"},
 					{"type": "command", "command": "'traceary' 'hook' 'session' 'codex' 'stop'"}
 				]}],
@@ -383,6 +384,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 				"PostCompact": [{"hooks": [{"name": "traceary-compact-post-compact", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'compact' 'codex' 'post-compact'"}]}],
 				"UserPromptSubmit": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'prompt' 'codex'"}]}],
 				"Stop": [{"hooks": [
+					{"name": "traceary-usage", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'usage' 'codex'"},
 					{"name": "traceary-transcript", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'transcript' 'codex'"},
 					{"name": "traceary-session-stop", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'session' 'codex' 'stop'"}
 				]}],


### PR DESCRIPTION
## Summary

Doctor's Codex package contract now includes the `usage` Stop hook (`traceary-usage.sh:codex`). `expectedCodexPluginHookCount()` becomes 10, matching the shipped package and what Codex actually trusts. A count mismatch names the extra or missing commands.

## Why

Dogfood after the 0.39.0 Codex refresh warned "10 vs 9". The 10th command is a legitimate package hook that doctor never registered — not a leftover trust entry.

Closes #1975

Leaves parent #1968 open.

## Test plan

- [x] `go test ./presentation/cli/ ./infrastructure/filesystem/ -run 'CodexHook|expectedCodex|hooks_merge|DoctorCodex'`
- [x] `go tool golangci-lint run ./presentation/cli/... ./infrastructure/filesystem/...`