### PR TITLE
fix: reuse one read-only handle for an orphan consolidation pass

### DIFF
--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -185,6 +185,69 @@ type Database struct {
 	// resolved generation ids inside its snapshot transaction and before it
 	// reads generation-scoped counters. Tests commit a cutover here.
 	afterStatusGenerationScopeRead func()
+	// afterReadOnlyConnectionOpened runs each time openReadOnly or
+	// WithReadScope opens a genuinely fresh read-only connection (i.e. not a
+	// scope/shared-handle reuse). Tests use it to assert O(1) opens across a
+	// read-scoped pass; production leaves it nil.
+	afterReadOnlyConnectionOpened func()
+	// afterCompatibilityCheck runs each time checkStoreCompatibility succeeds
+	// inside openReadOnly or WithReadScope. Tests use it to assert the guard
+	// runs once per scope; production leaves it nil.
+	afterCompatibilityCheck func()
+}
+
+// readScopeKey is the unexported context key WithReadScope uses to carry its
+// shared read-only handle. Unexported so no package outside sqlite can read
+// or forge a scope value.
+type readScopeKey struct{}
+
+// readScope holds the read-only handle opened for the lifetime of a
+// WithReadScope call.
+type readScope struct {
+	db *sql.DB
+}
+
+// WithReadScope opens one read-only handle for the duration of fn, running
+// the store-compatibility guard exactly once at entry, and closes the handle
+// when fn returns (including on panic, via defer). Datasource methods that
+// call openReadOnly while ctx carries the scope reuse the shared handle
+// instead of opening their own. Nesting is safe: a WithReadScope call made
+// while ctx already carries a scope reuses the outer handle without opening
+// a second connection or re-running the guard. Callers that never enter a
+// scope are unaffected — openReadOnly keeps its current per-call behaviour.
+func (d *Database) WithReadScope(ctx context.Context, fn func(context.Context) error) error {
+	if _, ok := ctx.Value(readScopeKey{}).(*readScope); ok {
+		return fn(ctx)
+	}
+	if d.sharedReadOnly != nil {
+		// The benchmark-only shared immutable connection group already gives
+		// every openReadOnly call the same handle; nothing further to scope.
+		return fn(ctx)
+	}
+
+	dbPath := d.Path()
+	db := openCoordinatedDB(dbPath, sqliteReadOnlyDSN(dbPath))
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return xerrors.Errorf("failed to ping read-only SQLite DB: %w", err)
+	}
+	if err := checkStoreCompatibility(ctx, db); err != nil {
+		_ = db.Close()
+		return err
+	}
+	if d.afterCompatibilityCheck != nil {
+		d.afterCompatibilityCheck()
+	}
+	if d.afterReadOnlyConnectionOpened != nil {
+		d.afterReadOnlyConnectionOpened()
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			slog.Debug("failed to close resource", "error", closeErr)
+		}
+	}()
+
+	return fn(context.WithValue(ctx, readScopeKey{}, &readScope{db: db}))
 }
 
 // NewImmutableReadDatabase opens one shared immutable connection group for benchmark orchestration.
