### PR TITLE
fix: fold oldest orphan ranges first so compact can delete during a long drain

### DIFF
--- a/application/compact.go
+++ b/application/compact.go
@@ -38,8 +38,12 @@ type CommandBodyReclaim struct {
 // CompactFilter configures the copy-filter inside Build.
 // A zero value is vacuum-only: no body discard, no AfterClone.
 type CompactFilter struct {
-	Cutoff     time.Time
-	AfterClone func(context.Context, string) error
+	Cutoff time.Time
+	// AfterClone runs the --force mechanical cover on the work copy before the
+	// discard/vacuum steps. It receives Cutoff so the cover can decide it has
+	// folded enough of the oldest backlog to let CollectGarbage proceed even
+	// when unrelated, newer-than-cutoff material is still unfolded (#1721).
+	AfterClone func(ctx context.Context, work string, cutoff time.Time) error
 }
 
 // BodyGate classifies discardable-age transcript bodies on the source.
@@ -107,16 +111,40 @@ func formatCompactBytes(n int64) string {
 	}
 }
 
-// ForceCoverMustComplete refuses --force when mechanical cover did not finish.
-// HasMore is leftover discovery; Skipped is Failures.Count(). Either means
-// unrefined material may still be on the work copy, so Compact must not
-// report UnrefinedRemaining=0.
-func ForceCoverMustComplete(hasMore bool, skipped int) error {
+// ForceCoverSafeToDelete refuses --force when mechanical cover left behind
+// material that might still be older than cutoff. hasMore is leftover
+// discovery; earliestUnprocessed is that leftover's earliest event time (nil
+// when hasMore is false, or when the pass could not determine it). skipped is
+// Failures.Count(); earliestSkipped is the same for skipped candidates.
+//
+// This replaces the earlier "cover must be 100% complete" gate (#1795's
+// Complete(), later reconstructed as hasMore==false && skipped==0). That gate
+// refused any leftover regardless of age, which meant a large but
+// newer-than-cutoff backlog blocked deletion indefinitely (#1721). Discovery
+// now orders candidates oldest-first, so the earliest leftover time is a
+// sound bound: deletion is safe once every leftover range is no older than
+// cutoff. An unknown time (nil while the corresponding count is nonzero)
+// fails closed, matching the previous conservatism.
+func ForceCoverSafeToDelete(
+	hasMore bool, earliestUnprocessed *time.Time,
+	skipped int, earliestSkipped *time.Time,
+	cutoff time.Time,
+) error {
 	if hasMore {
-		return fmt.Errorf("compact --force cover is incomplete: more orphan ranges remain")
+		if earliestUnprocessed == nil {
+			return fmt.Errorf("compact --force cover is incomplete: earliest unprocessed orphan range time is unknown")
+		}
+		if earliestUnprocessed.Before(cutoff) {
+			return fmt.Errorf("compact --force cover is incomplete: unprocessed orphan ranges may be older than the retention cutoff")
+		}
 	}
 	if skipped > 0 {
-		return fmt.Errorf("compact --force cover is incomplete: %d orphan range(s) were skipped", skipped)
+		if earliestSkipped == nil {
+			return fmt.Errorf("compact --force cover is incomplete: earliest skipped orphan range time is unknown")
+		}
+		if earliestSkipped.Before(cutoff) {
+			return fmt.Errorf("compact --force cover is incomplete: %d orphan range(s) were skipped and may be older than the retention cutoff", skipped)
+		}
 	}
 	return nil
 }

--- a/application/compact_test.go
+++ b/application/compact_test.go
@@ -72,28 +72,63 @@ func TestUnrefinedMaterialErrorNamesSkillAndForceCost(t *testing.T) {
 	}
 }
 
