### PR TITLE
fix: store encoded payload bytes in the dedupe archive

### DIFF
--- a/infrastructure/sqlite/content_event_dedupe_codec_internal_test.go
+++ b/infrastructure/sqlite/content_event_dedupe_codec_internal_test.go
@@ -1,0 +1,234 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// dedupeCodecMigrations returns the on-disk embedded migration set, matching
+// the pattern content_event_dedupe_unreadable_internal_test.go already uses
+// for internal (package sqlite) tests that need an on-disk store.
+func dedupeCodecMigrations() fs.FS {
+	return os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations"))
+}
+
+// migrationsBeforeDedupeArchiveCodec returns every embedded migration older
+// than #1744's, so a test can build a genuine pre-migration archive row
+// before reopening with the full set -- mirrors
+// migrationsBeforeCodecFoundation in payload_codec_compatibility_internal_test.go.
+func migrationsBeforeDedupeArchiveCodec(t *testing.T) fstest.MapFS {
+	t.Helper()
+	dir := filepath.Join("..", "..", "schema", "sqlite", "migrations")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := fstest.MapFS{}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() >= "000067" {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		out[entry.Name()] = &fstest.MapFile{Data: data}
+	}
+	return out
+}
+
+// insertCompressedDedupeEvent writes an events row exactly as the canonical
+// write path would after choosing zstd: the raw INSERT bypasses
+// appendAttestationLink (unlike EventDatasource.Save), which is what keeps a
+// prompt-kind row eligible for dedupe in this fixture.
+func insertCompressedDedupeEvent(t *testing.T, db *sql.DB, id, sessionID, createdAt, plaintext string) encodedPayload {
+	t.Helper()
+	payload, err := encodePayload([]byte(plaintext), payloadCodecZstd)
+	if err != nil {
+		t.Fatalf("encodePayload(%s) error = %v", id, err)
+	}
+	if payload.StoredBytes >= payload.PlaintextBytes {
+		t.Fatalf("insertCompressedDedupeEvent(%s): fixture body did not compress (stored=%d plaintext=%d)", id, payload.StoredBytes, payload.PlaintextBytes)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client,
+		                     body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256)
+		 VALUES (?, 'prompt', 'codex', ?, 'w1', ?, ?, 'user_prompt_submit', 'hook', ?, ?, ?, ?, ?)`,
+		id, sessionID, payload.Bytes, createdAt,
+		payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256,
+	); err != nil {
+		t.Fatalf("insert compressed event %s: %v", id, err)
+	}
+	return payload
+}
+
+// TestApplyDedupe_CopiesEncodedPayloadAsIs is the #1744 apply-side contract:
+// quarantining a compressed duplicate must not decode it. The archived row's
+// body and codec metadata must equal the source row's stored (encoded) form
+// byte-for-byte, not the larger decoded plaintext.
+func TestApplyDedupe_CopiesEncodedPayloadAsIs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, dedupeCodecMigrations())
+	store := NewStoreManagementDatasource(database)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	plain := compressibleBody("apply-as-is")
+	insertCompressedDedupeEvent(t, db, "evt-keep", "s1", "2026-05-01T00:00:00Z", plain)
+	dupPayload := insertCompressedDedupeEvent(t, db, "evt-dup", "s1", "2026-05-01T00:00:03Z", plain)
+
+	now := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	result, err := store.DedupeContentEvents(ctx, apptypes.ContentEventDedupeParams{
+		Agent: "codex", Apply: true, RunID: "run-codec", Now: now,
+	})
+	if err != nil {
+		t.Fatalf("DedupeContentEvents() error = %v", err)
+	}
+	if result.MovedCount() != 1 {
+		t.Fatalf("MovedCount() = %d, want 1 (result=%+v)", result.MovedCount(), result)
+	}
+
+	var (
+		archivedBody           []byte
+		codec, sha256Hex       string
+		formatVersion          int
+		plaintextBytes, stored int64
+	)
+	if err := db.QueryRow(
+		`SELECT body, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256
+		   FROM event_content_dedupe_archive WHERE id = 'evt-dup'`,
+	).Scan(&archivedBody, &codec, &formatVersion, &plaintextBytes, &stored, &sha256Hex); err != nil {
+		t.Fatalf("read archived row: %v", err)
+	}
+
+	if string(archivedBody) != string(dupPayload.Bytes) {
+		t.Fatalf("archived body = %d bytes, want the %d encoded bytes copied verbatim (not decoded)", len(archivedBody), len(dupPayload.Bytes))
+	}
+	if codec != payloadCodecZstd {
+		t.Fatalf("archived body_codec = %q, want %q", codec, payloadCodecZstd)
+	}
+	if int64(formatVersion) != int64(dupPayload.FormatVersion) || plaintextBytes != dupPayload.PlaintextBytes ||
+		stored != dupPayload.StoredBytes || sha256Hex != dupPayload.SHA256 {
+		t.Fatalf("archived codec metadata mismatch: got (fv=%d plain=%d stored=%d sha=%s), want (fv=%d plain=%d stored=%d sha=%s)",
+			formatVersion, plaintextBytes, stored, sha256Hex,
+			dupPayload.FormatVersion, dupPayload.PlaintextBytes, dupPayload.StoredBytes, dupPayload.SHA256)
+	}
+	if stored >= plaintextBytes {
+		t.Fatalf("archived stored size (%d) is not smaller than plaintext size (%d); fixture no longer proves the archive avoids inflation", stored, plaintextBytes)
+	}
+}
+
+// TestPurgeDedupeRun_ReleasedBodyReportsStoredNotDecodedSize is the
+// ReleasedBody-side contract of #1744: purging a run must report the bytes a
+// purge actually frees (the encoded/stored size), not the larger logical
+// plaintext size a decode-on-archive design would have reported.
+func TestPurgeDedupeRun_ReleasedBodyReportsStoredNotDecodedSize(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, dedupeCodecMigrations())
+	store := NewStoreManagementDatasource(database)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	plain := compressibleBody("purge-released-body")
+	insertCompressedDedupeEvent(t, db, "evt-keep", "s2", "2026-05-02T00:00:00Z", plain)
+	dupPayload := insertCompressedDedupeEvent(t, db, "evt-dup", "s2", "2026-05-02T00:00:03Z", plain)
+
+	now := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	if _, err := store.DedupeContentEvents(ctx, apptypes.ContentEventDedupeParams{
+		Agent: "codex", Apply: true, RunID: "run-purge", Now: now,
+	}); err != nil {
+		t.Fatalf("DedupeContentEvents(apply) error = %v", err)
+	}
+
+	purge, err := store.PurgeContentEventDedupeRun(ctx, "run-purge")
+	if err != nil {
+		t.Fatalf("PurgeContentEventDedupeRun() error = %v", err)
+	}
+	if purge.ReleasedBody != dupPayload.StoredBytes {
+		t.Fatalf("ReleasedBody = %d, want the stored size %d (not the decoded plaintext size %d)",
+			purge.ReleasedBody, dupPayload.StoredBytes, dupPayload.PlaintextBytes)
+	}
+}
+
+// TestMigration_EventContentDedupeArchiveCodecColumnsAreAdditive: a pre-#1744
+// archive row (no codec columns yet) survives the new migration unchanged and
+// reads back with NULL codec metadata -- the identity path, matching what
+// payloadRow.decode already does for a legacy events row.
+func TestMigration_EventContentDedupeArchiveCodecColumnsAreAdditive(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+
+	store := NewStoreManagementDatasource(NewDatabase(dbPath, migrationsBeforeDedupeArchiveCodec(t)))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(pre-67) error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO event_content_dedupe_archive
+		    (id, kind, client, agent, session_id, workspace, body, created_at,
+		     source_hook, kept_event_id, dedupe_run_id, archived_at, group_key, reason)
+		 VALUES ('legacy-1', 'prompt', 'hook', 'codex', 's1', 'w1', 'legacy plaintext', '2026-01-01T00:00:00Z',
+		         'user_prompt_submit', 'evt-kept', 'legacy-run', '2026-01-02T00:00:00Z', 'legacy-group', 'strict exact duplicate')`,
+	); err != nil {
+		t.Fatalf("insert legacy archive row: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store = NewStoreManagementDatasource(NewDatabase(dbPath, dedupeCodecMigrations()))
+	if err := store.InitializeAuthorized(ctx); err != nil {
+		t.Fatalf("Initialize(current) error = %v", err)
+	}
+
+	db, err = sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var (
+		body  string
+		codec sql.NullString
+	)
+	if err := db.QueryRow(`SELECT body, body_codec FROM event_content_dedupe_archive WHERE id = 'legacy-1'`).Scan(&body, &codec); err != nil {
+		t.Fatalf("read migrated legacy row: %v", err)
+	}
+	if body != "legacy plaintext" {
+		t.Fatalf("legacy body = %q, want unchanged", body)
+	}
+	if codec.Valid {
+		t.Fatalf("legacy body_codec = %q, want NULL (identity by convention)", codec.String)
+	}
+}

--- a/infrastructure/sqlite/content_event_dedupe_datasource.go
+++ b/infrastructure/sqlite/content_event_dedupe_datasource.go
@@ -33,6 +33,14 @@ const (
 	contentEventDedupeReasonUnreadableBody = "skipped: unreadable body"
 )
 
+// dedupeArchiveStoredSizeExpr is the physical bytes an archived row occupies:
+// body_encoded_bytes when the row carries codec metadata, or the raw body
+// length for a legacy identity row (NULL codec, #1744). Reported bytes must
+// match what a purge actually frees, not the logical (decoded) size -- a
+// compressed row's body_encoded_bytes is smaller than length(body) would
+// suggest if the stored bytes were (wrongly) decoded plaintext.
+const dedupeArchiveStoredSizeExpr = `COALESCE(body_encoded_bytes, length(CAST(body AS BLOB)))`
+
 // dedupeMemberRef is one row's participation in an identity group.
 //
 // The body is deliberately absent. A body is needed for exactly two things: to
@@ -834,9 +842,16 @@ func (d *StoreManagementDatasource) applyDedupeGroups(
 	plan dedupePlan,
 	params apptypes.ContentEventDedupeParams,
 ) error {
+	// Probed once per apply run rather than once per archived row: the shape
+	// of the events table does not change mid-run, so a per-row pragma query
+	// (as loadEventPlaintext issued before this) is pure waste at batch scale.
+	hasCodec, err := databaseColumnExists(ctx, db, "events", "body_codec")
+	if err != nil {
+		return err
+	}
 	archivedAt := formatTimestamp(params.Now)
 	for _, batch := range partitionDedupeTargets(plan, params.BatchSize) {
-		if err := d.archiveDedupeBatch(ctx, db, batch, params.RunID, archivedAt); err != nil {
+		if err := d.archiveDedupeBatch(ctx, db, batch, params.RunID, archivedAt, hasCodec); err != nil {
 			return err
 		}
 		if d.onAfterDedupeBatchCommit != nil {
@@ -902,6 +917,7 @@ func (d *StoreManagementDatasource) archiveDedupeBatch(
 	targets []dedupeArchiveTarget,
 	runID string,
 	archivedAt string,
+	hasCodec bool,
 ) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -920,7 +936,7 @@ func (d *StoreManagementDatasource) archiveDedupeBatch(
 	for _, target := range targets {
 		// A row absent from events was already archived by an interrupted earlier
 		// run; the repair is idempotent, so skip rather than fail.
-		source, found, err := readDedupeArchiveSource(ctx, tx, target.id)
+		source, found, err := readDedupeArchiveSource(ctx, tx, target.id, hasCodec)
 		if err != nil {
 			return err
 		}
@@ -946,17 +962,29 @@ func (d *StoreManagementDatasource) archiveDedupeBatch(
 			// guard if a plan is stale.
 			continue
 		}
-		if _, err := tx.ExecContext(
-			ctx,
-			`INSERT INTO event_content_dedupe_archive
+		insertQuery := `INSERT INTO event_content_dedupe_archive
 			    (id, kind, client, agent, session_id, workspace, body, created_at,
 			     source_hook, kept_event_id, dedupe_run_id, archived_at, group_key, reason)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-			     ON CONFLICT(dedupe_run_id, id) DO NOTHING`,
+			     ON CONFLICT(dedupe_run_id, id) DO NOTHING`
+		insertArgs := []any{
 			source.id, source.kind, source.client, source.agent, source.sessionID, source.workspace,
-			source.body, source.createdAt, source.sourceHook,
+			archiveBodyArg(source.payload), source.createdAt, source.sourceHook,
 			target.keptID, runID, archivedAt, target.forensicKey, target.reason,
-		); err != nil {
+		}
+		if hasCodec {
+			insertQuery = `INSERT INTO event_content_dedupe_archive
+			    (id, kind, client, agent, session_id, workspace, body, created_at,
+			     source_hook, kept_event_id, dedupe_run_id, archived_at, group_key, reason,
+			     body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			     ON CONFLICT(dedupe_run_id, id) DO NOTHING`
+			insertArgs = append(insertArgs,
+				source.payload.Codec, source.payload.FormatVersion, source.payload.PlaintextBytes,
+				source.payload.StoredBytes, source.payload.SHA256,
+			)
+		}
+		if _, err := tx.ExecContext(ctx, insertQuery, insertArgs...); err != nil {
 			return xerrors.Errorf("failed to archive duplicate event %s: %w", target.id, err)
 		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE id = ?`, target.id); err != nil {
@@ -994,10 +1022,11 @@ func (d *StoreManagementDatasource) archiveDedupeBatch(
 	return nil
 }
 
-// dedupeArchiveSource is an events row as the quarantine archive stores it. body
-// is the *decoded* plaintext, matching what RestoreContentEventDedupeRun expects
-// to re-encode with encodeCanonicalPayload; copying the raw stored column
-// instead would corrupt a codec-encoded payload on restore.
+// dedupeArchiveSource is an events row as the quarantine archive stores it.
+// payload carries the *encoded* (stored) bytes and codec metadata exactly as
+// events held them: quarantine is a move, not a re-encode (#1744), so nothing
+// here decodes the body. Decoding happens only when the archive is restored or
+// displayed.
 type dedupeArchiveSource struct {
 	id         string
 	kind       string
@@ -1007,35 +1036,50 @@ type dedupeArchiveSource struct {
 	workspace  string
 	createdAt  string
 	sourceHook sql.NullString
-	body       string
+	payload    payloadRow
 }
 
 // readDedupeArchiveSource reads one row about to be quarantined. A missing row is
 // reported as not-found rather than as an error so a resumed run can skip rows an
-// earlier interrupted run already archived.
-func readDedupeArchiveSource(ctx context.Context, tx *sql.Tx, eventID string) (dedupeArchiveSource, bool, error) {
+// earlier interrupted run already archived. hasCodec is probed once per apply
+// run by the caller rather than per row.
+func readDedupeArchiveSource(ctx context.Context, tx *sql.Tx, eventID string, hasCodec bool) (dedupeArchiveSource, bool, error) {
 	var source dedupeArchiveSource
-	err := tx.QueryRowContext(
-		ctx,
-		`SELECT id, kind, client, agent, session_id, workspace, created_at, source_hook
-		   FROM events WHERE id = ?`,
-		eventID,
-	).Scan(
+	query := `SELECT id, kind, client, agent, session_id, workspace, created_at, source_hook, body`
+	if hasCodec {
+		query += `, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256`
+	}
+	query += ` FROM events WHERE id = ?`
+	destinations := []any{
 		&source.id, &source.kind, &source.client, &source.agent,
-		&source.sessionID, &source.workspace, &source.createdAt, &source.sourceHook,
-	)
+		&source.sessionID, &source.workspace, &source.createdAt, &source.sourceHook, &source.payload.Stored,
+	}
+	if hasCodec {
+		destinations = append(destinations,
+			&source.payload.Codec, &source.payload.FormatVersion, &source.payload.PlaintextBytes,
+			&source.payload.StoredBytes, &source.payload.SHA256,
+		)
+	}
+	err := tx.QueryRowContext(ctx, query, eventID).Scan(destinations...)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		return dedupeArchiveSource{}, false, nil
 	case err != nil:
 		return dedupeArchiveSource{}, false, xerrors.Errorf("failed to read duplicate event %s: %w", eventID, err)
 	}
-	plain, err := loadEventPlaintext(ctx, tx, eventID)
-	if err != nil {
-		return dedupeArchiveSource{}, false, xerrors.Errorf("decode duplicate event %s: %w", eventID, err)
-	}
-	source.body = string(plain)
 	return source, true, nil
+}
+
+// archiveBodyArg preserves the column affinity a payload's own codec was
+// stored with when copying it verbatim, whether into the archive or back into
+// events on restore: a legacy row whose codec metadata is entirely NULL binds
+// as identity, matching storedBodyArg's contract for every other writer.
+func archiveBodyArg(payload payloadRow) any {
+	codec := payload.Codec.String
+	if !payload.Codec.Valid {
+		codec = payloadCodecIdentity
+	}
+	return storedBodyArg(encodedPayload{Codec: codec, Bytes: payload.Stored})
 }
 
 // PurgeContentEventDedupeRun drops the rows a dedupe run quarantined, ending that
@@ -1068,7 +1112,7 @@ func (d *StoreManagementDatasource) PurgeContentEventDedupeRun(
 	)
 	if err := db.QueryRowContext(
 		ctx,
-		`SELECT COUNT(*), SUM(length(CAST(body AS BLOB)))
+		`SELECT COUNT(*), SUM(` + dedupeArchiveStoredSizeExpr + `)
 		   FROM event_content_dedupe_archive WHERE dedupe_run_id = ?`,
 		trimmed,
 	).Scan(&rowCount, &byteSum); err != nil {
@@ -1114,7 +1158,7 @@ func (d *StoreManagementDatasource) ListContentEventDedupeRuns(
 	}()
 
 	rows, err := db.QueryContext(ctx, `
-		SELECT dedupe_run_id, MAX(archived_at), COUNT(*), SUM(length(CAST(body AS BLOB)))
+		SELECT dedupe_run_id, MAX(archived_at), COUNT(*), SUM(` + dedupeArchiveStoredSizeExpr + `)
 		  FROM event_content_dedupe_archive
 		 GROUP BY dedupe_run_id`)
 	if err != nil {
@@ -1226,13 +1270,24 @@ func (d *StoreManagementDatasource) RestoreContentEventDedupeRun(
 		}
 	}()
 
-	rows, err := tx.QueryContext(
-		ctx,
-		`SELECT id, kind, client, agent, session_id, workspace, body, created_at, source_hook
+	// Probed once for the whole restore rather than once per row: migrations
+	// are additive and applied in numeric order, so whenever the archive table
+	// carries codec columns (added after events' own, #1744) events does too.
+	hasCodec, err := transactionColumnExists(ctx, tx, "events", "body_codec")
+	if err != nil {
+		return apptypes.ContentEventDedupeRestoreResult{}, err
+	}
+
+	selectQuery := `SELECT id, kind, client, agent, session_id, workspace, created_at, source_hook, body
 		   FROM event_content_dedupe_archive
-		  WHERE dedupe_run_id = ?`,
-		trimmed,
-	)
+		  WHERE dedupe_run_id = ?`
+	if hasCodec {
+		selectQuery = `SELECT id, kind, client, agent, session_id, workspace, created_at, source_hook, body,
+		       body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256
+		   FROM event_content_dedupe_archive
+		  WHERE dedupe_run_id = ?`
+	}
+	rows, err := tx.QueryContext(ctx, selectQuery, trimmed)
 	if err != nil {
 		return apptypes.ContentEventDedupeRestoreResult{}, xerrors.Errorf("failed to query dedupe archive run: %w", err)
 	}
@@ -1244,17 +1299,24 @@ func (d *StoreManagementDatasource) RestoreContentEventDedupeRun(
 		agent      string
 		sessionID  string
 		workspace  string
-		body       string
 		createdAt  string
 		sourceHook sql.NullString
+		payload    payloadRow
 	}
 	var archived []archivedRow
 	for rows.Next() {
 		var r archivedRow
-		if err := rows.Scan(
+		destinations := []any{
 			&r.id, &r.kind, &r.client, &r.agent, &r.sessionID,
-			&r.workspace, &r.body, &r.createdAt, &r.sourceHook,
-		); err != nil {
+			&r.workspace, &r.createdAt, &r.sourceHook, &r.payload.Stored,
+		}
+		if hasCodec {
+			destinations = append(destinations,
+				&r.payload.Codec, &r.payload.FormatVersion, &r.payload.PlaintextBytes,
+				&r.payload.StoredBytes, &r.payload.SHA256,
+			)
+		}
+		if err := rows.Scan(destinations...); err != nil {
 			if closeErr := rows.Close(); closeErr != nil {
 				slog.Debug("failed to close resource", "error", closeErr)
 			}
@@ -1288,20 +1350,21 @@ func (d *StoreManagementDatasource) RestoreContentEventDedupeRun(
 			return apptypes.ContentEventDedupeRestoreResult{}, xerrors.Errorf("failed to check existing event %s: %w", r.id, err)
 		}
 
-		hasCodec, err := transactionColumnExists(ctx, tx, "events", "body_codec")
-		if err != nil {
-			return apptypes.ContentEventDedupeRestoreResult{}, err
+		// Fail closed the same way loadEventPlaintext does: a corrupted or
+		// oversized archived payload must not be restored. The decoded bytes
+		// exist only to prove integrity -- the row is written back below from
+		// the still-encoded payload, not re-encoded from this plaintext.
+		if _, err := r.payload.decode(maxDecodedPayloadBytes); err != nil {
+			return apptypes.ContentEventDedupeRestoreResult{}, xerrors.Errorf(
+				"decode archived event %s: %w", r.id, annotatePayloadError(err, r.id, "body"))
 		}
-		payload, err := encodeCanonicalPayload([]byte(r.body), hasCodec)
-		if err != nil {
-			return apptypes.ContentEventDedupeRestoreResult{}, err
-		}
+
 		query := insertEventQuery
-		args := []any{r.id, r.kind, r.client, r.agent, r.sessionID, r.workspace, storedBodyArg(payload), r.createdAt, r.sourceHook}
+		args := []any{r.id, r.kind, r.client, r.agent, r.sessionID, r.workspace, archiveBodyArg(r.payload), r.createdAt, r.sourceHook}
 		if hasCodec {
 			query = `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook,
 body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-			args = append(args, payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256)
+			args = append(args, r.payload.Codec, r.payload.FormatVersion, r.payload.PlaintextBytes, r.payload.StoredBytes, r.payload.SHA256)
 		}
 		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return apptypes.ContentEventDedupeRestoreResult{}, xerrors.Errorf("failed to restore event %s: %w", r.id, err)

--- a/infrastructure/sqlite/migrate_offline_test.go
+++ b/infrastructure/sqlite/migrate_offline_test.go
@@ -51,8 +51,8 @@ func TestStoreInitAppliesOfflineMigrations(t *testing.T) {
 	if err := current.InitializeAuthorized(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 66 {
-		t.Fatalf("schema version=%d, want 66", got)
+	if got := maxSchemaVersion(t, path); got != 67 {
+		t.Fatalf("schema version=%d, want 67", got)
 	}
 }
 
@@ -64,8 +64,8 @@ func TestEmptyStoreReachesCurrentSchemaImplicitly(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 66 {
-		t.Fatalf("schema version=%d, want 66", got)
+	if got := maxSchemaVersion(t, path); got != 67 {
+		t.Fatalf("schema version=%d, want 67", got)
 	}
 }
 

--- a/infrastructure/sqlite/payload_codec_call_sites_test.go
+++ b/infrastructure/sqlite/payload_codec_call_sites_test.go
@@ -138,7 +138,13 @@ VALUES ('archive-zstd', ?, ?, ?, 0, 0, 0, 0)`, "go test "+plain, plain, plain); 
 	}
 }
 
-func TestDedupeRestore_UsesCanonicalPayloadCodec(t *testing.T) {
+// TestDedupeRestore_PreservesArchivedPayloadCodec is the dedupe-specific
+// counterpart of the other tests in this file. Every other call site
+// canonicalizes (compresses when beneficial) because it writes a *new*
+// physical row. Dedupe quarantine and restore are a move of an existing row,
+// not a re-encode (#1744): the row's codec at restore must match the codec it
+// carried when archived, not be re-derived from the decoded plaintext.
+func TestDedupeRestore_PreservesArchivedPayloadCodec(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
@@ -147,16 +153,27 @@ func TestDedupeRestore_UsesCanonicalPayloadCodec(t *testing.T) {
 		t.Fatalf("Initialize() error = %v", err)
 	}
 	plain := compressiblePayloadBody()
-	conn := openCallSiteDB(t, dbPath)
-	for _, id := range []string{"dedupe-a1", "dedupe-a2"} {
-		if _, err := conn.Exec(
-			`INSERT INTO events (id, kind, agent, session_id, workspace, body, created_at, source_hook, client)
-			 VALUES (?, 'prompt', 'codex', 's1', 'w1', ?, ?, 'user_prompt_submit', 'hook')`,
-			id, plain, map[string]string{"dedupe-a1": "2026-04-10T00:00:00Z", "dedupe-a2": "2026-04-10T00:00:03Z"}[id],
-		); err != nil {
-			t.Fatalf("insert %s: %v", id, err)
+	// Kind transcript, not prompt: a prompt event is auto-attested on Save
+	// (appendAttestationLink), and an attested row is never a dedupe
+	// duplicate candidate (archivableDuplicates) -- unrelated to what this
+	// test checks.
+	for i, id := range []string{"dedupe-a1", "dedupe-a2"} {
+		event := model.EventOf(
+			types.EventID(id), types.EventKindTranscript, types.Client("hook"), types.Agent("codex"),
+			types.SessionID("s1"), types.Workspace("w1"), plain,
+			time.Date(2026, 4, 10, 0, 0, i*3, 0, time.UTC),
+		)
+		if err := events.Save(ctx, event); err != nil {
+			t.Fatalf("Save(%s) error = %v", id, err)
 		}
 	}
+
+	conn := openCallSiteDB(t, dbPath)
+	// The write path chose zstd because the body is compressible: the source
+	// row this test archives and restores must actually exercise a
+	// non-identity codec, or preservation and re-derivation would look the
+	// same.
+	assertCallSiteBodyCodec(t, conn, "dedupe-a2", "zstd")
 
 	now := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
 	if _, err := store.DedupeContentEvents(ctx, apptypes.ContentEventDedupeParams{
@@ -164,6 +181,15 @@ func TestDedupeRestore_UsesCanonicalPayloadCodec(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("DedupeContentEvents() error = %v", err)
 	}
+
+	var archivedCodec sql.NullString
+	if err := conn.QueryRow(`SELECT body_codec FROM event_content_dedupe_archive WHERE id = 'dedupe-a2'`).Scan(&archivedCodec); err != nil {
+		t.Fatalf("read archived body_codec: %v", err)
+	}
+	if !archivedCodec.Valid || archivedCodec.String != "zstd" {
+		t.Fatalf("archived body_codec = %+v, want zstd", archivedCodec)
+	}
+
 	if _, err := store.RestoreContentEventDedupeRun(ctx, "dedupe-codec"); err != nil {
 		t.Fatalf("RestoreContentEventDedupeRun() error = %v", err)
 	}

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -101,6 +101,10 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	// 66 only drops two writer triggers. The unread recent FTS virtual
 	// table stays until store compact (052: no multi-GiB DROP on open).
 	66: {66, "000066_drop_recent_fts_writers.sql", "3de6d4706f043d23d6212def8e23344684e5a95444587c361ad7f970062bb892", MigrationConstantInPlace},
+	// 67 only adds five nullable codec columns to event_content_dedupe_archive
+	// (#1744). Same shape as 36 on events: no backfill, no row rewrite; SQLite
+	// ADD COLUMN is O(1) regardless of table size.
+	67: {67, "000067_add_payload_codec_to_event_content_dedupe_archive.sql", "f9f912f21290e64af38dffc86398f86d08503f8345926a99cf459901fff743c2", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 66 || len(plan.Pending) != 31 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 67 || len(plan.Pending) != 32 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -63,6 +63,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		64: MigrationConstantInPlace,
 		65: MigrationConstantInPlace,
 		66: MigrationConstantInPlace,
+		67: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 66 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 67 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/schema/sqlite/migrations/000067_add_payload_codec_to_event_content_dedupe_archive.sql
+++ b/schema/sqlite/migrations/000067_add_payload_codec_to_event_content_dedupe_archive.sql
@@ -1,0 +1,14 @@
+-- #1744: the dedupe quarantine archive stores decoded plaintext, which
+-- re-inflates the store when a compressed row is quarantined and makes
+-- ReleasedBody report logical rather than physical bytes.
+--
+-- Additive only, mirroring how migration 000036 added the same five columns
+-- to `events`: no existing archive row is rewritten. A row with NULL
+-- body_codec is a legacy (pre-#1685 or pre-migration) plaintext row and reads
+-- as codec=identity, stored_size=length(body) -- the same contract
+-- payloadRow.decode already applies to `events`.
+ALTER TABLE event_content_dedupe_archive ADD COLUMN body_codec TEXT;
+ALTER TABLE event_content_dedupe_archive ADD COLUMN body_format_version INTEGER;
+ALTER TABLE event_content_dedupe_archive ADD COLUMN body_plaintext_bytes INTEGER;
+ALTER TABLE event_content_dedupe_archive ADD COLUMN body_encoded_bytes INTEGER;
+ALTER TABLE event_content_dedupe_archive ADD COLUMN body_sha256 TEXT;


### PR DESCRIPTION
## Summary

`event_content_dedupe_archive` gets the same codec columns as `events`. Apply copies the encoded payload as-is. `ReleasedBody` sums stored size. Restore decodes only to validate integrity and writes the original encoded bytes back. Legacy plaintext archive rows stay identity-codec.

Closes #1744

Leaves parent #1968 open.

## Test plan

- [x] `go test ./infrastructure/sqlite/ -run 'Dedupe|Archive|Codec|ReleasedBody|content_event_dedupe'`
- [x] `go tool golangci-lint run ./infrastructure/sqlite/...`