### PR TITLE
fix: fold pre-cutoff tails of never-ending active sessions

### DIFF
--- a/application/types/orphan_consolidation_result.go
+++ b/application/types/orphan_consolidation_result.go
@@ -120,11 +120,15 @@ func (r OrphanConsolidationResult) Failures() OrphanConsolidationFailures { retu
 // can actually act on.
 //
 // This is a statement about this pass, not a proof that nothing unfolded
-// remains anywhere. Discovery sees ended or stale sessions plus recorded
-// markers, so a session that has stayed continuously active for longer than
-// the retention window still holds old unfolded events. Those keep their
-// bodies rather than losing them, but they also never become discardable; that
-// gap predates bounding and is tracked in #1724.
+// remains anywhere. Discovery sees ended or stale sessions, recorded markers,
+// and (when the caller supplies a retention cutoff) sessions that never go
+// ended or stale but still hold material past coverage older than that
+// cutoff. The last of these closes what used to be a standing gap: a session
+// that stayed continuously active for longer than the retention window used
+// to be invisible to every discovery source, so its old material was never
+// folded no matter how old it got. It is now discovered and folded up to,
+// but never past, the supplied cutoff — the still-recent tail is left
+// uncovered and surfaces again on a later pass once it too ages past cutoff.
 //
 // There is deliberately no Complete() beside this. It used to mean "no more
 // candidates and nothing was skipped", and conflating those two facts is the

--- a/application/usecase/orphan_consolidation_usecase.go
+++ b/application/usecase/orphan_consolidation_usecase.go
@@ -24,6 +24,15 @@ type OrphanConsolidationInput struct {
 	// Unlimited ignores Limit and Budget so compact --force can cover every
 	// discardable-age unrefined session in one rewrite.
 	Unlimited bool
+	// RetentionCutoff enables the third orphan-discovery source (#1724):
+	// sessions that never go ended/stale but still hold material past
+	// refinement coverage older than this cutoff. The zero value disables
+	// that source, keeping discovery to the recorded-marker and
+	// ended/stale sources only. Callers that know the compact retention
+	// cutoff (e.g. the --force cover pass) should pass it here so an
+	// always-on session's pre-cutoff tail is folded before CollectGarbage's
+	// DELETE runs.
+	RetentionCutoff time.Time
 }
 
 // OrphanConsolidationUsecase folds unfolded orphan ranges into degraded

--- a/application/usecase/orphan_consolidation_usecase_impl.go
+++ b/application/usecase/orphan_consolidation_usecase_impl.go
@@ -94,7 +94,7 @@ func (u *orphanConsolidationUsecase) Consolidate(
 
 	started := u.clock.Now()
 	now := started
-	candidates, err := u.orphans.DiscoverCandidates(ctx, input.StaleAfter, now, limit)
+	candidates, err := u.orphans.DiscoverCandidates(ctx, input.StaleAfter, now, input.RetentionCutoff, limit)
 	if err != nil {
 		return apptypes.OrphanConsolidationResult{}, xerrors.Errorf("failed to discover orphan ranges: %w", err)
 	}

--- a/application/usecase/orphan_consolidation_usecase_test.go
+++ b/application/usecase/orphan_consolidation_usecase_test.go
@@ -36,7 +36,7 @@ func (s *orphanRepoStub) Record(context.Context, *model.SessionOrphanRange) erro
 	return nil
 }
 
-func (s *orphanRepoStub) DiscoverCandidates(_ context.Context, _ time.Duration, _ time.Time, limit int) (model.SessionOrphanCandidates, error) {
+func (s *orphanRepoStub) DiscoverCandidates(_ context.Context, _ time.Duration, _ time.Time, _ time.Time, limit int) (model.SessionOrphanCandidates, error) {
 	s.discoverCall++
 	s.lastLimit = limit
 	if s.discoverErr != nil {

--- a/application/usecase/session_orphan_range_usecase_test.go
+++ b/application/usecase/session_orphan_range_usecase_test.go
@@ -19,7 +19,7 @@ func (s *orphanRecordRepoStub) Record(_ context.Context, orphan *model.SessionOr
 	return nil
 }
 
-func (s *orphanRecordRepoStub) DiscoverCandidates(context.Context, time.Duration, time.Time, int) (model.SessionOrphanCandidates, error) {
+func (s *orphanRecordRepoStub) DiscoverCandidates(context.Context, time.Duration, time.Time, time.Time, int) (model.SessionOrphanCandidates, error) {
 	return model.SessionOrphanCandidates{}, nil
 }
 

--- a/domain/model/session_orphan_range_repository.go
+++ b/domain/model/session_orphan_range_repository.go
@@ -31,11 +31,26 @@ type SessionOrphanRangeRepository interface {
 	//      and whose to_event_id is not yet covered by the session refinement
 	//   2. ended or stale sessions with material past covers_to (or the whole
 	//      session when no refinement exists)
-	// staleAfter is the same activity window as session gc (default 24h).
+	//   3. sessions that are neither ended nor stale (an always-on session
+	//      never satisfies source 2's predicate) but hold material past
+	//      covers_to that is older than retentionCutoff. The folded terminus
+	//      is the last-observed event strictly before retentionCutoff, never
+	//      "now" or the session's true latest event: material at or after
+	//      retentionCutoff is left uncovered so a later activity burst starts
+	//      a fresh orphan range instead of being claimed as already folded
+	//      (#1724). A recorded marker (source 1) for the same session is
+	//      skipped in favour of this source when this source also matches,
+	//      the same way source 1 already defers to source 2.
+	// staleAfter is the same activity window as session gc (default 24h); it
+	// bounds sources 1 and 2. retentionCutoff bounds source 3; the zero value
+	// disables source 3 entirely (callers that do not know the compact
+	// retention cutoff keep today's two-source behaviour unchanged).
 	// limit bounds the work one pass performs; it is a query bound, not a
 	// persistence detail. limit must be greater than zero.
 	// This asks a question; it changes nothing.
-	DiscoverCandidates(ctx context.Context, staleAfter time.Duration, now time.Time, limit int) (SessionOrphanCandidates, error)
+	DiscoverCandidates(
+		ctx context.Context, staleAfter time.Duration, now time.Time, retentionCutoff time.Time, limit int,
+	) (SessionOrphanCandidates, error)
 
 	// LoadMaterial returns the mechanical-summary inputs for a range under
 	// canonical event order (ts_norm(created_at), id). Like DiscoverCandidates,

--- a/infrastructure/sqlite/compaction_copy_filter_test.go
+++ b/infrastructure/sqlite/compaction_copy_filter_test.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 
 	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
@@ -366,6 +367,140 @@ func TestCompactForceCoverCompletesOnRealStore(t *testing.T) {
 	defer func() { _ = db.Close() }()
 	if avail := gcEventAvailability(t, db, "event-old"); avail != "unavailable_retention" {
 		t.Fatalf("forced body availability = %s, want unavailable_retention", avail)
+	}
+}
+
+// TestCompactForceCoverFoldsNeverEndingSessionsPreCutoffTail is the #1724
+// regression pin. A session that stays continuously active (recent activity,
+// ended_at always NULL) satisfies neither of the two discovery sources #1721
+// coordinates with: it is never "ended", and the 24h staleness rule never
+// fires because there is always recent activity.
+//
+// Before the third discovery source existed, such a session's old material
+// was never seen by any consolidation pass, no matter how old it got: repeated
+// force-cover passes here would report ProducedCount() == 0 and leave
+// session_refinements empty for it forever, so the material stayed unfolded
+// for as long as the session kept receiving occasional activity — even though
+// select_discardable_event_bodies.sql's own ended_at IS NOT NULL clause
+// already keeps its transcript bodies from being physically discarded while
+// active. Once the session eventually does end (or goes stale), the whole
+// accumulated backlog surfaces to source 2 at once with no prior folding
+// progress, which is exactly the large, all-at-once blast radius #1721's
+// bounded, oldest-first passes exist to avoid.
+//
+// This test wires the third source's RetentionCutoff through the same real
+// Compact() --force path the other #1721 tests use and asserts folding now
+// happens incrementally for the still-active session, with a terminus bounded
+// to the last event strictly before the retention cutoff — not the session's
+// true latest event.
+func TestCompactForceCoverFoldsNeverEndingSessionsPreCutoffTail(t *testing.T) {
+	t.Parallel()
+	dbPath, events, store := prepareDiscardGCFixture(t)
+	_ = store
+	old := newGCEventFixture(t, "event-old", types.EventKindTranscript, "why-is-here", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), old); err != nil {
+		t.Fatal(err)
+	}
+	recent := newGCEventFixture(t, "event-recent", types.EventKindTranscript, "still-going", time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), recent); err != nil {
+		t.Fatal(err)
+	}
+
+	db := openRetentionDB(t, dbPath)
+	insertGCSession(t, db, "session-1", false) // never ends
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := usecase.NewStoreCompactionUsecase(
+		dbPath,
+		&sqlite.CompactionFileJournal{Dir: filepath.Join(t.TempDir(), "journal")},
+		&sqlite.SQLiteCompactionBuilder{},
+		sqlite.StoreReplacementFiles{CallerHoldsExclusiveLease: true},
+		sqlite.StoreLeaseCoordinator{},
+	)
+	migrations := onDiskSQLiteMigrations(t)
+	// compactWorkCover in main.go always pairs a real-clock staleness rule
+	// with a real-now retention cutoff, so the two agree in production. This
+	// test fixes CompactInput.Now to a historical instant to keep the fixture
+	// deterministic, so the cover's own clock must be pinned to that same
+	// instant too — otherwise the 24h staleness rule would race the actual
+	// wall clock and classify session-1 as stale via source 2 (unbounded)
+	// well before the cutoff-bounded source 3 was meant to be exercised.
+	fixedNow := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	var lastResult apptypes.OrphanConsolidationResult
+	usecase.BindCompactionWorkCover(svc, func(ctx context.Context, work string, cutoff time.Time) error {
+		database := sqlite.NewDatabase(work, migrations)
+		refine := usecase.NewSessionRefinementUsecase(
+			sqlite.NewSessionDatasource(database),
+			sqlite.NewSessionRefinementDatasource(database),
+			sqlite.NewEventDatasource(database),
+			fixedEventClock{at: fixedNow},
+		)
+		cover := usecase.NewOrphanConsolidationUsecase(
+			sqlite.NewSessionOrphanRangeDatasource(database),
+			refine,
+			fixedEventClock{at: fixedNow},
+		)
+		result, err := cover.Consolidate(ctx, usecase.OrphanConsolidationInput{
+			StaleAfter:      24 * time.Hour,
+			RetentionCutoff: cutoff,
+		})
+		if err != nil {
+			return fmt.Errorf("compact force cover: %w", err)
+		}
+		lastResult = result
+		if err := application.ForceCoverSafeToDelete(
+			result.HasMore(), result.EarliestUnprocessedEventTime(),
+			result.Skipped(), result.EarliestSkippedEventTime(),
+			cutoff,
+		); err != nil {
+			return fmt.Errorf("compact force cover: %w", err)
+		}
+		return nil
+	})
+
+	// MechanicalSummaries/UnrefinedRemaining are reported from a separate
+	// legacy body-gate query (unrefinedDiscardableSessionsQuery) that joins on
+	// sessions.ended_at IS NOT NULL and so never counts an always-on session
+	// either; that gate is out of scope for #1724 (see the responsibility
+	// table) and is not asserted on here.
+	if _, err := svc.Compact(context.Background(), application.CompactInput{
+		Source:   dbPath,
+		Force:    true,
+		KeepDays: 10,
+		Now:      time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("Compact() error = %v, want the never-ending session's pre-cutoff tail to be folded by the third discovery source", err)
+	}
+	if lastResult.ProducedCount() != 1 {
+		t.Fatalf("ProducedCount = %d, want 1: the third discovery source must have folded session-1's pre-cutoff tail", lastResult.ProducedCount())
+	}
+
+	db = openRetentionDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+
+	var coversTo string
+	if err := db.QueryRow(`SELECT covers_to_event_id FROM session_refinements WHERE session_id = 'session-1'`).Scan(&coversTo); err != nil {
+		t.Fatalf("query session_refinements: %v", err)
+	}
+	if coversTo != "event-old" {
+		t.Fatalf("covers_to_event_id = %s, want event-old: the fold must stop at the last pre-cutoff event, not the still-active session's latest event", coversTo)
+	}
+
+	// The transcript discard allowlist itself refuses any session whose
+	// ended_at is NULL (select_discardable_event_bodies.sql), independent of
+	// fold status, so neither event's body_availability changes here — that
+	// guard already keeps an active session's bodies from being physically
+	// discarded. What this test pins is that the fold happened at all, and
+	// that it stopped at the correct pre-cutoff terminus rather than either
+	// skipping the session (the pre-#1724 gap) or claiming coverage over the
+	// still-recent, post-cutoff activity.
+	if avail := gcEventAvailability(t, db, "event-old"); avail != "available" {
+		t.Fatalf("event-old body_availability = %s, want available (an active session's bodies are never discarded)", avail)
+	}
+	if avail := gcEventAvailability(t, db, "event-recent"); avail != "available" {
+		t.Fatalf("event-recent body_availability = %s, want available", avail)
 	}
 }
 

--- a/infrastructure/sqlite/session_orphan_range_datasource.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource.go
@@ -24,8 +24,14 @@ var listRecordedOrphanRangesQuery string
 //go:embed sql/list_ended_or_stale_sessions_for_orphan.sql
 var listEndedOrStaleSessionsForOrphanQuery string
 
+//go:embed sql/list_active_sessions_for_orphan.sql
+var listActiveSessionsForOrphanQuery string
+
 //go:embed sql/select_latest_event_id_for_session.sql
 var selectLatestEventIDForSessionQuery string
+
+//go:embed sql/select_latest_event_id_for_session_before_cutoff.sql
+var selectLatestEventIDForSessionBeforeCutoffQuery string
 
 //go:embed sql/select_orphan_range_events.sql
 var selectOrphanRangeEventsQuery string
@@ -100,6 +106,7 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 	ctx context.Context,
 	staleAfter time.Duration,
 	now time.Time,
+	retentionCutoff time.Time,
 	limit int,
 ) (model.SessionOrphanCandidates, error) {
 	if staleAfter <= 0 {
@@ -116,6 +123,14 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 		}
 
 		cutoff := formatTimestamp(now.UTC().Add(-staleAfter))
+		// Source 3 (#1724) is opt-in: the zero value means the caller does not
+		// know the compact retention cutoff, so it keeps today's two-source
+		// behaviour rather than guessing a cutoff that could be wrong.
+		retentionCutoffEnabled := !retentionCutoff.IsZero()
+		retentionCutoffNorm := ""
+		if retentionCutoffEnabled {
+			retentionCutoffNorm = formatTimestamp(retentionCutoff.UTC())
+		}
 		seen := map[string]struct{}{}
 		var candidates []*model.SessionOrphanRange
 		target := limit + 1
@@ -148,6 +163,21 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 			if endedOrStale {
 				// Will be rediscovered from covers_to below with the full gap.
 				continue
+			}
+			if retentionCutoffEnabled {
+				// This active session's marker is a frozen shortcut (see the
+				// package doc above); if source 3 also has pre-cutoff material
+				// past coverage for it, source 3 recomputes the authoritative
+				// range from covers_to, so this snapshot is skipped in favour
+				// of it rather than surfaced as a second, possibly stale range
+				// for the same session (#1724).
+				_, hasFuller, err := d.gapPastCoverageBeforeCutoff(ctx, db, orphan.SessionID(), now, now, retentionCutoffNorm)
+				if err != nil {
+					return err
+				}
+				if hasFuller {
+					continue
+				}
 			}
 			key := orphan.SessionID().String() + "\x00" + orphan.ToEventID().String()
 			if _, ok := seen[key]; ok {
@@ -202,6 +232,56 @@ func (d *SessionOrphanRangeDatasource) DiscoverCandidates(
 			}
 			if len(page) < pageSize {
 				break
+			}
+		}
+
+		// Source 3 (#1724): sessions that never satisfy source 2's
+		// ended-or-stale predicate (always active) but hold material past
+		// covers_to older than the compact retention cutoff. Paginated the
+		// same oldest-first way as source 2, and independently bounded by
+		// target so a large active-session backlog cannot starve the other
+		// sources within one pass.
+		if retentionCutoffEnabled {
+			activeCount := 0
+			activeCursorNorm := ""
+			activeCursorSessionID := ""
+			activePageSize := limit + 1
+			for activeCount < target {
+				if err := ctx.Err(); err != nil {
+					return xerrors.Errorf("orphan candidate discovery cancelled: %w", err)
+				}
+				page, err := d.listActivePage(ctx, db, cutoff, retentionCutoffNorm, activeCursorNorm, activeCursorSessionID, activePageSize)
+				if err != nil {
+					return err
+				}
+				if len(page) == 0 {
+					break
+				}
+				last := page[len(page)-1]
+				activeCursorNorm = last.earliestEventNorm
+				activeCursorSessionID = last.sessionID.String()
+				for _, row := range page {
+					if activeCount >= target {
+						break
+					}
+					orphan, ok, err := d.gapPastCoverageBeforeCutoff(ctx, db, row.sessionID, row.earliestEventTime, now, retentionCutoffNorm)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						continue
+					}
+					key := orphan.SessionID().String() + "\x00" + orphan.ToEventID().String()
+					if _, exists := seen[key]; exists {
+						continue
+					}
+					seen[key] = struct{}{}
+					candidates = append(candidates, orphan)
+					activeCount++
+				}
+				if len(page) < activePageSize {
+					break
+				}
 			}
 		}
 
@@ -421,6 +501,55 @@ func (d *SessionOrphanRangeDatasource) listEndedOrStalePage(
 	return result, nil
 }
 
+// listActivePage lists one oldest-first page of source-3 candidates (#1724):
+// sessions that never satisfy source 2's ended-or-stale predicate but hold
+// material past covers_to older than retentionCutoffNorm. Shares the
+// endedOrStaleCandidate row shape and keyset-cursor convention with
+// listEndedOrStalePage.
+func (d *SessionOrphanRangeDatasource) listActivePage(
+	ctx context.Context,
+	db *sql.DB,
+	staleCutoff string,
+	retentionCutoffNorm string,
+	cursorNorm string,
+	cursorSessionID string,
+	limit int,
+) ([]endedOrStaleCandidate, error) {
+	rows, err := db.QueryContext(
+		ctx, listActiveSessionsForOrphanQuery,
+		staleCutoff, staleCutoff, retentionCutoffNorm, retentionCutoffNorm, cursorNorm, cursorSessionID, limit,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list active sessions with pre-cutoff material: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []endedOrStaleCandidate
+	for rows.Next() {
+		var id, earliestRaw string
+		if err := rows.Scan(&id, &earliestRaw); err != nil {
+			return nil, xerrors.Errorf("failed to scan active session row: %w", err)
+		}
+		sessionID, err := types.SessionIDFrom(id)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid stored session id: %w", err)
+		}
+		earliest, err := time.Parse(time.RFC3339Nano, earliestRaw)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid orphan earliest_event_time %q: %w", earliestRaw, err)
+		}
+		result = append(result, endedOrStaleCandidate{
+			sessionID:         sessionID,
+			earliestEventTime: earliest,
+			earliestEventNorm: normalizeRFC3339NanoForCompare(earliestRaw),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate active sessions with pre-cutoff material: %w", err)
+	}
+	return result, nil
+}
+
 func (d *SessionOrphanRangeDatasource) sessionEndedOrStale(
 	ctx context.Context,
 	db *sql.DB,
@@ -486,6 +615,10 @@ SELECT covers_to_event_id
 	return after == 1, nil
 }
 
+// gapPastCoverage builds the orphan range for a session (source 2), folding
+// through the session's true latest event. Safe for ended/stale sessions
+// only: no more activity is coming, so there is no risk of claiming coverage
+// over an event that has not happened yet.
 func (d *SessionOrphanRangeDatasource) gapPastCoverage(
 	ctx context.Context,
 	db *sql.DB,
@@ -501,6 +634,48 @@ func (d *SessionOrphanRangeDatasource) gapPastCoverage(
 	if err != nil {
 		return nil, false, xerrors.Errorf("failed to resolve latest event: %w", err)
 	}
+	return d.buildGapPastCoverage(ctx, db, sessionID, latestID, earliestEventTime, now)
+}
+
+// gapPastCoverageBeforeCutoff is gapPastCoverage's bounded counterpart for
+// source 3 (#1724): the terminus is the last event strictly before cutoff,
+// not the session's true latest event. This is what keeps folding an active
+// session's tail from claiming coverage over events that have not aged past
+// the retention cutoff yet — a later activity burst starts a fresh orphan
+// range instead of falling inside this one. cutoff is the normalized
+// (formatTimestamp) retention cutoff.
+func (d *SessionOrphanRangeDatasource) gapPastCoverageBeforeCutoff(
+	ctx context.Context,
+	db *sql.DB,
+	sessionID types.SessionID,
+	earliestEventTime time.Time,
+	now time.Time,
+	cutoff string,
+) (*model.SessionOrphanRange, bool, error) {
+	var latestID string
+	err := db.QueryRowContext(ctx, selectLatestEventIDForSessionBeforeCutoffQuery, sessionID.String(), cutoff).Scan(&latestID)
+	if errors.Is(err, sql.ErrNoRows) {
+		// No event of this session is older than the cutoff.
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, xerrors.Errorf("failed to resolve latest pre-cutoff event: %w", err)
+	}
+	return d.buildGapPastCoverage(ctx, db, sessionID, latestID, earliestEventTime, now)
+}
+
+// buildGapPastCoverage is the shared tail of gapPastCoverage and
+// gapPastCoverageBeforeCutoff: given a resolved terminus event id, compare it
+// against the session's current refinement coverage and build the orphan
+// range when material remains.
+func (d *SessionOrphanRangeDatasource) buildGapPastCoverage(
+	ctx context.Context,
+	db *sql.DB,
+	sessionID types.SessionID,
+	latestID string,
+	earliestEventTime time.Time,
+	now time.Time,
+) (*model.SessionOrphanRange, bool, error) {
 	latest, err := types.EventIDFrom(latestID)
 	if err != nil {
 		return nil, false, xerrors.Errorf("invalid latest event id: %w", err)
@@ -513,7 +688,7 @@ SELECT covers_to_event_id
  WHERE session_id = ?
 `, sessionID.String()).Scan(&coversTo)
 	if errors.Is(err, sql.ErrNoRows) {
-		// No refinement: the whole session is orphaned.
+		// No refinement: the whole session (up to latest) is orphaned.
 		orphan, buildErr := model.NewSessionOrphanRange(
 			sessionID,
 			types.None[types.EventID](),

--- a/infrastructure/sqlite/session_orphan_range_datasource_test.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource_test.go
@@ -141,7 +141,7 @@ func TestSessionOrphanRangeDatasource_RecordAtCompactAfterUnfoldedRange(t *testi
 		t.Fatalf("RecordAtCompact() error = %v", err)
 	}
 
-	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, compactAt, 100)
+	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, compactAt, time.Time{}, 100)
 	if err != nil {
 		t.Fatalf("DiscoverCandidates() error = %v", err)
 	}
@@ -216,7 +216,7 @@ func TestSessionOrphanRangeDatasource_GCFindsEndedSessionWithoutMarker(t *testin
 
 	// No orphan row recorded — discovery must still find the gap past covers_to.
 	now := frac.Add(2 * time.Hour)
-	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, 100)
+	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, time.Time{}, 100)
 	if err != nil {
 		t.Fatalf("DiscoverCandidates() error = %v", err)
 	}
@@ -307,7 +307,7 @@ func TestSessionOrphanRangeDatasource_RunningSessionLeftAlone(t *testing.T) {
 		{id: "evt-2", at: now.Add(-time.Minute)},
 	}, false)
 
-	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, 100)
+	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, time.Time{}, 100)
 	if err != nil {
 		t.Fatalf("DiscoverCandidates() error = %v", err)
 	}
@@ -699,7 +699,7 @@ func TestSessionOrphanRangeDatasource_DiscoverCandidatesOnPreMigration47Store(t 
 	refineUC := usecase.NewSessionRefinementUsecase(fx.sessions, fx.refine, fx.events, types.SystemClock{})
 
 	now := base.Add(48 * time.Hour)
-	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, 100)
+	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, time.Time{}, 100)
 	if err != nil {
 		t.Fatalf("DiscoverCandidates() on pre-47 store error = %v", err)
 	}
@@ -830,7 +830,7 @@ func TestSessionOrphanRangeDatasource_FractionalSecondBoundaryOrdering(t *testin
 		t.Fatal("evt-frac should be strictly after evt-whole under ts_norm")
 	}
 
-	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, frac.Add(time.Hour), 100)
+	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, frac.Add(time.Hour), time.Time{}, 100)
 	if err != nil {
 		t.Fatalf("DiscoverCandidates() error = %v", err)
 	}
@@ -855,7 +855,7 @@ func TestSessionOrphanRangeDatasource_DiscoverCandidatesRespectsLimit(t *testing
 		}, true)
 	}
 	now := base.Add(48 * time.Hour)
-	got, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, 2)
+	got, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, time.Time{}, 2)
 	if err != nil {
 		t.Fatalf("DiscoverCandidates() error = %v", err)
 	}
@@ -882,7 +882,7 @@ func TestSessionOrphanRangeDatasource_DiscoverCandidatesProgressesAcrossPages(t 
 	now := base.Add(48 * time.Hour)
 	limit := 3
 
-	first, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, limit)
+	first, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, time.Time{}, limit)
 	if err != nil {
 		t.Fatalf("first DiscoverCandidates() error = %v", err)
 	}
@@ -907,7 +907,7 @@ func TestSessionOrphanRangeDatasource_DiscoverCandidatesProgressesAcrossPages(t 
 		t.Fatalf("ProducedCount = %d, want %d", got.ProducedCount(), limit)
 	}
 
-	second, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, limit)
+	second, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, time.Time{}, limit)
 	if err != nil {
 		t.Fatalf("second DiscoverCandidates() error = %v", err)
 	}
@@ -956,7 +956,7 @@ func TestSessionOrphanRangeDatasource_RecordedShortcutsDoNotHideOlderEndedSessio
 		{id: "evt-old-ended", at: base},
 	}, true)
 
-	got, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, 2)
+	got, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, time.Time{}, 2)
 	if err != nil {
 		t.Fatalf("DiscoverCandidates() error = %v", err)
 	}
@@ -1030,7 +1030,7 @@ func TestSessionOrphanRangeDatasource_SessionsWithNoEventsAreNotReturned(t *test
 	}
 
 	now := base.Add(48 * time.Hour)
-	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, 100)
+	candidates, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, now, time.Time{}, 100)
 	if err != nil {
 		t.Fatalf("DiscoverCandidates() error = %v", err)
 	}
@@ -1313,5 +1313,231 @@ func TestSessionOrphanRangeDatasource_WithoutReadScope_OpensPerCandidateCall(t *
 	// LoadMaterial calls opens its own connection: candidateCount+1 total.
 	if want := candidateCount + 1; opens != want {
 		t.Fatalf("read-only opens = %d, want %d (no shared scope entered)", opens, want)
+	}
+}
+
+// TestSessionOrphanRangeDatasource_ThirdSourceDiscoversActiveSessionsPastRetentionCutoff
+// covers the third orphan-discovery source added by #1724: sessions that
+// never satisfy source 2's ended-or-stale predicate (continuous activity,
+// never ended_at) but hold material past refinement coverage older than the
+// compact retention cutoff. staleAfter (24h) governs whether the session
+// looks "active"; retentionCutoff (independent, and in these fixtures much
+// closer to now) governs whether its material is old enough to fold. The
+// four subtests are the fixture shapes from the design spec's TDD plan: all
+// newer than cutoff, straddling, all older, and a tail past a recorded
+// marker.
+func TestSessionOrphanRangeDatasource_ThirdSourceDiscoversActiveSessionsPastRetentionCutoff(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	const staleAfter = 24 * time.Hour
+
+	t.Run("all events newer than cutoff is not a candidate", func(t *testing.T) {
+		t.Parallel()
+		fx := newOrphanFixture(t)
+		now := base
+		cutoff := now.Add(-time.Hour)
+		_ = seedOrphanSession(ctx, t, fx, "sess-active-newer", []eventSeed{
+			{id: "evt-1", at: now.Add(-30 * time.Minute)},
+			{id: "evt-2", at: now.Add(-5 * time.Minute)},
+		}, false)
+
+		got, err := fx.orphans.DiscoverCandidates(ctx, staleAfter, now, cutoff, 100)
+		if err != nil {
+			t.Fatalf("DiscoverCandidates() error = %v", err)
+		}
+		for _, r := range got.Ranges {
+			if r.SessionID().String() == "sess-active-newer" {
+				t.Fatal("session with events all newer than the retention cutoff must not be a candidate")
+			}
+		}
+	})
+
+	t.Run("straddling cutoff terminates at the last pre-cutoff event", func(t *testing.T) {
+		t.Parallel()
+		fx := newOrphanFixture(t)
+		now := base
+		cutoff := now.Add(-time.Hour)
+		_ = seedOrphanSession(ctx, t, fx, "sess-active-straddle", []eventSeed{
+			{id: "evt-old-1", at: now.Add(-3 * time.Hour)},
+			{id: "evt-old-2", at: now.Add(-2 * time.Hour)}, // last event strictly before cutoff
+			{id: "evt-new-1", at: now.Add(-30 * time.Minute)},
+		}, false)
+
+		got, err := fx.orphans.DiscoverCandidates(ctx, staleAfter, now, cutoff, 100)
+		if err != nil {
+			t.Fatalf("DiscoverCandidates() error = %v", err)
+		}
+		found := findOrphanRangeForSession(got, "sess-active-straddle")
+		if found == nil {
+			t.Fatal("session straddling the retention cutoff must be a candidate")
+		}
+		if found.ToEventID() != "evt-old-2" {
+			t.Fatalf("ToEventID = %s, want evt-old-2 (last event before cutoff)", found.ToEventID())
+		}
+		if from, ok := found.FromEventID().Value(); ok {
+			t.Fatalf("FromEventID = %v, want None (whole session, no prior coverage)", from)
+		}
+	})
+
+	t.Run("all events older than cutoff but session still active is a candidate", func(t *testing.T) {
+		t.Parallel()
+		fx := newOrphanFixture(t)
+		now := base
+		cutoff := now.Add(-time.Hour)
+		_ = seedOrphanSession(ctx, t, fx, "sess-active-allold", []eventSeed{
+			{id: "evt-1", at: now.Add(-5 * time.Hour)},
+			{id: "evt-2", at: now.Add(-3 * time.Hour)}, // latest activity; still within staleAfter
+		}, false)
+
+		got, err := fx.orphans.DiscoverCandidates(ctx, staleAfter, now, cutoff, 100)
+		if err != nil {
+			t.Fatalf("DiscoverCandidates() error = %v", err)
+		}
+		found := findOrphanRangeForSession(got, "sess-active-allold")
+		if found == nil {
+			t.Fatal("active session with all-older material must be a candidate")
+		}
+		if found.ToEventID() != "evt-2" {
+			t.Fatalf("ToEventID = %s, want evt-2 (latest event, all before cutoff)", found.ToEventID())
+		}
+	})
+
+	t.Run("tail past a recorded marker dedupes into one candidate", func(t *testing.T) {
+		t.Parallel()
+		fx := newOrphanFixture(t)
+		now := base
+		cutoff := now.Add(-time.Hour)
+		sessionID := seedOrphanSession(ctx, t, fx, "sess-active-marker", []eventSeed{
+			{id: "evt-whole", at: now.Add(-5 * time.Hour)},
+			{id: "evt-marker", at: now.Add(-4 * time.Hour)},
+			{id: "evt-tail", at: now.Add(-2 * time.Hour)}, // past the marker, still before cutoff
+		}, false)
+
+		refineUC := usecase.NewSessionRefinementUsecase(fx.sessions, fx.refine, fx.events, types.SystemClock{})
+		if _, err := refineUC.Refine(ctx, usecase.SessionRefineInput{
+			SessionID: sessionID, Summary: "to whole", ProducedBy: "agent", CoversTo: "evt-whole",
+		}); err != nil {
+			t.Fatalf("Refine() error = %v", err)
+		}
+		orphanUC := usecase.NewSessionOrphanRangeUsecase(fx.orphans, fx.refine, fx.events, types.SystemClock{})
+		if err := orphanUC.RecordAtCompact(ctx, sessionID, "evt-marker"); err != nil {
+			t.Fatalf("RecordAtCompact() error = %v", err)
+		}
+
+		got, err := fx.orphans.DiscoverCandidates(ctx, staleAfter, now, cutoff, 100)
+		if err != nil {
+			t.Fatalf("DiscoverCandidates() error = %v", err)
+		}
+		var matches []*model.SessionOrphanRange
+		for _, r := range got.Ranges {
+			if r.SessionID() == sessionID {
+				matches = append(matches, r)
+			}
+		}
+		if len(matches) != 1 {
+			t.Fatalf("candidates for session = %d, want 1 (marker and third source must dedupe)", len(matches))
+		}
+		if matches[0].ToEventID() != "evt-tail" {
+			t.Fatalf("ToEventID = %s, want evt-tail: the third source's range extends past the marker's frozen point", matches[0].ToEventID())
+		}
+		from, ok := matches[0].FromEventID().Value()
+		if !ok || from != "evt-whole" {
+			t.Fatalf("FromEventID = %v present=%v, want evt-whole (actual refinement coverage boundary)", from, ok)
+		}
+	})
+}
+
+func findOrphanRangeForSession(candidates model.SessionOrphanCandidates, sessionID string) *model.SessionOrphanRange {
+	for _, r := range candidates.Ranges {
+		if r.SessionID().String() == sessionID {
+			return r
+		}
+	}
+	return nil
+}
+
+// TestSessionOrphanRangeDatasource_ActiveSessionFoldTerminatesAtDefiniteEventNotLatest
+// pins the consolidator/folder half of #1724: folding an active session's
+// pre-cutoff tail must stop at a definite last-observed event, never at
+// "now" or the session's true latest event. A subsequent event landing after
+// the fold must not be silently claimed as covered — it must surface as its
+// own fresh orphan range once it, too, ages past a (later) cutoff.
+func TestSessionOrphanRangeDatasource_ActiveSessionFoldTerminatesAtDefiniteEventNotLatest(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fx := newOrphanFixture(t)
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	sessionID := seedOrphanSession(ctx, t, fx, "sess-fold-active", []eventSeed{
+		{id: "evt-old-1", at: base.Add(-3 * time.Hour)},
+		{id: "evt-old-2", at: base.Add(-2 * time.Hour)},
+	}, false)
+
+	cutoff := base.Add(-time.Hour)
+	refineUC := usecase.NewSessionRefinementUsecase(fx.sessions, fx.refine, fx.events, types.SystemClock{})
+	consol := usecase.NewOrphanConsolidationUsecase(fx.orphans, refineUC, fixedEventClock{at: base})
+	got, err := consol.Consolidate(ctx, usecase.OrphanConsolidationInput{
+		StaleAfter:      24 * time.Hour,
+		RetentionCutoff: cutoff,
+	})
+	if err != nil {
+		t.Fatalf("Consolidate() error = %v", err)
+	}
+	if got.ProducedCount() != 1 {
+		t.Fatalf("ProducedCount = %d, want 1", got.ProducedCount())
+	}
+
+	stored, err := fx.refine.FindBySessionID(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("FindBySessionID() error = %v", err)
+	}
+	refinement, ok := stored.Value()
+	if !ok {
+		t.Fatal("expected a refinement after folding the pre-cutoff tail")
+	}
+	if refinement.CoversToEventID() != "evt-old-2" {
+		t.Fatalf("CoversTo = %s, want evt-old-2 (last event before cutoff, not now)", refinement.CoversToEventID())
+	}
+
+	// A new event lands after the fold.
+	newEvt, err := model.NewEventWithClock(
+		"evt-new-after-fold", types.EventKindNote, "cli", "codex", sessionID, "ws", "later",
+		fixedEventClock{at: base.Add(-30 * time.Minute)},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fx.events.Save(ctx, newEvt); err != nil {
+		t.Fatal(err)
+	}
+
+	// The folded range's own material must not include the new event.
+	material, err := fx.orphans.LoadMaterial(ctx, sessionID, types.None[types.EventID](), "evt-old-2")
+	if err != nil {
+		t.Fatalf("LoadMaterial() error = %v", err)
+	}
+	if material.EventCount != 3 {
+		t.Fatalf("EventCount = %d, want 3 (session-started boundary plus the two pre-cutoff events; the post-fold event must not be included)", material.EventCount)
+	}
+
+	// Time passes: the new event now also ages past a later cutoff. Discovery
+	// must treat it as a fresh orphan range starting exclusively after the
+	// earlier fold's terminus, not as material the earlier fold already covers.
+	laterNow := base.Add(2 * time.Hour)
+	laterCutoff := laterNow.Add(-time.Hour) // = base+1h, past evt-new-after-fold (base-30m)
+	got2, err := fx.orphans.DiscoverCandidates(ctx, 24*time.Hour, laterNow, laterCutoff, 100)
+	if err != nil {
+		t.Fatalf("second DiscoverCandidates() error = %v", err)
+	}
+	found := findOrphanRangeForSession(got2, "sess-fold-active")
+	if found == nil {
+		t.Fatal("expected a fresh orphan range for the post-fold event once it ages past a later cutoff")
+	}
+	if found.ToEventID() != "evt-new-after-fold" {
+		t.Fatalf("ToEventID = %s, want evt-new-after-fold", found.ToEventID())
+	}
+	from, ok := found.FromEventID().Value()
+	if !ok || from != "evt-old-2" {
+		t.Fatalf("FromEventID = %v present=%v, want evt-old-2 (exclusive: the earlier fold's terminus)", from, ok)
 	}
 }

--- a/infrastructure/sqlite/sql/list_active_sessions_for_orphan.sql
+++ b/infrastructure/sqlite/sql/list_active_sessions_for_orphan.sql
@@ -1,0 +1,71 @@
+-- Sessions that are neither ended nor stale (still active by the same 24h
+-- activity rule as source 2) but that hold material past refinement coverage
+-- older than the compact retention cutoff (#1724). An always-on session never
+-- satisfies source 2's ended-or-stale predicate, so without this source its
+-- pre-cutoff material would never surface as an orphan candidate even though
+-- CollectGarbage's DELETE does not care about session lifecycle.
+--
+-- Ordered oldest-first by the earliest orphaned-and-pre-cutoff event's
+-- created_at, matching list_ended_or_stale_sessions_for_orphan.sql's
+-- convention (#1721) via the same composite keyset cursor.
+--
+-- earliest_event_time/earliest_event_norm are bound to events strictly older
+-- than the retention cutoff: material at or after the cutoff is left alone.
+-- Folding it here would claim coverage over events that have not aged into
+-- deletion range yet, and a later activity burst must start a fresh orphan
+-- range rather than extend this one.
+--
+-- Canonical event order is (ts_norm(created_at), id): created_at is
+-- variable-width RFC3339Nano and is not lexically ordered (#1185). Every
+-- comparison and sort here uses the persisted created_at_norm column rather
+-- than ts_norm(created_at) so idx_events_session_created_at_norm_id_desc
+-- applies. sessions has no such column, so started_at still goes through
+-- ts_norm.
+--
+-- Bind: stale_cutoff (started_at), stale_cutoff (last activity),
+-- retention_cutoff (material age, twice), cursor earliest_event_norm,
+-- cursor session_id, limit.
+WITH eligible_sessions AS (
+  SELECT s.session_id AS session_id,
+         (SELECT e2.created_at_norm
+            FROM events AS e2
+           WHERE e2.id = r.covers_to_event_id
+             AND e2.session_id = s.session_id) AS covers_to_norm
+    FROM sessions AS s
+    LEFT JOIN session_refinements AS r ON r.session_id = s.session_id
+   WHERE s.ended_at IS NULL
+     AND NOT (
+           ts_norm(s.started_at) < ts_norm(?)
+           AND NOT EXISTS (
+                 SELECT 1
+                   FROM events AS e
+                  WHERE e.session_id = s.session_id
+                    AND e.created_at_norm >= ts_norm(?)
+               )
+         )
+     AND EXISTS (SELECT 1 FROM events AS e3 WHERE e3.session_id = s.session_id)
+),
+candidates AS (
+  SELECT es.session_id AS session_id,
+         (SELECT e5.created_at
+            FROM events AS e5
+           WHERE e5.session_id = es.session_id
+             AND (es.covers_to_norm IS NULL OR e5.created_at_norm > es.covers_to_norm)
+             AND e5.created_at_norm < ts_norm(?)
+           ORDER BY e5.created_at_norm ASC, e5.id ASC
+           LIMIT 1) AS earliest_event_time,
+         (SELECT e5.created_at_norm
+            FROM events AS e5
+           WHERE e5.session_id = es.session_id
+             AND (es.covers_to_norm IS NULL OR e5.created_at_norm > es.covers_to_norm)
+             AND e5.created_at_norm < ts_norm(?)
+           ORDER BY e5.created_at_norm ASC, e5.id ASC
+           LIMIT 1) AS earliest_event_norm
+    FROM eligible_sessions AS es
+)
+SELECT session_id, earliest_event_time
+  FROM candidates
+ WHERE earliest_event_time IS NOT NULL
+   AND (earliest_event_norm, session_id) > (?, ?)
+ ORDER BY earliest_event_norm ASC, session_id ASC
+ LIMIT ?

--- a/infrastructure/sqlite/sql/select_latest_event_id_for_session_before_cutoff.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_id_for_session_before_cutoff.sql
@@ -1,0 +1,15 @@
+-- Bounded variant of select_latest_event_id_for_session.sql: the last event
+-- strictly before a given cutoff, not the session's true latest event. Used
+-- by the third orphan-discovery source (#1724) so an active session's folded
+-- terminus never claims coverage over events that have not aged past the
+-- retention cutoff yet.
+--
+-- Canonical order is (ts_norm(created_at), id). created_at is variable-width
+-- RFC3339Nano and is not lexically ordered (#1185).
+-- Bind: session_id, cutoff.
+SELECT id
+  FROM events
+ WHERE session_id = ?
+   AND ts_norm(created_at) < ts_norm(?)
+ ORDER BY ts_norm(created_at) DESC, id DESC
+ LIMIT 1

--- a/main.go
+++ b/main.go
@@ -463,7 +463,8 @@ func compactWorkCover(migrations fs.FS) func(context.Context, string, time.Time)
 		err := orphanDatasource.WithReadScope(ctx, func(scopedCtx context.Context) error {
 			var consolidateErr error
 			result, consolidateErr = cover.Consolidate(scopedCtx, usecase.OrphanConsolidationInput{
-				StaleAfter: 24 * time.Hour,
+				StaleAfter:      24 * time.Hour,
+				RetentionCutoff: cutoff,
 			})
 			if consolidateErr != nil {
 				return xerrors.Errorf("consolidate orphan ranges: %w", consolidateErr)


### PR DESCRIPTION
## Summary

Orphan discovery only saw recorded compact markers and ended-or-stale sessions. A session that stays continuously active (activity at least every 24h, never `ended_at`) never became a candidate, so its pre-cutoff tail was never folded.

This adds a third discovery source, opt-in via `OrphanConsolidationInput.RetentionCutoff` (zero value keeps the previous two-source behaviour):

- Sessions with events past `covers_to` older than the compact retention cutoff, regardless of lifecycle.
- Fold terminus is the last-observed event strictly before the cutoff, not "now" or the session's latest event.
- Marker source defers to this live re-derivation when both match.
- `compactWorkCover` threads the compact cutoff through so `--force` cover closes the gap in production.

Coverage-aware DELETE is still out of scope. Transcript body discard already refuses `ended_at IS NULL` sessions; this PR is the incremental fold (so the backlog does not surface all at once when the session finally ends or goes stale).

Leaves parent #1968 open.

## Test plan

- [x] `go test ./domain/model/ ./application/ ./application/usecase/ ./infrastructure/sqlite/`
- [x] `go build .`
- [x] `go tool golangci-lint run` on touched packages
- [x] Discovery fixtures: all-newer / straddling / all-older / tail past marker
- [x] Compact `--force` pin: never-ending session folds at last pre-cutoff event (`TestCompactForceCoverFoldsNeverEndingSessionsPreCutoffTail`)

Closes #1724