-func TestForceCoverMustComplete(t *testing.T) {
+func TestForceCoverSafeToDelete(t *testing.T) {
 	t.Parallel()
+	cutoff := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	older := cutoff.Add(-time.Hour)
+	newer := cutoff.Add(time.Hour)
 	for _, tc := range []struct {
-		name    string
-		hasMore bool
-		skipped int
-		wantErr bool
+		name                string
+		hasMore             bool
+		earliestUnprocessed *time.Time
+		skipped             int
+		earliestSkipped     *time.Time
+		wantErr             bool
 	}{
 		{name: "complete"},
-		{name: "has more leftover", hasMore: true, wantErr: true},
-		{name: "skipped ranges", skipped: 2, wantErr: true},
-		{name: "both incomplete signals", hasMore: true, skipped: 1, wantErr: true},
+		{
+			name: "has more but all newer than cutoff",
+			hasMore: true, earliestUnprocessed: &newer,
+		},
+		{
+			name: "has more and unknown earliest time",
+			hasMore: true, wantErr: true,
+		},
+		{
+			name: "has more and unprocessed older than cutoff",
+			hasMore: true, earliestUnprocessed: &older, wantErr: true,
+		},
+		{
+			name: "skipped but newer than cutoff",
+			skipped: 2, earliestSkipped: &newer,
+		},
+		{
+			name: "skipped with unknown earliest time",
+			skipped: 2, wantErr: true,
+		},
+		{
+			name: "skipped older than cutoff",
+			skipped: 2, earliestSkipped: &older, wantErr: true,
+		},
+		{
+			name:                "both incomplete signals but both newer than cutoff",
+			hasMore:             true,
+			earliestUnprocessed: &newer,
+			skipped:             1,
+			earliestSkipped:     &newer,
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := application.ForceCoverMustComplete(tc.hasMore, tc.skipped)
+			err := application.ForceCoverSafeToDelete(
+				tc.hasMore, tc.earliestUnprocessed, tc.skipped, tc.earliestSkipped, cutoff,
+			)
 			if tc.wantErr && err == nil {
-				t.Fatal("ForceCoverMustComplete() error = nil, want incomplete cover")
+				t.Fatal("ForceCoverSafeToDelete() error = nil, want incomplete cover")
 			}
 			if !tc.wantErr && err != nil {
-				t.Fatalf("ForceCoverMustComplete() error = %v", err)
+				t.Fatalf("ForceCoverSafeToDelete() error = %v", err)
 			}
 		})
 	}

--- a/application/types/orphan_consolidation_result.go
+++ b/application/types/orphan_consolidation_result.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 const maxOrphanConsolidationFailures = 10
 
 // OrphanConsolidationFailure identifies an orphan range that could not be
@@ -62,21 +64,37 @@ func (f OrphanConsolidationFailures) Truncated() bool { return f.total > len(f.i
 
 // OrphanConsolidationResult is the result of an orphan-range consolidation run.
 type OrphanConsolidationResult struct {
-	attempted int
-	produced  int
-	failures  OrphanConsolidationFailures
-	hasMore   bool
-	dryRun    bool
+	attempted                  int
+	produced                   int
+	failures                   OrphanConsolidationFailures
+	hasMore                    bool
+	dryRun                     bool
+	earliestUnprocessEventTime *time.Time
+	earliestSkippedEventTime   *time.Time
 }
 
 // OrphanConsolidationResultOf creates an OrphanConsolidationResult.
-func OrphanConsolidationResultOf(attempted, produced int, failures OrphanConsolidationFailures, hasMore, dryRun bool) OrphanConsolidationResult {
+//
+// earliestUnprocessedEventTime is the earliest event time among candidates
+// this pass never attempted (nil when hasMore is false, since there is
+// nothing left unprocessed; nil while hasMore is true means the time could
+// not be determined and callers must fail closed, per #1721).
+// earliestSkippedEventTime is the same for candidates that were attempted and
+// failed (nil when nothing was skipped).
+func OrphanConsolidationResultOf(
+	attempted, produced int,
+	failures OrphanConsolidationFailures,
+	hasMore, dryRun bool,
+	earliestUnprocessedEventTime, earliestSkippedEventTime *time.Time,
+) OrphanConsolidationResult {
 	return OrphanConsolidationResult{
-		attempted: attempted,
-		produced:  produced,
-		failures:  failures,
-		hasMore:   hasMore,
-		dryRun:    dryRun,
+		attempted:                  attempted,
+		produced:                   produced,
+		failures:                   failures,
+		hasMore:                    hasMore,
+		dryRun:                     dryRun,
+		earliestUnprocessEventTime: earliestUnprocessedEventTime,
+		earliestSkippedEventTime:   earliestSkippedEventTime,
 	}
 }
 
@@ -116,3 +134,21 @@ func (r OrphanConsolidationResult) HasMore() bool { return r.hasMore }
 
 // DryRun reports whether the run was a dry run.
 func (r OrphanConsolidationResult) DryRun() bool { return r.dryRun }
+
+// EarliestUnprocessedEventTime returns the earliest event time among
+// candidates this pass never attempted, or nil when there were none (HasMore
+// is false) or the time could not be determined. A caller deciding whether
+// deletion up to some cutoff is safe must treat nil while HasMore is true as
+// unknown and refuse (#1721).
+func (r OrphanConsolidationResult) EarliestUnprocessedEventTime() *time.Time {
+	return r.earliestUnprocessEventTime
+}
+
+// EarliestSkippedEventTime returns the earliest event time among candidates
+// that were attempted and failed, or nil when nothing was skipped or the time
+// could not be determined. A caller deciding whether deletion up to some
+// cutoff is safe must treat nil while Skipped() > 0 as unknown and refuse
+// (#1721).
+func (r OrphanConsolidationResult) EarliestSkippedEventTime() *time.Time {
+	return r.earliestSkippedEventTime
+}

--- a/application/usecase/orphan_consolidation_usecase_impl.go
+++ b/application/usecase/orphan_consolidation_usecase_impl.go
@@ -105,6 +105,15 @@ func (u *orphanConsolidationUsecase) Consolidate(
 	failures := apptypes.OrphanConsolidationFailuresOf(nil)
 	consecutive := 0
 
+	// Candidates are ordered oldest-first (#1721), so the first one this pass
+	// never attempts is the earliest unprocessed event time. lastAttempted
+	// backs the case where the whole page was attempted but discovery has
+	// more beyond it: since ordering is monotone, the last attempted
+	// candidate's time is a safe lower bound for whatever remains unseen.
+	var earliestUnprocessed *time.Time
+	var earliestSkipped *time.Time
+	var lastAttempted *model.SessionOrphanRange
+
 	for _, orphan := range candidates.Ranges {
 		if orphan == nil {
 			continue
@@ -115,10 +124,13 @@ func (u *orphanConsolidationUsecase) Consolidate(
 		}
 		if u.clock.Now().Sub(started) >= budget {
 			hasMore = true
+			t := orphan.EarliestEventTime()
+			earliestUnprocessed = &t
 			break
 		}
 
 		attempted++
+		lastAttempted = orphan
 		wrote, failure := u.processCandidate(ctx, orphan, input.DryRun)
 		if failure == nil {
 			if wrote {
@@ -130,6 +142,9 @@ func (u *orphanConsolidationUsecase) Consolidate(
 		failures = failures.Add(apptypes.OrphanConsolidationFailureOf(
 			orphan.SessionID().String(), failure.Error(),
 		))
+		if t := orphan.EarliestEventTime(); earliestSkipped == nil || t.Before(*earliestSkipped) {
+			earliestSkipped = &t
+		}
 		consecutive++
 		slog.Warn(
 			"skipped orphan range",
@@ -144,7 +159,13 @@ func (u *orphanConsolidationUsecase) Consolidate(
 			)
 		}
 	}
-	return apptypes.OrphanConsolidationResultOf(attempted, produced, failures, hasMore, input.DryRun), nil
+	if earliestUnprocessed == nil && hasMore && lastAttempted != nil {
+		t := lastAttempted.EarliestEventTime()
+		earliestUnprocessed = &t
+	}
+	return apptypes.OrphanConsolidationResultOf(
+		attempted, produced, failures, hasMore, input.DryRun, earliestUnprocessed, earliestSkipped,
+	), nil
 }
 
 // processCandidate performs the single operation one candidate needs: a dry run

--- a/application/usecase/orphan_consolidation_usecase_test.go
+++ b/application/usecase/orphan_consolidation_usecase_test.go
@@ -122,7 +122,7 @@ func (c *steppingOrphanClock) Now() time.Time {
 
 func mustOrphanRange(t *testing.T, sessionID string, to string, at time.Time) *model.SessionOrphanRange {
 	t.Helper()
-	orphan, err := model.NewSessionOrphanRange(types.SessionID(sessionID), types.None[types.EventID](), types.EventID(to), at)
+	orphan, err := model.NewSessionOrphanRange(types.SessionID(sessionID), types.None[types.EventID](), types.EventID(to), at, at)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,6 +137,7 @@ func TestOrphanConsolidationUsecase_ProducesDegradedRefinement(t *testing.T) {
 		"sess-1",
 		types.Some(types.EventID("evt-a")),
 		"evt-c",
+		now,
 		now,
 	)
 	if err != nil {
@@ -210,6 +211,7 @@ func TestOrphanConsolidationUsecase_ComposesOntoExistingAgentSummary(t *testing.
 		sessionID,
 		types.Some(types.EventID("evt-100")),
 		"evt-150",
+		now,
 		now,
 	)
 	if err != nil {
@@ -315,6 +317,7 @@ func TestOrphanConsolidationUsecase_CompositionObservesCASReRead(t *testing.T) {
 		types.Some(evt100),
 		evt150,
 		now,
+		now,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -397,7 +400,7 @@ func TestOrphanConsolidationUsecase_AdvancesCoverageForLifecycleOnlyTail(t *test
 	const agentSummary = "Agent folded the session: split the refactor because shared types blocked the UI."
 	existing := mustRefinement(t, sessionID, 1, evt1, evt1, agentSummary)
 
-	orphan, err := model.NewSessionOrphanRange(sessionID, types.Some(evt1), evtEnd, now)
+	orphan, err := model.NewSessionOrphanRange(sessionID, types.Some(evt1), evtEnd, now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,7 +476,7 @@ func TestOrphanConsolidationUsecase_SkipsLifecycleOnlyWhenNoRefinement(t *testin
 	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
 	sessionID := types.SessionID("sess-empty-lifecycle")
 	evtEnd := types.EventID("evt-end")
-	orphan, err := model.NewSessionOrphanRange(sessionID, types.None[types.EventID](), evtEnd, now)
+	orphan, err := model.NewSessionOrphanRange(sessionID, types.None[types.EventID](), evtEnd, now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -530,7 +533,7 @@ func TestOrphanConsolidationUsecase_PreservesHasAgentReasoningOnCompose(t *testi
 	const agentSummary = "Agent decided to split the PR because of shared types."
 	existing := mustRefinement(t, sessionID, 1, evt1, evt100, agentSummary)
 
-	orphan, err := model.NewSessionOrphanRange(sessionID, types.Some(evt100), evt150, now)
+	orphan, err := model.NewSessionOrphanRange(sessionID, types.Some(evt100), evt150, now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +596,7 @@ func TestOrphanConsolidationUsecase_DryRunCountsWithoutWriting(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
-	orphan, err := model.NewSessionOrphanRange("sess-1", types.None[types.EventID](), "evt-z", now)
+	orphan, err := model.NewSessionOrphanRange("sess-1", types.None[types.EventID](), "evt-z", now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -616,7 +619,7 @@ func TestOrphanConsolidationUsecase_DryRunCountsWithoutWriting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Consolidate() error = %v", err)
 	}
-	want := apptypes.OrphanConsolidationResultOf(1, 1, apptypes.OrphanConsolidationFailuresOf(nil), false, true)
+	want := apptypes.OrphanConsolidationResultOf(1, 1, apptypes.OrphanConsolidationFailuresOf(nil), false, true, nil, nil)
 	if diff := cmp.Diff(want.ProducedCount(), got.ProducedCount()); diff != "" {
 		t.Fatalf("ProducedCount mismatch (-want +got):\n%s", diff)
 	}
@@ -671,7 +674,7 @@ func TestBuildMechanicalOrphanSummary_TruncatesDeterministically(t *testing.T) {
 	}
 	// buildMechanicalOrphanSummary is package-private; exercise via Consolidate.
 	now := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
-	orphan, err := model.NewSessionOrphanRange("sess", types.None[types.EventID](), "evt", now)
+	orphan, err := model.NewSessionOrphanRange("sess", types.None[types.EventID](), "evt", now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -721,6 +724,7 @@ func TestOrphanConsolidationUsecase_TruncationDoesNotCutAgentText(t *testing.T) 
 		sessionID,
 		types.Some(types.EventID("evt-10")),
 		"evt-20",
+		now,
 		now,
 	)
 	if err != nil {

--- a/application/usecase/session_orphan_range_usecase_impl.go
+++ b/application/usecase/session_orphan_range_usecase_impl.go
@@ -100,7 +100,11 @@ func (u *sessionOrphanRangeUsecase) RecordAtCompact(
 		from = types.Some(coversTo)
 	}
 
-	orphan, err := model.NewSessionOrphanRange(sessionID, from, compactEventID, u.clock.Now())
+	// earliestEventTime is not persisted by Record (see insert_session_orphan_range.sql);
+	// it only matters for objects built during discovery, so a filler value is
+	// fine here.
+	now := u.clock.Now()
+	orphan, err := model.NewSessionOrphanRange(sessionID, from, compactEventID, now, now)
 	if err != nil {
 		return xerrors.Errorf("failed to build orphan range: %w", err)
 	}

--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -22,7 +22,7 @@ type storeCompactionUsecase struct {
 	lease         application.StoreCompactionLease
 	now           func() time.Time
 	expectedStore string
-	cover         func(context.Context, string) error
+	cover         func(ctx context.Context, work string, cutoff time.Time) error
 }
 
 type compactFilterSetter interface {
@@ -31,7 +31,7 @@ type compactFilterSetter interface {
 
 // BindCompactionWorkCover attaches the --force mechanical cover used on the
 // work copy. Composition root only; tests omit it.
-func BindCompactionWorkCover(u application.StoreCompactionUsecase, cover func(context.Context, string) error) {
+func BindCompactionWorkCover(u application.StoreCompactionUsecase, cover func(ctx context.Context, work string, cutoff time.Time) error) {
 	if concrete, ok := u.(*storeCompactionUsecase); ok {
 		concrete.cover = cover
 	}

--- a/domain/model/session_orphan_range.go
+++ b/domain/model/session_orphan_range.go
@@ -17,24 +17,30 @@ import (
 // FromEventID is an exclusive lower bound. None means the range starts at the
 // session's first event. ToEventID is inclusive.
 type SessionOrphanRange struct {
-	sessionID   types.SessionID
-	fromEventID types.Optional[types.EventID]
-	toEventID   types.EventID
-	observedAt  time.Time
+	sessionID         types.SessionID
+	fromEventID       types.Optional[types.EventID]
+	toEventID         types.EventID
+	observedAt        time.Time
+	earliestEventTime time.Time
 }
 
-// NewSessionOrphanRange constructs a validated orphan range.
+// NewSessionOrphanRange constructs a validated orphan range. earliestEventTime
+// is the created_at of the range's oldest event; it drives oldest-first
+// discovery ordering and the CollectGarbage safety gate (#1721), and is
+// distinct from observedAt (when the range was recorded or discovered).
 func NewSessionOrphanRange(
 	sessionID types.SessionID,
 	fromEventID types.Optional[types.EventID],
 	toEventID types.EventID,
 	observedAt time.Time,
+	earliestEventTime time.Time,
 ) (*SessionOrphanRange, error) {
 	orphan := &SessionOrphanRange{
-		sessionID:   sessionID,
-		fromEventID: fromEventID,
-		toEventID:   toEventID,
-		observedAt:  observedAt.UTC(),
+		sessionID:         sessionID,
+		fromEventID:       fromEventID,
+		toEventID:         toEventID,
+		observedAt:        observedAt.UTC(),
+		earliestEventTime: earliestEventTime.UTC(),
 	}
 	if err := orphan.validate(); err != nil {
 		return nil, err
@@ -48,8 +54,9 @@ func SessionOrphanRangeOf(
 	fromEventID types.Optional[types.EventID],
 	toEventID types.EventID,
 	observedAt time.Time,
+	earliestEventTime time.Time,
 ) (*SessionOrphanRange, error) {
-	return NewSessionOrphanRange(sessionID, fromEventID, toEventID, observedAt)
+	return NewSessionOrphanRange(sessionID, fromEventID, toEventID, observedAt, earliestEventTime)
 }
 
 func (r *SessionOrphanRange) validate() error {
@@ -68,6 +75,9 @@ func (r *SessionOrphanRange) validate() error {
 	if r.observedAt.IsZero() {
 		return xerrors.Errorf("observed_at is required: %w", ErrInvalidSessionOrphanRange)
 	}
+	if r.earliestEventTime.IsZero() {
+		return xerrors.Errorf("earliest_event_time is required: %w", ErrInvalidSessionOrphanRange)
+	}
 	return nil
 }
 
@@ -83,6 +93,11 @@ func (r *SessionOrphanRange) ToEventID() types.EventID { return r.toEventID }
 
 // ObservedAt returns when the orphan range was recorded or discovered.
 func (r *SessionOrphanRange) ObservedAt() time.Time { return r.observedAt }
+
+// EarliestEventTime returns the created_at of the range's oldest event. It is
+// the ordering key for oldest-first discovery and the CollectGarbage safety
+// gate (#1721).
+func (r *SessionOrphanRange) EarliestEventTime() time.Time { return r.earliestEventTime }
 
 // ErrInvalidSessionOrphanRange indicates an orphan-range invariant was violated.
 var ErrInvalidSessionOrphanRange = xerrors.New("invalid session orphan range")

--- a/domain/model/session_orphan_range_test.go
+++ b/domain/model/session_orphan_range_test.go
@@ -17,6 +17,7 @@ func TestNewSessionOrphanRange_EnforcesInvariants(t *testing.T) {
 		types.Some(types.EventID("evt-from")),
 		"evt-to",
 		now,
+		now,
 	)
 	if err != nil {
 		t.Fatalf("NewSessionOrphanRange() error = %v", err)
@@ -42,9 +43,15 @@ func TestNewSessionOrphanRange_EnforcesInvariants(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if _, err := model.NewSessionOrphanRange(tt.sessionID, tt.from, tt.to, tt.at); err == nil {
+			if _, err := model.NewSessionOrphanRange(tt.sessionID, tt.from, tt.to, tt.at, now); err == nil {
 				t.Fatal("error = nil, want error")
 			}
 		})
 	}
+	t.Run("zero earliest_event_time", func(t *testing.T) {
+		t.Parallel()
+		if _, err := model.NewSessionOrphanRange("sess", types.None[types.EventID](), "evt-to", now, time.Time{}); err == nil {
+			t.Fatal("error = nil, want error")
+		}
+	})
 }

--- a/infrastructure/sqlite/compaction_copy_filter_test.go
+++ b/infrastructure/sqlite/compaction_copy_filter_test.go
@@ -318,7 +318,7 @@ func TestCompactForceCoverCompletesOnRealStore(t *testing.T) {
 		sqlite.StoreLeaseCoordinator{},
 	)
 	migrations := onDiskSQLiteMigrations(t)
-	usecase.BindCompactionWorkCover(svc, func(ctx context.Context, work string) error {
+	usecase.BindCompactionWorkCover(svc, func(ctx context.Context, work string, cutoff time.Time) error {
 		database := sqlite.NewDatabase(work, migrations)
 		refine := usecase.NewSessionRefinementUsecase(
 			sqlite.NewSessionDatasource(database),
@@ -333,12 +333,15 @@ func TestCompactForceCoverCompletesOnRealStore(t *testing.T) {
 		)
 		result, err := cover.Consolidate(ctx, usecase.OrphanConsolidationInput{
 			StaleAfter: 24 * time.Hour,
-			Unlimited:  true,
 		})
 		if err != nil {
 			return fmt.Errorf("compact force cover: %w", err)
 		}
-		if err := application.ForceCoverMustComplete(result.HasMore(), result.Skipped()); err != nil {
+		if err := application.ForceCoverSafeToDelete(
+			result.HasMore(), result.EarliestUnprocessedEventTime(),
+			result.Skipped(), result.EarliestSkippedEventTime(),
+			cutoff,
+		); err != nil {
 			return fmt.Errorf("compact force cover: %w", err)
 		}
 		return nil
@@ -363,6 +366,176 @@ func TestCompactForceCoverCompletesOnRealStore(t *testing.T) {
 	defer func() { _ = db.Close() }()
 	if avail := gcEventAvailability(t, db, "event-old"); avail != "unavailable_retention" {
 		t.Fatalf("forced body availability = %s, want unavailable_retention", avail)
+	}
+}
+
+// TestCompactForceCoverProceedsWhenLeftoverIsNewerThanCutoff pins the #1721
+// fix: an already-covered, discardable-age session must still be deleted even
+// though a bounded cover pass leaves part of the orphan backlog unfolded, as
+// long as that leftover is entirely newer than the retention cutoff.
+// Discovery orders oldest-first, so a Limit of 1 folds session-new-a and
+// leaves session-new-b (newer still) as the reported leftover; both are newer
+// than cutoff, so the safe lower bound the cover reports (session-new-a's
+// earliest event time) is newer than cutoff too.
+func TestCompactForceCoverProceedsWhenLeftoverIsNewerThanCutoff(t *testing.T) {
+	t.Parallel()
+	dbPath, events, store := prepareDiscardGCFixture(t)
+	_ = store
+	old := newGCEventFixture(t, "event-old", types.EventKindTranscript, "why-is-here", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), old); err != nil {
+		t.Fatal(err)
+	}
+	newA := newGCEventFixture(t, "event-new-a", types.EventKindTranscript, "why-is-here", time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), newA); err != nil {
+		t.Fatal(err)
+	}
+	newB := newGCEventFixture(t, "event-new-b", types.EventKindTranscript, "why-is-here", time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), newB); err != nil {
+		t.Fatal(err)
+	}
+	db := openRetentionDB(t, dbPath)
+	insertGCSession(t, db, "session-covered", true)
+	insertGCSession(t, db, "session-new-a", true)
+	insertGCSession(t, db, "session-new-b", true)
+	insertGCFold(t, db, "session-covered", "event-old", "event-old")
+	if _, err := db.Exec(`UPDATE events SET session_id = 'session-covered' WHERE id = 'event-old'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE events SET session_id = 'session-new-a' WHERE id = 'event-new-a'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE events SET session_id = 'session-new-b' WHERE id = 'event-new-b'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := usecase.NewStoreCompactionUsecase(
+		dbPath,
+		&sqlite.CompactionFileJournal{Dir: filepath.Join(t.TempDir(), "journal")},
+		&sqlite.SQLiteCompactionBuilder{},
+		sqlite.StoreReplacementFiles{CallerHoldsExclusiveLease: true},
+		sqlite.StoreLeaseCoordinator{},
+	)
+	migrations := onDiskSQLiteMigrations(t)
+	usecase.BindCompactionWorkCover(svc, func(ctx context.Context, work string, cutoff time.Time) error {
+		database := sqlite.NewDatabase(work, migrations)
+		refine := usecase.NewSessionRefinementUsecase(
+			sqlite.NewSessionDatasource(database),
+			sqlite.NewSessionRefinementDatasource(database),
+			sqlite.NewEventDatasource(database),
+			types.SystemClock{},
+		)
+		cover := usecase.NewOrphanConsolidationUsecase(
+			sqlite.NewSessionOrphanRangeDatasource(database),
+			refine,
+			types.SystemClock{},
+		)
+		result, err := cover.Consolidate(ctx, usecase.OrphanConsolidationInput{
+			StaleAfter: 24 * time.Hour,
+			Limit:      1,
+		})
+		if err != nil {
+			return fmt.Errorf("compact force cover: %w", err)
+		}
+		if err := application.ForceCoverSafeToDelete(
+			result.HasMore(), result.EarliestUnprocessedEventTime(),
+			result.Skipped(), result.EarliestSkippedEventTime(),
+			cutoff,
+		); err != nil {
+			return fmt.Errorf("compact force cover: %w", err)
+		}
+		return nil
+	})
+
+	if _, err := svc.Compact(context.Background(), application.CompactInput{
+		Source:   dbPath,
+		Force:    true,
+		KeepDays: 10,
+		Now:      time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("Compact() error = %v, want compact to proceed: the unfolded leftover is newer than the cutoff", err)
+	}
+
+	db = openRetentionDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	if avail := gcEventAvailability(t, db, "event-old"); avail != "unavailable_retention" {
+		t.Fatalf("forced body availability = %s, want unavailable_retention for the already-covered pre-cutoff session", avail)
+	}
+}
+
+// TestCompactForceCoverRefusesWhenLeftoverIsOlderThanCutoff is the regression
+// pinned by #1721: a bounded cover pass that leaves behind a range whose
+// earliest event is older than the retention cutoff must refuse rather than
+// let CollectGarbage discard material no fold has ever seen.
+func TestCompactForceCoverRefusesWhenLeftoverIsOlderThanCutoff(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fx := newOrphanFixture(t)
+
+	seedOrphanSession(ctx, t, fx, "session-old-1", []eventSeed{
+		{id: "evt-old-1", at: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
+	}, true)
+	seedOrphanSession(ctx, t, fx, "session-old-2", []eventSeed{
+		{id: "evt-old-2", at: time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC)},
+	}, true)
+
+	svc := usecase.NewStoreCompactionUsecase(
+		fx.dbPath,
+		&sqlite.CompactionFileJournal{Dir: filepath.Join(t.TempDir(), "journal")},
+		&sqlite.SQLiteCompactionBuilder{},
+		sqlite.StoreReplacementFiles{CallerHoldsExclusiveLease: true},
+		sqlite.StoreLeaseCoordinator{},
+	)
+	migrations := onDiskSQLiteMigrations(t)
+	usecase.BindCompactionWorkCover(svc, func(ctx context.Context, work string, cutoff time.Time) error {
+		database := sqlite.NewDatabase(work, migrations)
+		refine := usecase.NewSessionRefinementUsecase(
+			sqlite.NewSessionDatasource(database),
+			sqlite.NewSessionRefinementDatasource(database),
+			sqlite.NewEventDatasource(database),
+			types.SystemClock{},
+		)
+		cover := usecase.NewOrphanConsolidationUsecase(
+			sqlite.NewSessionOrphanRangeDatasource(database),
+			refine,
+			types.SystemClock{},
+		)
+		result, err := cover.Consolidate(ctx, usecase.OrphanConsolidationInput{
+			StaleAfter: 24 * time.Hour,
+			Limit:      1,
+		})
+		if err != nil {
+			return fmt.Errorf("compact force cover: %w", err)
+		}
+		if err := application.ForceCoverSafeToDelete(
+			result.HasMore(), result.EarliestUnprocessedEventTime(),
+			result.Skipped(), result.EarliestSkippedEventTime(),
+			cutoff,
+		); err != nil {
+			return fmt.Errorf("compact force cover: %w", err)
+		}
+		return nil
+	})
+
+	_, err := svc.Compact(ctx, application.CompactInput{
+		Source:   fx.dbPath,
+		Force:    true,
+		KeepDays: 10,
+		Now:      time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("Compact() error = nil, want refusal: the unfolded leftover (session-old-2) is older than the cutoff")
+	}
+	if !strings.Contains(err.Error(), "may be older than the retention cutoff") {
+		t.Fatalf("Compact() error = %v, want it to name the retention cutoff as the reason", err)
+	}
+
+	db := openRetentionDB(t, fx.dbPath)
+	defer func() { _ = db.Close() }()
+	if avail := gcEventAvailability(t, db, "evt-old-1"); avail == "unavailable_retention" {
+		t.Fatal("evt-old-1 body_availability = unavailable_retention, want unchanged: a refused compact must not have touched the original store")
 	}
 }
 

--- a/infrastructure/sqlite/compaction_sqlite.go
+++ b/infrastructure/sqlite/compaction_sqlite.go
@@ -67,7 +67,7 @@ func (b SQLiteCompactionBuilder) Build(ctx context.Context, source, candidate st
 		removeSQLiteSidecars(work)
 	}()
 	if b.Filter.AfterClone != nil {
-		if err := b.Filter.AfterClone(ctx, work); err != nil {
+		if err := b.Filter.AfterClone(ctx, work, b.Filter.Cutoff); err != nil {
 			return fmt.Errorf("compact force cover: %w", err)
 		}
 		removeSQLiteSidecars(work)

--- a/infrastructure/sqlite/session_orphan_range_datasource.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource.go
@@ -130,9 +130,10 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 			if err := ctx.Err(); err != nil {
 				return xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
 			}
-			if len(candidates) >= target {
-				break
-			}
+			// Do not stop at `target` here. Recorded rows are unordered by age
+			// (session_id, to_event_id). Filling the page from them first would
+			// hide older ended/stale ranges and let ForceCoverSafeToDelete see
+			// only newer leftovers (#1721).
 			covered, err := d.refinementCovers(ctx, db, orphan.SessionID(), orphan.ToEventID())
 			if err != nil {
 				return err
@@ -157,51 +158,50 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 		}
 
 		// Source of truth: ended or stale sessions with material past covers_to.
-		// Paginate by a composite (earliest_event_norm, session_id) keyset until
-		// target valid candidates are collected or the scan is exhausted, so
-		// folding proceeds oldest-first (#1721) and the cursor stays unique even
-		// when two sessions share an earliest event time.
-		if len(candidates) < target {
-			cursorNorm := ""
-			cursorSessionID := ""
-			pageSize := limit + 1
-			for len(candidates) < target {
-				if err := ctx.Err(); err != nil {
-					return xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
+		// Paginate independently of how many recorded shortcuts we already have:
+		// the oldest `target` ended/stale rows plus every recorded shortcut
+		// contain the true oldest `limit` after the merge-sort below.
+		endedCount := 0
+		cursorNorm := ""
+		cursorSessionID := ""
+		pageSize := limit + 1
+		for endedCount < target {
+			if err := ctx.Err(); err != nil {
+				return xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
+			}
+			page, err := d.listEndedOrStalePage(ctx, db, cutoff, cursorNorm, cursorSessionID, pageSize)
+			if err != nil {
+				return err
+			}
+			if len(page) == 0 {
+				break
+			}
+			// Advance the cursor from the last SQL row even when every row was
+			// filtered out in Go; otherwise a page of non-candidates loops forever.
+			last := page[len(page)-1]
+			cursorNorm = last.earliestEventNorm
+			cursorSessionID = last.sessionID.String()
+			for _, row := range page {
+				if endedCount >= target {
+					break
 				}
-				page, err := d.listEndedOrStalePage(ctx, db, cutoff, cursorNorm, cursorSessionID, pageSize)
+				orphan, ok, err := d.gapPastCoverage(ctx, db, row.sessionID, row.earliestEventTime, now)
 				if err != nil {
 					return err
 				}
-				if len(page) == 0 {
-					break
+				if !ok {
+					continue
 				}
-				// Advance the cursor from the last SQL row even when every row was
-				// filtered out in Go; otherwise a page of non-candidates loops forever.
-				last := page[len(page)-1]
-				cursorNorm = last.earliestEventNorm
-				cursorSessionID = last.sessionID.String()
-				for _, row := range page {
-					if len(candidates) >= target {
-						break
-					}
-					orphan, ok, err := d.gapPastCoverage(ctx, db, row.sessionID, row.earliestEventTime, now)
-					if err != nil {
-						return err
-					}
-					if !ok {
-						continue
-					}
-					key := orphan.SessionID().String() + "\x00" + orphan.ToEventID().String()
-					if _, exists := seen[key]; exists {
-						continue
-					}
-					seen[key] = struct{}{}
-					candidates = append(candidates, orphan)
+				key := orphan.SessionID().String() + "\x00" + orphan.ToEventID().String()
+				if _, exists := seen[key]; exists {
+					continue
 				}
-				if len(page) < pageSize {
-					break
-				}
+				seen[key] = struct{}{}
+				candidates = append(candidates, orphan)
+				endedCount++
+			}
+			if len(page) < pageSize {
+				break
 			}
 		}
 

--- a/infrastructure/sqlite/session_orphan_range_datasource.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"errors"
 	"log/slog"
+	"sort"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -156,16 +157,19 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 		}
 
 		// Source of truth: ended or stale sessions with material past covers_to.
-		// Paginate by session_id keyset until target valid candidates are collected
-		// or the scan is exhausted.
+		// Paginate by a composite (earliest_event_norm, session_id) keyset until
+		// target valid candidates are collected or the scan is exhausted, so
+		// folding proceeds oldest-first (#1721) and the cursor stays unique even
+		// when two sessions share an earliest event time.
 		if len(candidates) < target {
-			cursor := ""
+			cursorNorm := ""
+			cursorSessionID := ""
 			pageSize := limit + 1
 			for len(candidates) < target {
 				if err := ctx.Err(); err != nil {
 					return xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
 				}
-				page, err := d.listEndedOrStalePage(ctx, db, cutoff, cursor, pageSize)
+				page, err := d.listEndedOrStalePage(ctx, db, cutoff, cursorNorm, cursorSessionID, pageSize)
 				if err != nil {
 					return err
 				}
@@ -174,12 +178,14 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 				}
 				// Advance the cursor from the last SQL row even when every row was
 				// filtered out in Go; otherwise a page of non-candidates loops forever.
-				cursor = page[len(page)-1].String()
-				for _, sessionID := range page {
+				last := page[len(page)-1]
+				cursorNorm = last.earliestEventNorm
+				cursorSessionID = last.sessionID.String()
+				for _, row := range page {
 					if len(candidates) >= target {
 						break
 					}
-					orphan, ok, err := d.gapPastCoverage(ctx, db, sessionID, now)
+					orphan, ok, err := d.gapPastCoverage(ctx, db, row.sessionID, row.earliestEventTime, now)
 					if err != nil {
 						return err
 					}
@@ -198,6 +204,17 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 				}
 			}
 		}
+
+		// Oldest-first across both sources (#1721). The ended/stale source is
+		// already ordered this way; sorting the merged, still-bounded set is
+		// cheap and keeps the recorded shortcut from disturbing the order.
+		sort.SliceStable(candidates, func(i, j int) bool {
+			ti, tj := candidates[i].EarliestEventTime(), candidates[j].EarliestEventTime()
+			if !ti.Equal(tj) {
+				return ti.Before(tj)
+			}
+			return candidates[i].SessionID().String() < candidates[j].SessionID().String()
+		})
 
 		hasMore := len(candidates) > limit
 		if hasMore {
@@ -341,6 +358,9 @@ func (d *SessionOrphanRangeDatasource) listRecorded(ctx context.Context, db *sql
 		if err != nil {
 			return nil, err
 		}
+		if orphan == nil {
+			continue
+		}
 		result = append(result, orphan)
 	}
 	if err := rows.Err(); err != nil {
@@ -349,30 +369,51 @@ func (d *SessionOrphanRangeDatasource) listRecorded(ctx context.Context, db *sql
 	return result, nil
 }
 
+// endedOrStaleCandidate is one row of the oldest-first ended/stale page: the
+// session id and the earliest orphaned event's time, both as returned by the
+// SQL (raw text and its normalized form, used as the next page's cursor).
+type endedOrStaleCandidate struct {
+	sessionID         types.SessionID
+	earliestEventTime time.Time
+	earliestEventNorm string
+}
+
 func (d *SessionOrphanRangeDatasource) listEndedOrStalePage(
 	ctx context.Context,
 	db *sql.DB,
 	cutoff string,
-	afterSessionID string,
+	cursorNorm string,
+	cursorSessionID string,
 	limit int,
-) ([]types.SessionID, error) {
-	rows, err := db.QueryContext(ctx, listEndedOrStaleSessionsForOrphanQuery, afterSessionID, cutoff, cutoff, limit)
+) ([]endedOrStaleCandidate, error) {
+	rows, err := db.QueryContext(
+		ctx, listEndedOrStaleSessionsForOrphanQuery,
+		cutoff, cutoff, cursorNorm, cursorSessionID, limit,
+	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to list ended or stale sessions: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	var result []types.SessionID
+	var result []endedOrStaleCandidate
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, xerrors.Errorf("failed to scan ended or stale session id: %w", err)
+		var id, earliestRaw string
+		if err := rows.Scan(&id, &earliestRaw); err != nil {
+			return nil, xerrors.Errorf("failed to scan ended or stale session row: %w", err)
 		}
 		sessionID, err := types.SessionIDFrom(id)
 		if err != nil {
 			return nil, xerrors.Errorf("invalid stored session id: %w", err)
 		}
-		result = append(result, sessionID)
+		earliest, err := time.Parse(time.RFC3339Nano, earliestRaw)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid orphan earliest_event_time %q: %w", earliestRaw, err)
+		}
+		result = append(result, endedOrStaleCandidate{
+			sessionID:         sessionID,
+			earliestEventTime: earliest,
+			earliestEventNorm: normalizeRFC3339NanoForCompare(earliestRaw),
+		})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, xerrors.Errorf("failed to iterate ended or stale sessions: %w", err)
@@ -449,6 +490,7 @@ func (d *SessionOrphanRangeDatasource) gapPastCoverage(
 	ctx context.Context,
 	db *sql.DB,
 	sessionID types.SessionID,
+	earliestEventTime time.Time,
 	now time.Time,
 ) (*model.SessionOrphanRange, bool, error) {
 	var latestID string
@@ -477,6 +519,7 @@ SELECT covers_to_event_id
 			types.None[types.EventID](),
 			latest,
 			now.UTC(),
+			earliestEventTime,
 		)
 		if buildErr != nil {
 			return nil, false, xerrors.Errorf("failed to build whole-session orphan range: %w", buildErr)
@@ -510,6 +553,7 @@ SELECT covers_to_event_id
 		types.Some(from),
 		latest,
 		now.UTC(),
+		earliestEventTime,
 	)
 	if err != nil {
 		return nil, false, xerrors.Errorf("failed to build orphan range past coverage: %w", err)
@@ -527,13 +571,24 @@ func scanSessionOrphanRange(row orphanRangeScanner) (*model.SessionOrphanRange, 
 		fromEventID string
 		toEventID   string
 		observedRaw string
+		earliestRaw sql.NullString
 	)
-	if err := row.Scan(&sessionID, &fromEventID, &toEventID, &observedRaw); err != nil {
+	if err := row.Scan(&sessionID, &fromEventID, &toEventID, &observedRaw, &earliestRaw); err != nil {
 		return nil, xerrors.Errorf("failed to scan session orphan range: %w", err)
 	}
 	observedAt, err := time.Parse(time.RFC3339Nano, observedRaw)
 	if err != nil {
 		return nil, xerrors.Errorf("invalid orphan observed_at %q: %w", observedRaw, err)
+	}
+	if !earliestRaw.Valid {
+		// The range's material was removed after the marker was recorded
+		// (e.g. compacted away). Nothing left to fold or delete; drop it
+		// rather than surface a range with an unknown earliest time.
+		return nil, nil
+	}
+	earliestEventTime, err := time.Parse(time.RFC3339Nano, earliestRaw.String)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid orphan earliest_event_time %q: %w", earliestRaw.String, err)
 	}
 	from := types.None[types.EventID]()
 	if fromEventID != "" {
@@ -547,7 +602,7 @@ func scanSessionOrphanRange(row orphanRangeScanner) (*model.SessionOrphanRange, 
 	if err != nil {
 		return nil, xerrors.Errorf("invalid orphan to_event_id: %w", err)
 	}
-	orphan, err := model.SessionOrphanRangeOf(types.SessionID(sessionID), from, to, observedAt)
+	orphan, err := model.SessionOrphanRangeOf(types.SessionID(sessionID), from, to, observedAt, earliestEventTime)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore session orphan range: %w", err)
 	}

--- a/infrastructure/sqlite/session_orphan_range_datasource_test.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource_test.go
@@ -1035,14 +1035,21 @@ func tableExistsAt(t *testing.T, dbPath, table string) bool {
 
 // TestSessionOrphanRangeDatasource_DiscoveryPlanUsesNormalizedTimestampIndex
 // pins the reason the discovery query reads events.created_at_norm instead of
-// calling ts_norm(created_at). Discovery evaluates the latest-event subquery for
-// every session it scans, so an unindexable ordering there costs a sort per
-// session — exactly the open-ended work #1719 exists to bound.
+// calling ts_norm(created_at). Discovery evaluates the latest-event and
+// earliest-orphaned-event subqueries for every session it scans, so an
+// unindexable ordering there costs a sort per session — exactly the
+// open-ended work #1719 exists to bound.
 //
-// Measured on the same fixture: with ts_norm(e2.created_at) the plan ends in
-// "USE TEMP B-TREE FOR ORDER BY" and the activity probe degrades to
-// "SEARCH e USING COVERING INDEX idx_events_session_created_at (session_id=?)",
-// dropping the timestamp from the seek.
+// Since #1721, the query also produces one global oldest-first order across
+// sessions (earliest_event_norm, session_id) so bounded gc passes fold the
+// ranges deletion is about to touch first. No per-session index can back a
+// cross-session composite order, so exactly one "USE TEMP B-TREE FOR ORDER
+// BY" over the already-filtered candidate set is expected; every per-session
+// correlated subquery must still hit the normalized index.
+//
+// Measured on the same fixture: with ts_norm(e2.created_at) the activity probe
+// degrades to "SEARCH e USING COVERING INDEX idx_events_session_created_at
+// (session_id=?)", dropping the timestamp from the seek.
 func TestSessionOrphanRangeDatasource_DiscoveryPlanUsesNormalizedTimestampIndex(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -1063,7 +1070,7 @@ func TestSessionOrphanRangeDatasource_DiscoveryPlanUsesNormalizedTimestampIndex(
 	rows, err := db.QueryContext(
 		ctx,
 		"EXPLAIN QUERY PLAN "+strings.TrimSpace(string(query)),
-		"", cutoff, cutoff, 10,
+		cutoff, cutoff, "", "", 10,
 	)
 	if err != nil {
 		t.Fatalf("explain discovery query: %v", err)
@@ -1087,8 +1094,13 @@ func TestSessionOrphanRangeDatasource_DiscoveryPlanUsesNormalizedTimestampIndex(
 	}
 
 	joined := strings.Join(plan, "\n")
-	if strings.Contains(joined, "TEMP B-TREE") {
-		t.Errorf("query plan sorts instead of using an index:\n%s", joined)
+	if got := strings.Count(joined, "TEMP B-TREE"); got != 1 {
+		t.Errorf("query plan uses %d temp b-tree sorts, want exactly 1 (the outer oldest-first order):\n%s", got, joined)
+	}
+	for _, line := range plan {
+		if strings.HasPrefix(line, "SCAN e") {
+			t.Errorf("query plan scans an events subquery without an index:\n%s", joined)
+		}
 	}
 	if !strings.Contains(joined, "idx_events_session_created_at_norm_id_desc") {
 		t.Errorf("query plan does not use the normalized timestamp index:\n%s", joined)

--- a/infrastructure/sqlite/session_orphan_range_datasource_test.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource_test.go
@@ -937,15 +937,15 @@ func TestSessionOrphanRangeDatasource_RecordedShortcutsDoNotHideOlderEndedSessio
 	now := base.Add(48 * time.Hour)
 	orphanUC := usecase.NewSessionOrphanRangeUsecase(fx.orphans, fx.refine, fx.events, types.SystemClock{})
 
-	// Still-active sessions with compact markers. Their events are newer than
-	// the ended session below. Enough of them would fill a limit-sized page
-	// if recorded shortcuts were allowed to occupy the discovery budget first.
+	// Still-active sessions with compact markers. Last activity must fall
+	// inside the 24h stale window so they stay on the recorded path and are
+	// not rediscovered as stale (which would hide this regression).
 	for i := 1; i <= 3; i++ {
 		id := fmt.Sprintf("sess-active-%d", i)
-		at := base.Add(time.Duration(i) * time.Hour)
+		at := now.Add(-time.Duration(i) * time.Minute)
 		_ = seedOrphanSession(ctx, t, fx, id, []eventSeed{
 			{id: id + "-evt", at: at},
-			{id: id + "-compact", at: at.Add(time.Minute)},
+			{id: id + "-compact", at: at.Add(time.Second)},
 		}, false)
 		if err := orphanUC.RecordAtCompact(ctx, types.SessionID(id), types.EventID(id+"-compact")); err != nil {
 			t.Fatalf("RecordAtCompact(%s) error = %v", id, err)

--- a/infrastructure/sqlite/session_orphan_range_datasource_test.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource_test.go
@@ -929,6 +929,48 @@ func TestSessionOrphanRangeDatasource_DiscoverCandidatesProgressesAcrossPages(t 
 	}
 }
 
+func TestSessionOrphanRangeDatasource_RecordedShortcutsDoNotHideOlderEndedSessions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fx := newOrphanFixture(t)
+	base := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	now := base.Add(48 * time.Hour)
+	orphanUC := usecase.NewSessionOrphanRangeUsecase(fx.orphans, fx.refine, fx.events, types.SystemClock{})
+
+	// Still-active sessions with compact markers. Their events are newer than
+	// the ended session below. Enough of them would fill a limit-sized page
+	// if recorded shortcuts were allowed to occupy the discovery budget first.
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("sess-active-%d", i)
+		at := base.Add(time.Duration(i) * time.Hour)
+		_ = seedOrphanSession(ctx, t, fx, id, []eventSeed{
+			{id: id + "-evt", at: at},
+			{id: id + "-compact", at: at.Add(time.Minute)},
+		}, false)
+		if err := orphanUC.RecordAtCompact(ctx, types.SessionID(id), types.EventID(id+"-compact")); err != nil {
+			t.Fatalf("RecordAtCompact(%s) error = %v", id, err)
+		}
+	}
+
+	_ = seedOrphanSession(ctx, t, fx, "sess-old-ended", []eventSeed{
+		{id: "evt-old-ended", at: base},
+	}, true)
+
+	got, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, 2)
+	if err != nil {
+		t.Fatalf("DiscoverCandidates() error = %v", err)
+	}
+	if len(got.Ranges) != 2 {
+		t.Fatalf("candidates = %d, want 2", len(got.Ranges))
+	}
+	if got.Ranges[0].SessionID().String() != "sess-old-ended" {
+		t.Fatalf("first candidate = %s, want sess-old-ended (oldest ended range must beat newer recorded shortcuts)", got.Ranges[0].SessionID())
+	}
+	if !got.HasMore {
+		t.Fatal("HasMore = false, want true: recorded shortcuts plus the ended session exceed the limit")
+	}
+}
+
 func TestSessionOrphanRangeDatasource_SessionsWithNoEventsAreNotReturned(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/infrastructure/sqlite/sql/list_ended_or_stale_sessions_for_orphan.sql
+++ b/infrastructure/sqlite/sql/list_ended_or_stale_sessions_for_orphan.sql
@@ -2,6 +2,12 @@
 -- may still have material past their refinement coverage. Same activity window
 -- as session gc.
 --
+-- Ordered oldest-first by the earliest orphaned event's created_at (#1721),
+-- not by session_id: CollectGarbage only needs the ranges it is about to
+-- delete folded, and those are the oldest ones. A composite
+-- (earliest_event_norm, session_id) keyset cursor keeps rows unique under
+-- this order even when two sessions share the same earliest event time.
+--
 -- The coverage filter lives here, not in Go, because the caller applies a
 -- LIMIT: against an unfiltered list a second pass would return the same
 -- already-folded sessions and make no progress forever. Filtering here lets
@@ -13,21 +19,23 @@
 -- session forever.
 --
 -- Canonical event order is (ts_norm(created_at), id): created_at is
--- variable-width RFC3339Nano and is not lexically ordered (#1185). The event
--- side uses the persisted created_at_norm column rather than ts_norm(created_at)
--- so idx_events_session_created_at_norm_id_desc applies: this query runs the
--- latest-event subquery for every session it scans, and a function call there
--- would turn each one into a scan-and-sort of that session's events. Migration
--- 031 backfills and trigger-maintains the column, and migrate_test pins
--- created_at_norm = ts_norm(created_at). sessions has no such column, so
--- started_at still goes through ts_norm.
+-- variable-width RFC3339Nano and is not lexically ordered (#1185). Every
+-- comparison and sort here uses the persisted created_at_norm column rather
+-- than ts_norm(created_at) so idx_events_session_created_at_norm_id_desc
+-- applies. sessions has no such column, so started_at still goes through
+-- ts_norm.
 --
--- Bind: after-cursor session_id, cutoff (started_at), cutoff (last activity), limit.
-SELECT s.session_id
-  FROM sessions AS s
-  LEFT JOIN session_refinements AS r ON r.session_id = s.session_id
- WHERE s.session_id > ?
-   AND (
+-- Bind: cutoff (started_at), cutoff (last activity), cursor earliest_event_norm,
+-- cursor session_id, limit.
+WITH eligible_sessions AS (
+  SELECT s.session_id AS session_id,
+         (SELECT e2.created_at_norm
+            FROM events AS e2
+           WHERE e2.id = r.covers_to_event_id
+             AND e2.session_id = s.session_id) AS covers_to_norm
+    FROM sessions AS s
+    LEFT JOIN session_refinements AS r ON r.session_id = s.session_id
+   WHERE (
          s.ended_at IS NOT NULL
          OR (
               s.ended_at IS NULL
@@ -40,17 +48,38 @@ SELECT s.session_id
                   )
             )
        )
-   AND EXISTS (SELECT 1 FROM events AS e3 WHERE e3.session_id = s.session_id)
-   AND (
-         r.session_id IS NULL
-         OR r.covers_to_event_id IS NULL
-         OR r.covers_to_event_id <> (
-              SELECT e2.id
-                FROM events AS e2
-               WHERE e2.session_id = s.session_id
-               ORDER BY e2.created_at_norm DESC, e2.id DESC
-               LIMIT 1
-            )
-       )
- ORDER BY s.session_id ASC
+     AND EXISTS (SELECT 1 FROM events AS e3 WHERE e3.session_id = s.session_id)
+     AND (
+           r.session_id IS NULL
+           OR r.covers_to_event_id IS NULL
+           OR r.covers_to_event_id <> (
+                SELECT e4.id
+                  FROM events AS e4
+                 WHERE e4.session_id = s.session_id
+                 ORDER BY e4.created_at_norm DESC, e4.id DESC
+                 LIMIT 1
+              )
+         )
+),
+candidates AS (
+  SELECT es.session_id AS session_id,
+         (SELECT e5.created_at
+            FROM events AS e5
+           WHERE e5.session_id = es.session_id
+             AND (es.covers_to_norm IS NULL OR e5.created_at_norm > es.covers_to_norm)
+           ORDER BY e5.created_at_norm ASC, e5.id ASC
+           LIMIT 1) AS earliest_event_time,
+         (SELECT e5.created_at_norm
+            FROM events AS e5
+           WHERE e5.session_id = es.session_id
+             AND (es.covers_to_norm IS NULL OR e5.created_at_norm > es.covers_to_norm)
+           ORDER BY e5.created_at_norm ASC, e5.id ASC
+           LIMIT 1) AS earliest_event_norm
+    FROM eligible_sessions AS es
+)
+SELECT session_id, earliest_event_time
+  FROM candidates
+ WHERE earliest_event_time IS NOT NULL
+   AND (earliest_event_norm, session_id) > (?, ?)
+ ORDER BY earliest_event_norm ASC, session_id ASC
  LIMIT ?

--- a/infrastructure/sqlite/sql/list_recorded_orphan_ranges.sql
+++ b/infrastructure/sqlite/sql/list_recorded_orphan_ranges.sql
@@ -1,3 +1,20 @@
-SELECT session_id, from_event_id, to_event_id, observed_at
-  FROM session_orphan_ranges
+SELECT o.session_id,
+       o.from_event_id,
+       o.to_event_id,
+       o.observed_at,
+       (SELECT e.created_at
+          FROM events AS e
+         WHERE e.session_id = o.session_id
+           AND (
+                 o.from_event_id = ''
+                 OR e.created_at_norm > (
+                      SELECT e2.created_at_norm
+                        FROM events AS e2
+                       WHERE e2.id = o.from_event_id
+                         AND e2.session_id = o.session_id
+                    )
+               )
+         ORDER BY e.created_at_norm ASC, e.id ASC
+         LIMIT 1) AS earliest_event_time
+  FROM session_orphan_ranges AS o
  ORDER BY session_id ASC, to_event_id ASC

--- a/main.go
+++ b/main.go
@@ -440,8 +440,14 @@ func writeCLIError(output io.Writer, err error) error {
 	return nil
 }
 
-func compactWorkCover(migrations fs.FS) func(context.Context, string) error {
-	return func(ctx context.Context, work string) error {
+// compactWorkCover runs the --force mechanical cover on the compact work
+// copy. Discovery folds the oldest orphan ranges first (#1721), so a bounded
+// pass is used instead of draining the whole backlog: CollectGarbage only
+// needs every range at or past the cutoff folded, not every range that
+// exists. ForceCoverSafeToDelete checks that condition against what the pass
+// left unprocessed or skipped.
+func compactWorkCover(migrations fs.FS) func(context.Context, string, time.Time) error {
+	return func(ctx context.Context, work string, cutoff time.Time) error {
 		db := sqlite.NewDatabase(work, migrations)
 		sessionDatasource := sqlite.NewSessionDatasource(db)
 		refinementDatasource := sqlite.NewSessionRefinementDatasource(db)
@@ -451,13 +457,13 @@ func compactWorkCover(migrations fs.FS) func(context.Context, string) error {
 		cover := usecase.NewOrphanConsolidationUsecase(orphanDatasource, refine, types.SystemClock{})
 		// One read-only handle for the whole pass: DiscoverCandidates and every
 		// per-candidate LoadMaterial call inherit it instead of each paying
-		// setup+ping+compat on its own (#1722).
+		// setup+ping+compat on its own (#1722). Bounded (not Unlimited): oldest
+		// first so CollectGarbage only needs pre-cutoff ranges folded (#1721).
 		var result apptypes.OrphanConsolidationResult
 		err := orphanDatasource.WithReadScope(ctx, func(scopedCtx context.Context) error {
 			var consolidateErr error
 			result, consolidateErr = cover.Consolidate(scopedCtx, usecase.OrphanConsolidationInput{
 				StaleAfter: 24 * time.Hour,
-				Unlimited:  true,
 			})
 			if consolidateErr != nil {
 				return xerrors.Errorf("consolidate orphan ranges: %w", consolidateErr)
@@ -467,7 +473,11 @@ func compactWorkCover(migrations fs.FS) func(context.Context, string) error {
 		if err != nil {
 			return xerrors.Errorf("compact force cover: %w", err)
 		}
-		if err := application.ForceCoverMustComplete(result.HasMore(), result.Skipped()); err != nil {
+		if err := application.ForceCoverSafeToDelete(
+			result.HasMore(), result.EarliestUnprocessedEventTime(),
+			result.Skipped(), result.EarliestSkippedEventTime(),
+			cutoff,
+		); err != nil {
 			return xerrors.Errorf("compact force cover: %w", err)
 		}
 		return nil


### PR DESCRIPTION
## Summary

Bounded orphan consolidation used to gate compact `--force` deletion on a 100% drained backlog (`!HasMore && Skipped == 0`). On a store with a large but recent unfolded backlog that blocked `CollectGarbage` even though deletion only ever touches events older than the retention cutoff.

This remaps the #1721 gate onto compact's work-copy cover (no `store gc` restoration):

- Discovery paginates ended/stale sessions oldest-first via a composite `(earliest_event_norm, session_id)` keyset cursor.
- `OrphanConsolidationResult` reports `EarliestUnprocessedEventTime` / `EarliestSkippedEventTime` (`nil` = unknown = refuse).
- `ForceCoverSafeToDelete` replaces `ForceCoverMustComplete`: deletion proceeds when leftover ranges are entirely newer than the cutoff, even with `HasMore`.
- `--force` cover is a bounded pass, not `Unlimited`.
- #1722's `WithReadScope` wrapping is kept.

Leaves parent #1968 open.

## Test plan

- [x] `go test ./domain/model/ ./application/ ./application/types/ ./application/usecase/ ./infrastructure/sqlite/`
- [x] `go build .`
- [x] `go tool golangci-lint run` on touched packages
- [x] Fixture: leftover newer than cutoff + `HasMore` → compact proceeds (`TestCompactForceCoverProceedsWhenLeftoverIsNewerThanCutoff`)
- [x] Fixture: leftover older than cutoff → compact refuses (`TestCompactForceCoverRefusesWhenLeftoverIsOlderThanCutoff`)

Closes #1721