@@ -279,6 +342,9 @@ func (d *Database) open(ctx context.Context) (_ *sql.DB, err error) {
 // migrate a store, change database content, or change file permissions. SQLite
 // may still create WAL shared-memory sidecars while reading a WAL-mode store.
 func (d *Database) openReadOnly(ctx context.Context) (_ *sql.DB, err error) {
+	if scope, ok := ctx.Value(readScopeKey{}).(*readScope); ok {
+		return scope.db, nil
+	}
 	if d.sharedReadOnly != nil {
 		return d.sharedReadOnly, nil
 	}
@@ -296,6 +362,12 @@ func (d *Database) openReadOnly(ctx context.Context) (_ *sql.DB, err error) {
 	}
 	if err := checkStoreCompatibility(ctx, db); err != nil {
 		return nil, err
+	}
+	if d.afterCompatibilityCheck != nil {
+		d.afterCompatibilityCheck()
+	}
+	if d.afterReadOnlyConnectionOpened != nil {
+		d.afterReadOnlyConnectionOpened()
 	}
 	return db, nil
 }

--- a/infrastructure/sqlite/database_read_scope_internal_test.go
+++ b/infrastructure/sqlite/database_read_scope_internal_test.go
@@ -1,0 +1,216 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newReadScopeTestDatabase(t *testing.T) *Database {
+	t.Helper()
+	path := t.TempDir() + "/store.db"
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// SQLite defers actually creating the file until first use; force it so
+	// the read-only DSN below (mode=ro) has a file to open.
+	if _, err := raw.Exec(`PRAGMA user_version`); err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return NewDatabase(path, nil)
+}
+
+// TestWithReadScope_OpensOnceClosesOnceChecksCompatOnce covers TDD plan item
+// 1: a single WithReadScope call opens exactly one connection, runs the
+// compatibility guard exactly once, and closes the connection when fn
+// returns.
+func TestWithReadScope_OpensOnceClosesOnceChecksCompatOnce(t *testing.T) {
+	ctx := context.Background()
+	database := newReadScopeTestDatabase(t)
+
+	var opens, compatChecks int
+	database.SetReadOnlyOpenHookForTest(func() { opens++ })
+	database.SetCompatibilityCheckHookForTest(func() { compatChecks++ })
+
+	var handleInsideScope *sql.DB
+	err := database.WithReadScope(ctx, func(scopedCtx context.Context) error {
+		db, err := database.openReadOnly(scopedCtx)
+		if err != nil {
+			return err
+		}
+		handleInsideScope = db
+		return db.PingContext(scopedCtx)
+	})
+	if err != nil {
+		t.Fatalf("WithReadScope() error = %v", err)
+	}
+	if opens != 1 {
+		t.Fatalf("opens = %d, want 1", opens)
+	}
+	if compatChecks != 1 {
+		t.Fatalf("compatChecks = %d, want 1", compatChecks)
+	}
+	if err := handleInsideScope.PingContext(ctx); err == nil {
+		t.Fatal("handle still usable after WithReadScope returned; want it closed")
+	}
+}
+
+// TestWithReadScope_NestedReusesOuterHandle covers TDD plan item 2: a nested
+// WithReadScope call made while ctx already carries a scope must reuse the
+// outer handle rather than opening a second connection or re-running the
+// compatibility guard.
+func TestWithReadScope_NestedReusesOuterHandle(t *testing.T) {
+	ctx := context.Background()
+	database := newReadScopeTestDatabase(t)
+
+	var opens, compatChecks int
+	database.SetReadOnlyOpenHookForTest(func() { opens++ })
+	database.SetCompatibilityCheckHookForTest(func() { compatChecks++ })
+
+	var outer, inner *sql.DB
+	err := database.WithReadScope(ctx, func(outerCtx context.Context) error {
+		var err error
+		outer, err = database.openReadOnly(outerCtx)
+		if err != nil {
+			return err
+		}
+		return database.WithReadScope(outerCtx, func(innerCtx context.Context) error {
+			var err error
+			inner, err = database.openReadOnly(innerCtx)
+			return err
+		})
+	})
+	if err != nil {
+		t.Fatalf("WithReadScope() error = %v", err)
+	}
+	if opens != 1 {
+		t.Fatalf("opens = %d, want 1 (nested scope must reuse the outer handle)", opens)
+	}
+	if compatChecks != 1 {
+		t.Fatalf("compatChecks = %d, want 1", compatChecks)
+	}
+	if outer != inner {
+		t.Fatal("nested WithReadScope returned a different handle than the outer scope")
+	}
+}
+
+// TestWithReadScope_CallerThatSkipsScopeSeesPerCallBehaviour covers TDD plan
+// item 4: a caller that never enters WithReadScope must keep paying
+// setup+ping+compat on every openReadOnly call.
+func TestWithReadScope_CallerThatSkipsScopeSeesPerCallBehaviour(t *testing.T) {
+	ctx := context.Background()
+	database := newReadScopeTestDatabase(t)
+
+	var opens, compatChecks int
+	database.SetReadOnlyOpenHookForTest(func() { opens++ })
+	database.SetCompatibilityCheckHookForTest(func() { compatChecks++ })
+
+	for i := 0; i < 3; i++ {
+		db, err := database.openReadOnly(ctx)
+		if err != nil {
+			t.Fatalf("openReadOnly() error = %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}
+	if opens != 3 {
+		t.Fatalf("opens = %d, want 3 (no scope entered, so each call opens its own connection)", opens)
+	}
+	if compatChecks != 3 {
+		t.Fatalf("compatChecks = %d, want 3", compatChecks)
+	}
+}
+
+// TestWithReadScope_ClosesHandleOnPanic covers the Given/When/Then panic
+// case: the handle opened by WithReadScope must close via defer even when fn
+// panics, so no *sql.DB leaks out of a crashed candidate loop.
+func TestWithReadScope_ClosesHandleOnPanic(t *testing.T) {
+	ctx := context.Background()
+	database := newReadScopeTestDatabase(t)
+
+	var handleInsideScope *sql.DB
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic to propagate through WithReadScope")
+			}
+		}()
+		_ = database.WithReadScope(ctx, func(scopedCtx context.Context) error {
+			db, err := database.openReadOnly(scopedCtx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			handleInsideScope = db
+			panic("boom")
+		})
+	}()
+
+	if err := handleInsideScope.PingContext(ctx); err == nil {
+		t.Fatal("handle still usable after a panic inside WithReadScope; want it closed")
+	}
+}
+
+// TestWithReadScope_CompatibilityFailureStopsAtEntry covers the
+// Given/When/Then compatibility case: an incompatible store must fail scope
+// entry before fn runs at all, and openReadOnly must independently reject
+// the same store.
+func TestWithReadScope_CompatibilityFailureStopsAtEntry(t *testing.T) {
+	ctx := context.Background()
+	path := t.TempDir() + "/future.db"
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE store_format_state(singleton INTEGER PRIMARY KEY, minimum_reader_version INTEGER NOT NULL, maximum_payload_format INTEGER NOT NULL); INSERT INTO store_format_state VALUES(1, 35, 1)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	database := NewDatabase(path, nil)
+	fnRan := false
+	err = database.WithReadScope(ctx, func(context.Context) error {
+		fnRan = true
+		return nil
+	})
+	if err == nil {
+		t.Fatal("WithReadScope accepted a future reader requirement")
+	}
+	if fnRan {
+		t.Fatal("fn ran despite a failed compatibility guard at scope entry")
+	}
+	if _, err := database.openReadOnly(ctx); err == nil {
+		t.Fatal("openReadOnly accepted a future reader requirement")
+	}
+}
+
+// TestWithReadScope_PropagatesCancelledContext covers the Given/When/Then
+// cancellation case: fn observes ctx.Err() from the scoped context.
+func TestWithReadScope_PropagatesCancelledContext(t *testing.T) {
+	database := newReadScopeTestDatabase(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := database.WithReadScope(context.Background(), func(_ context.Context) error {
+		// Re-derive cancellation state inside fn using the already-cancelled
+		// parent, mirroring a candidate loop that checks ctx.Err() mid-pass.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return errors.New("expected ctx to already be cancelled")
+		}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}

--- a/infrastructure/sqlite/export_test.go
+++ b/infrastructure/sqlite/export_test.go
@@ -82,3 +82,18 @@ func (d *StoreManagementDatasource) SetGarbageCollectionNowForTest(now func() ti
 // WAL, busy_timeout DSN production readers and writers use, so tests do not
 // hand-write a divergent DSN for the store they exercise.
 func OpenStoreForTest(path string) *sql.DB { return openCoordinatedDB(path, sqliteDSN(path)) }
+
+// SetReadOnlyOpenHookForTest runs each time openReadOnly or WithReadScope
+// opens a genuinely fresh read-only connection (not a scope/shared-handle
+// reuse). Tests use it to assert O(1) opens across a read-scoped pass. Pass
+// nil to clear.
+func (d *Database) SetReadOnlyOpenHookForTest(hook func()) {
+	d.afterReadOnlyConnectionOpened = hook
+}
+
+// SetCompatibilityCheckHookForTest runs each time checkStoreCompatibility
+// succeeds inside openReadOnly or WithReadScope. Tests use it to assert the
+// guard runs once per scope. Pass nil to clear.
+func (d *Database) SetCompatibilityCheckHookForTest(hook func()) {
+	d.afterCompatibilityCheck = hook
+}

--- a/infrastructure/sqlite/session_orphan_range_datasource.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource.go
@@ -50,6 +50,16 @@ func NewSessionOrphanRangeDatasource(db *Database) *SessionOrphanRangeDatasource
 
 var _ model.SessionOrphanRangeRepository = (*SessionOrphanRangeDatasource)(nil)
 
+// WithReadScope lets a caller that will run DiscoverCandidates and
+// LoadMaterial together as one orphan-consolidation pass share a single
+// read-only handle instead of paying setup+ping+compat once per candidate.
+// fn receives a context carrying the scope; pass it (or a context derived
+// from it) to the calls that should share the handle. Callers that never
+// enter a scope see the current per-call behaviour on each call.
+func (d *SessionOrphanRangeDatasource) WithReadScope(ctx context.Context, fn func(context.Context) error) error {
+	return d.db.WithReadScope(ctx, fn)
+}
+
 // Record inserts an orphan range. Re-recording the same PK is a no-op.
 func (d *SessionOrphanRangeDatasource) Record(ctx context.Context, orphan *model.SessionOrphanRange) error {
 	if orphan == nil {
@@ -97,109 +107,112 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 	if limit <= 0 {
 		return model.SessionOrphanCandidates{}, xerrors.Errorf("limit must be greater than zero")
 	}
-	db, err := d.openForDiscovery(ctx)
-	if err != nil {
-		return model.SessionOrphanCandidates{}, err
-	}
-	defer func() {
-		if err := db.Close(); err != nil {
-			slog.Debug("failed to close resource", "error", err)
-		}
-	}()
-
-	cutoff := formatTimestamp(now.UTC().Add(-staleAfter))
-	seen := map[string]struct{}{}
-	var candidates []*model.SessionOrphanRange
-	target := limit + 1
-
-	// Front-loaded shortcuts: recorded rows on sessions that are still active.
-	// Ended/stale discovery below is the source of truth for those sessions.
-	recorded, err := d.listRecorded(ctx, db)
-	if err != nil {
-		return model.SessionOrphanCandidates{}, err
-	}
-	for _, orphan := range recorded {
-		if err := ctx.Err(); err != nil {
-			return model.SessionOrphanCandidates{}, xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
-		}
-		if len(candidates) >= target {
-			break
-		}
-		covered, err := d.refinementCovers(ctx, db, orphan.SessionID(), orphan.ToEventID())
+	var result model.SessionOrphanCandidates
+	err := d.db.WithReadScope(ctx, func(ctx context.Context) error {
+		db, err := d.openForDiscovery(ctx)
 		if err != nil {
-			return model.SessionOrphanCandidates{}, err
+			return err
 		}
-		if covered {
-			continue
-		}
-		endedOrStale, err := d.sessionEndedOrStale(ctx, db, orphan.SessionID(), cutoff)
-		if err != nil {
-			return model.SessionOrphanCandidates{}, err
-		}
-		if endedOrStale {
-			// Will be rediscovered from covers_to below with the full gap.
-			continue
-		}
-		key := orphan.SessionID().String() + "\x00" + orphan.ToEventID().String()
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		candidates = append(candidates, orphan)
-	}
 
-	// Source of truth: ended or stale sessions with material past covers_to.
-	// Paginate by session_id keyset until target valid candidates are collected
-	// or the scan is exhausted.
-	if len(candidates) < target {
-		cursor := ""
-		pageSize := limit + 1
-		for len(candidates) < target {
+		cutoff := formatTimestamp(now.UTC().Add(-staleAfter))
+		seen := map[string]struct{}{}
+		var candidates []*model.SessionOrphanRange
+		target := limit + 1
+
+		// Front-loaded shortcuts: recorded rows on sessions that are still active.
+		// Ended/stale discovery below is the source of truth for those sessions.
+		recorded, err := d.listRecorded(ctx, db)
+		if err != nil {
+			return err
+		}
+		for _, orphan := range recorded {
 			if err := ctx.Err(); err != nil {
-				return model.SessionOrphanCandidates{}, xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
+				return xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
 			}
-			page, err := d.listEndedOrStalePage(ctx, db, cutoff, cursor, pageSize)
-			if err != nil {
-				return model.SessionOrphanCandidates{}, err
-			}
-			if len(page) == 0 {
+			if len(candidates) >= target {
 				break
 			}
-			// Advance the cursor from the last SQL row even when every row was
-			// filtered out in Go; otherwise a page of non-candidates loops forever.
-			cursor = page[len(page)-1].String()
-			for _, sessionID := range page {
-				if len(candidates) >= target {
+			covered, err := d.refinementCovers(ctx, db, orphan.SessionID(), orphan.ToEventID())
+			if err != nil {
+				return err
+			}
+			if covered {
+				continue
+			}
+			endedOrStale, err := d.sessionEndedOrStale(ctx, db, orphan.SessionID(), cutoff)
+			if err != nil {
+				return err
+			}
+			if endedOrStale {
+				// Will be rediscovered from covers_to below with the full gap.
+				continue
+			}
+			key := orphan.SessionID().String() + "\x00" + orphan.ToEventID().String()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			candidates = append(candidates, orphan)
+		}
+
+		// Source of truth: ended or stale sessions with material past covers_to.
+		// Paginate by session_id keyset until target valid candidates are collected
+		// or the scan is exhausted.
+		if len(candidates) < target {
+			cursor := ""
+			pageSize := limit + 1
+			for len(candidates) < target {
+				if err := ctx.Err(); err != nil {
+					return xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
+				}
+				page, err := d.listEndedOrStalePage(ctx, db, cutoff, cursor, pageSize)
+				if err != nil {
+					return err
+				}
+				if len(page) == 0 {
 					break
 				}
-				orphan, ok, err := d.gapPastCoverage(ctx, db, sessionID, now)
-				if err != nil {
-					return model.SessionOrphanCandidates{}, err
+				// Advance the cursor from the last SQL row even when every row was
+				// filtered out in Go; otherwise a page of non-candidates loops forever.
+				cursor = page[len(page)-1].String()
+				for _, sessionID := range page {
+					if len(candidates) >= target {
+						break
+					}
+					orphan, ok, err := d.gapPastCoverage(ctx, db, sessionID, now)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						continue
+					}
+					key := orphan.SessionID().String() + "\x00" + orphan.ToEventID().String()
+					if _, exists := seen[key]; exists {
+						continue
+					}
+					seen[key] = struct{}{}
+					candidates = append(candidates, orphan)
 				}
-				if !ok {
-					continue
+				if len(page) < pageSize {
+					break
 				}
-				key := orphan.SessionID().String() + "\x00" + orphan.ToEventID().String()
-				if _, exists := seen[key]; exists {
-					continue
-				}
-				seen[key] = struct{}{}
-				candidates = append(candidates, orphan)
-			}
-			if len(page) < pageSize {
-				break
 			}
 		}
-	}
 
-	hasMore := len(candidates) > limit
-	if hasMore {
-		candidates = candidates[:limit]
+		hasMore := len(candidates) > limit
+		if hasMore {
+			candidates = candidates[:limit]
+		}
+		result = model.SessionOrphanCandidates{
+			Ranges:  candidates,
+			HasMore: hasMore,
+		}
+		return nil
+	})
+	if err != nil {
+		return model.SessionOrphanCandidates{}, err
 	}
-	return model.SessionOrphanCandidates{
-		Ranges:  candidates,
-		HasMore: hasMore,
-	}, nil
+	return result, nil
 }
 
 // LoadMaterial returns mechanical-summary inputs for a range.
@@ -209,79 +222,82 @@ func (d *SessionOrphanRangeDatasource) LoadMaterial(
 	fromExclusive types.Optional[types.EventID],
 	toInclusive types.EventID,
 ) (model.SessionOrphanMaterial, error) {
-	db, err := d.openForDiscovery(ctx)
+	var material model.SessionOrphanMaterial
+	err := d.db.WithReadScope(ctx, func(ctx context.Context) error {
+		db, err := d.openForDiscovery(ctx)
+		if err != nil {
+			return err
+		}
+
+		fromID := ""
+		if from, ok := fromExclusive.Value(); ok {
+			fromID = from.String()
+		}
+		toID := toInclusive.String()
+
+		rows, err := db.QueryContext(ctx, selectOrphanRangeEventsQuery, sessionID.String(), fromID, fromID, toID)
+		if err != nil {
+			return xerrors.Errorf("failed to list orphan range events: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+
+		loaded := model.SessionOrphanMaterial{
+			KindCounts: map[string]int{},
+		}
+		for rows.Next() {
+			var id, kind, createdAtRaw string
+			if err := rows.Scan(&id, &kind, &createdAtRaw); err != nil {
+				return xerrors.Errorf("failed to scan orphan range event: %w", err)
+			}
+			createdAt, err := time.Parse(time.RFC3339Nano, createdAtRaw)
+			if err != nil {
+				return xerrors.Errorf("invalid orphan event created_at %q: %w", createdAtRaw, err)
+			}
+			if loaded.EventCount == 0 {
+				loaded.FirstCreatedAt = createdAt
+			}
+			loaded.LastCreatedAt = createdAt
+			loaded.KindCounts[kind]++
+			loaded.EventCount++
+		}
+		if err := rows.Err(); err != nil {
+			return xerrors.Errorf("failed to iterate orphan range events: %w", err)
+		}
+		if loaded.EventCount == 0 {
+			return xerrors.Errorf(
+				"orphan range %s..%s for session %s has no events: %w",
+				fromID, toID, sessionID, model.ErrInvalidSessionOrphanRange,
+			)
+		}
+
+		cmdRows, err := db.QueryContext(ctx, selectOrphanRangeCommandsQuery, sessionID.String(), fromID, fromID, toID)
+		if err != nil {
+			return xerrors.Errorf("failed to list orphan range commands: %w", err)
+		}
+		defer func() { _ = cmdRows.Close() }()
+		for cmdRows.Next() {
+			var eventID string
+			if err := cmdRows.Scan(&eventID); err != nil {
+				return xerrors.Errorf("failed to scan orphan range command event id: %w", err)
+			}
+			// command_text is codec-managed; decode through the shared boundary so
+			// a zstd-compressed audit never surfaces as binary garbage here.
+			command, err := hydrateAuditPayload(ctx, db, eventID, "command")
+			if err != nil {
+				return xerrors.Errorf("failed to decode orphan range command for %s: %w", eventID, err)
+			}
+			if command.Valid {
+				loaded.Commands = append(loaded.Commands, command.String)
+			}
+		}
+		if err := cmdRows.Err(); err != nil {
+			return xerrors.Errorf("failed to iterate orphan range commands: %w", err)
+		}
+		material = loaded
+		return nil
+	})
 	if err != nil {
 		return model.SessionOrphanMaterial{}, err
-	}
-	defer func() {
-		if err := db.Close(); err != nil {
-			slog.Debug("failed to close resource", "error", err)
-		}
-	}()
-
-	fromID := ""
-	if from, ok := fromExclusive.Value(); ok {
-		fromID = from.String()
-	}
-	toID := toInclusive.String()
-
-	rows, err := db.QueryContext(ctx, selectOrphanRangeEventsQuery, sessionID.String(), fromID, fromID, toID)
-	if err != nil {
-		return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to list orphan range events: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	material := model.SessionOrphanMaterial{
-		KindCounts: map[string]int{},
-	}
-	for rows.Next() {
-		var id, kind, createdAtRaw string
-		if err := rows.Scan(&id, &kind, &createdAtRaw); err != nil {
-			return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to scan orphan range event: %w", err)
-		}
-		createdAt, err := time.Parse(time.RFC3339Nano, createdAtRaw)
-		if err != nil {
-			return model.SessionOrphanMaterial{}, xerrors.Errorf("invalid orphan event created_at %q: %w", createdAtRaw, err)
-		}
-		if material.EventCount == 0 {
-			material.FirstCreatedAt = createdAt
-		}
-		material.LastCreatedAt = createdAt
-		material.KindCounts[kind]++
-		material.EventCount++
-	}
-	if err := rows.Err(); err != nil {
-		return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to iterate orphan range events: %w", err)
-	}
-	if material.EventCount == 0 {
-		return model.SessionOrphanMaterial{}, xerrors.Errorf(
-			"orphan range %s..%s for session %s has no events: %w",
-			fromID, toID, sessionID, model.ErrInvalidSessionOrphanRange,
-		)
-	}
-
-	cmdRows, err := db.QueryContext(ctx, selectOrphanRangeCommandsQuery, sessionID.String(), fromID, fromID, toID)
-	if err != nil {
-		return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to list orphan range commands: %w", err)
-	}
-	defer func() { _ = cmdRows.Close() }()
-	for cmdRows.Next() {
-		var eventID string
-		if err := cmdRows.Scan(&eventID); err != nil {
-			return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to scan orphan range command event id: %w", err)
-		}
-		// command_text is codec-managed; decode through the shared boundary so
-		// a zstd-compressed audit never surfaces as binary garbage here.
-		command, err := hydrateAuditPayload(ctx, db, eventID, "command")
-		if err != nil {
-			return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to decode orphan range command for %s: %w", eventID, err)
-		}
-		if command.Valid {
-			material.Commands = append(material.Commands, command.String)
-		}
-	}
-	if err := cmdRows.Err(); err != nil {
-		return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to iterate orphan range commands: %w", err)
 	}
 	return material, nil
 }

--- a/infrastructure/sqlite/session_orphan_range_datasource_test.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource_test.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/xerrors"
 	_ "modernc.org/sqlite"
 
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
@@ -21,6 +23,7 @@ import (
 
 type orphanFixture struct {
 	dbPath   string
+	database *sqlite.Database
 	orphans  *sqlite.SessionOrphanRangeDatasource
 	refine   *sqlite.SessionRefinementDatasource
 	sessions *sqlite.SessionDatasource
@@ -37,6 +40,7 @@ func newOrphanFixture(t *testing.T) orphanFixture {
 	}
 	return orphanFixture{
 		dbPath:   dbPath,
+		database: database,
 		orphans:  sqlite.NewSessionOrphanRangeDatasource(database),
 		refine:   sqlite.NewSessionRefinementDatasource(database),
 		sessions: sqlite.NewSessionDatasource(database),
@@ -1156,5 +1160,104 @@ SELECT id,
 	}
 	if seen == 0 {
 		t.Fatal("no events found for the seeded session")
+	}
+}
+
+// TestSessionOrphanRangeDatasource_WithReadScope_SharesOneHandleAcrossManyCandidates
+// is the #1722 integration case: a real consolidation pass over N candidates
+// wrapped in one WithReadScope must open exactly one read-only connection and
+// run the store-compatibility guard exactly once, not once per candidate.
+func TestSessionOrphanRangeDatasource_WithReadScope_SharesOneHandleAcrossManyCandidates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fx := newOrphanFixture(t)
+
+	const candidateCount = 25
+	base := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < candidateCount; i++ {
+		sessionID := fmt.Sprintf("sess-scope-%02d", i)
+		seedOrphanSession(ctx, t, fx, sessionID, []eventSeed{
+			{id: sessionID + "-evt-1", at: base.Add(time.Duration(i) * time.Minute)},
+			{id: sessionID + "-evt-2", at: base.Add(time.Duration(i)*time.Minute + 30*time.Second)},
+		}, true)
+	}
+
+	now := base.Add(48 * time.Hour)
+	consol := usecase.NewOrphanConsolidationUsecase(
+		fx.orphans,
+		usecase.NewSessionRefinementUsecase(fx.sessions, fx.refine, fx.events, types.SystemClock{}),
+		fixedEventClock{at: now},
+	)
+
+	var opens, compatChecks int
+	fx.database.SetReadOnlyOpenHookForTest(func() { opens++ })
+	fx.database.SetCompatibilityCheckHookForTest(func() { compatChecks++ })
+	defer fx.database.SetReadOnlyOpenHookForTest(nil)
+	defer fx.database.SetCompatibilityCheckHookForTest(nil)
+
+	var result apptypes.OrphanConsolidationResult
+	err := fx.orphans.WithReadScope(ctx, func(scopedCtx context.Context) error {
+		var consolidateErr error
+		result, consolidateErr = consol.Consolidate(scopedCtx, usecase.OrphanConsolidationInput{StaleAfter: 24 * time.Hour})
+		if consolidateErr != nil {
+			return xerrors.Errorf("consolidate orphan ranges: %w", consolidateErr)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Consolidate() error = %v", err)
+	}
+	if result.ProducedCount() != candidateCount {
+		t.Fatalf("ProducedCount = %d, want %d", result.ProducedCount(), candidateCount)
+	}
+	if opens != 1 {
+		t.Fatalf("read-only opens = %d, want 1 for a single read-scoped pass over %d candidates", opens, candidateCount)
+	}
+	if compatChecks != 1 {
+		t.Fatalf("compatibility checks = %d, want 1", compatChecks)
+	}
+}
+
+// TestSessionOrphanRangeDatasource_WithoutReadScope_OpensPerCandidateCall is
+// the regression guard: a caller that never enters WithReadScope must keep
+// today's per-call behaviour (DiscoverCandidates plus one LoadMaterial per
+// candidate, each paying its own open+compat).
+func TestSessionOrphanRangeDatasource_WithoutReadScope_OpensPerCandidateCall(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fx := newOrphanFixture(t)
+
+	const candidateCount = 3
+	base := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < candidateCount; i++ {
+		sessionID := fmt.Sprintf("sess-noscope-%02d", i)
+		seedOrphanSession(ctx, t, fx, sessionID, []eventSeed{
+			{id: sessionID + "-evt-1", at: base.Add(time.Duration(i) * time.Minute)},
+			{id: sessionID + "-evt-2", at: base.Add(time.Duration(i)*time.Minute + 30*time.Second)},
+		}, true)
+	}
+
+	now := base.Add(48 * time.Hour)
+	consol := usecase.NewOrphanConsolidationUsecase(
+		fx.orphans,
+		usecase.NewSessionRefinementUsecase(fx.sessions, fx.refine, fx.events, types.SystemClock{}),
+		fixedEventClock{at: now},
+	)
+
+	var opens int
+	fx.database.SetReadOnlyOpenHookForTest(func() { opens++ })
+	defer fx.database.SetReadOnlyOpenHookForTest(nil)
+
+	result, err := consol.Consolidate(ctx, usecase.OrphanConsolidationInput{StaleAfter: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("Consolidate() error = %v", err)
+	}
+	if result.ProducedCount() != candidateCount {
+		t.Fatalf("ProducedCount = %d, want %d", result.ProducedCount(), candidateCount)
+	}
+	// DiscoverCandidates opens once, then each of the candidateCount
+	// LoadMaterial calls opens its own connection: candidateCount+1 total.
+	if want := candidateCount + 1; opens != want {
+		t.Fatalf("read-only opens = %d, want %d (no shared scope entered)", opens, want)
 	}
 }

--- a/layering_sql_leak_test.go
+++ b/layering_sql_leak_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"golang.org/x/xerrors"
+)
+
+// sqlConnectionTypePattern matches a connection-typed reference (*sql.DB or
+// *sql.Conn) as a Go identifier, not a substring of an unrelated word.
+var sqlConnectionTypePattern = regexp.MustCompile(`\*sql\.(DB|Conn)\b`)
+
+// TestDomainAndApplicationDoNotLeakSQLConnectionTypes guards the layer
+// boundary #1722 depends on: Database.WithReadScope hands datasources a
+// shared *sql.DB internally, but that connection type must never surface in
+// a domain or application signature. If it does, the read-scope primitive
+// (or some unrelated change) has punched a hole through the repository
+// interface that hides infrastructure lifetime management from callers who
+// cannot see it.
+func TestDomainAndApplicationDoNotLeakSQLConnectionTypes(t *testing.T) {
+	t.Parallel()
+	for _, root := range []string{"domain", "application"} {
+		root := root
+		t.Run(root, func(t *testing.T) {
+			t.Parallel()
+			err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() || !strings.HasSuffix(path, ".go") {
+					return nil
+				}
+				contents, readErr := os.ReadFile(path)
+				if readErr != nil {
+					return xerrors.Errorf("read %s: %w", path, readErr)
+				}
+				if loc := sqlConnectionTypePattern.FindIndex(contents); loc != nil {
+					t.Errorf("%s references a connection-typed value (%q); domain/application must depend only on repository interfaces, never *sql.DB or *sql.Conn", path, contents[loc[0]:loc[1]])
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("failed to walk %s: %v", root, err)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/filesystem"
@@ -448,9 +449,20 @@ func compactWorkCover(migrations fs.FS) func(context.Context, string) error {
 		orphanDatasource := sqlite.NewSessionOrphanRangeDatasource(db)
 		refine := usecase.NewSessionRefinementUsecase(sessionDatasource, refinementDatasource, eventDatasource, types.SystemClock{})
 		cover := usecase.NewOrphanConsolidationUsecase(orphanDatasource, refine, types.SystemClock{})
-		result, err := cover.Consolidate(ctx, usecase.OrphanConsolidationInput{
-			StaleAfter: 24 * time.Hour,
-			Unlimited:  true,
+		// One read-only handle for the whole pass: DiscoverCandidates and every
+		// per-candidate LoadMaterial call inherit it instead of each paying
+		// setup+ping+compat on its own (#1722).
+		var result apptypes.OrphanConsolidationResult
+		err := orphanDatasource.WithReadScope(ctx, func(scopedCtx context.Context) error {
+			var consolidateErr error
+			result, consolidateErr = cover.Consolidate(scopedCtx, usecase.OrphanConsolidationInput{
+				StaleAfter: 24 * time.Hour,
+				Unlimited:  true,
+			})
+			if consolidateErr != nil {
+				return xerrors.Errorf("consolidate orphan ranges: %w", consolidateErr)
+			}
+			return nil
 		})
 		if err != nil {
 			return xerrors.Errorf("compact force cover: %w", err)


### PR DESCRIPTION
## Summary

`Database.WithReadScope` opens one read-only handle, runs `checkStoreCompatibility` once, and reuses the handle for `openReadOnly` while the scope is active. The compact orphan-consolidation pass enters that scope so N candidates cost O(1) connections, not O(N). Callers outside a scope keep the per-call path. No `*sql.DB` appears in `domain/` or `application/` signatures.

Closes #1722

Leaves parent #1968 open.

## Test plan

- [x] `go test ./infrastructure/sqlite/ -run 'WithReadScope|ReadScope|OrphanRangeDatasource_WithReadScope'`
- [x] `go test -run Leak .`
- [x] `go tool golangci-lint run ./infrastructure/sqlite/...`