### PR TITLE
fix: rank session latest events without scanning every body

### DIFF
--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -998,6 +998,34 @@ func TestDatasource_LineageAndTreeLatestEventsArePerSession(t *testing.T) {
 	assertSummaryLatest(t, tree, "latest-child", types.EventKindReviewed, "child latest")
 }
 
+func TestDatasource_LineageOfLatestEventAmongManyEventsInOneSession(t *testing.T) {
+	t.Parallel()
+
+	fixture := newListSessionsFixture(t, filepath.Join(t.TempDir(), "traceary.db"), listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	saveTestSession(ctx, t, fixture.sessionDS, "busy-session", started, types.None[time.Time](), "codex", "duck8823/traceary")
+
+	const eventCount = 500
+	for i := 0; i < eventCount; i++ {
+		saveListTestEvent(ctx, t, fixture.eventDS, fmt.Sprintf("busy-event-%03d", i), types.EventKindNote, "busy-session",
+			fmt.Sprintf("body-%03d", i), started.Add(time.Duration(i)*time.Second))
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	lineage, err := fixture.sessionDS.LineageOf(ctx, types.SessionID("busy-session"))
+	if err != nil {
+		t.Fatalf("LineageOf() error = %v", err)
+	}
+	if time.Now().After(deadline) {
+		t.Fatalf("LineageOf() took longer than the bound expected for a single-row-per-session latest event lookup")
+	}
+	assertSummaryLatest(t, lineage, "busy-session", types.EventKindNote, fmt.Sprintf("body-%03d", eventCount-1))
+}
+
 func assertSummaryLatest(t *testing.T, summaries []apptypes.SessionSummary, sessionID string, wantKind types.EventKind, wantMessage string) {
 	t.Helper()
 	for _, summary := range summaries {

--- a/infrastructure/sqlite/session_lineage_query_plan_internal_test.go
+++ b/infrastructure/sqlite/session_lineage_query_plan_internal_test.go
@@ -1,0 +1,163 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+func TestSessionLineageLatestEventUsesSessionCreatedAtNormIndexWithoutTempBTree(t *testing.T) {
+	t.Parallel()
+	path := t.TempDir() + "/lineage.db"
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	schema := `
+CREATE TABLE sessions (
+    session_id TEXT PRIMARY KEY,
+    workspace TEXT NOT NULL DEFAULT '',
+    client TEXT NOT NULL DEFAULT '',
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    label TEXT NOT NULL DEFAULT '',
+    parent_session_id TEXT REFERENCES sessions(session_id),
+    spawn_event_id TEXT,
+    subagent_kind TEXT NOT NULL DEFAULT '',
+    spawn_order INTEGER,
+    model TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    created_at_norm TEXT NOT NULL
+);
+CREATE INDEX idx_events_session_created_at_norm_id_desc
+    ON events(session_id, created_at_norm DESC, id DESC);
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    command_codec TEXT
+);
+CREATE TABLE session_refinements (
+    session_id TEXT PRIMARY KEY,
+    summary TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO sessions (session_id, started_at) VALUES ('root-session', '2026-08-16T00:00:00.000000000Z');
+`
+	if _, err := db.ExecContext(context.Background(), schema); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+sessionLineageQuery, "root-session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	var plan []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	assertLatestEventUsesCreatedAtNormIndex(t, plan)
+}
+
+func TestSessionTreeLatestEventUsesSessionCreatedAtNormIndexWithoutTempBTree(t *testing.T) {
+	t.Parallel()
+	path := t.TempDir() + "/tree.db"
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	schema := `
+CREATE TABLE sessions (
+    session_id TEXT PRIMARY KEY,
+    workspace TEXT NOT NULL DEFAULT '',
+    client TEXT NOT NULL DEFAULT '',
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    label TEXT NOT NULL DEFAULT '',
+    parent_session_id TEXT REFERENCES sessions(session_id),
+    spawn_event_id TEXT,
+    subagent_kind TEXT NOT NULL DEFAULT '',
+    spawn_order INTEGER,
+    model TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    created_at_norm TEXT NOT NULL
+);
+CREATE INDEX idx_events_session_created_at_norm_id_desc
+    ON events(session_id, created_at_norm DESC, id DESC);
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    command_codec TEXT
+);
+CREATE TABLE session_refinements (
+    session_id TEXT PRIMARY KEY,
+    summary TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO sessions (session_id, started_at) VALUES ('root-session', '2026-08-16T00:00:00.000000000Z');
+`
+	if _, err := db.ExecContext(context.Background(), schema); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+listSessionTreeQuery, "root-session", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	var plan []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	assertLatestEventUsesCreatedAtNormIndex(t, plan)
+}
+
+func assertLatestEventUsesCreatedAtNormIndex(t *testing.T, plan []string) {
+	t.Helper()
+	joined := strings.Join(plan, "\n")
+	if !strings.Contains(joined, "idx_events_session_created_at_norm_id_desc") {
+		t.Fatalf("plan does not use idx_events_session_created_at_norm_id_desc: %s", joined)
+	}
+	if strings.Contains(joined, "ts_norm(") {
+		t.Fatalf("plan still ranks latest events through ts_norm(created_at): %s", joined)
+	}
+	for _, line := range plan {
+		if strings.Contains(line, "USE TEMP B-TREE FOR ORDER BY") &&
+			(strings.Contains(strings.ToLower(line), "event") || strings.Contains(line, "created_at")) {
+			t.Fatalf("latest-event ranking sorts with a temp b-tree: %s\nfull plan:\n%s", line, joined)
+		}
+	}
+}

--- a/infrastructure/sqlite/sql/list_session_tree.sql
+++ b/infrastructure/sqlite/sql/list_session_tree.sql
@@ -25,29 +25,38 @@ WITH RECURSIVE
     JOIN selected_ids ON selected_ids.session_id = e.session_id
     GROUP BY e.session_id
   ),
-  latest_events AS (
-    SELECT session_id, id AS latest_event_id, created_at AS latest_event_at, kind AS latest_event_kind, latest_event_body
+  latest_event_ids AS (
+    SELECT session_id, id, created_at, kind
     FROM (
       SELECT
         e.session_id,
         e.id,
         e.created_at,
         e.kind,
-        COALESCE(
-          NULLIF(e.body, ''),
-          CASE WHEN COALESCE(a.command_codec, 'identity') = 'identity'
-               THEN a.command_text END,
-          ''
-        ) AS latest_event_body,
         ROW_NUMBER() OVER (
           PARTITION BY e.session_id
-          ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+          ORDER BY e.created_at_norm DESC, e.id DESC
         ) AS rn
       FROM events e
       JOIN selected_ids ON selected_ids.session_id = e.session_id
-      LEFT JOIN command_audits a ON a.event_id = e.id
     )
     WHERE rn = 1
+  ),
+  latest_events AS (
+    SELECT
+      lei.session_id,
+      lei.id AS latest_event_id,
+      lei.created_at AS latest_event_at,
+      lei.kind AS latest_event_kind,
+      COALESCE(
+        NULLIF(e.body, ''),
+        CASE WHEN COALESCE(a.command_codec, 'identity') = 'identity'
+             THEN a.command_text END,
+        ''
+      ) AS latest_event_body
+    FROM latest_event_ids lei
+    JOIN events e ON e.id = lei.id
+    LEFT JOIN command_audits a ON a.event_id = e.id
   )
 SELECT
   s.session_id,

--- a/infrastructure/sqlite/sql/session_lineage.sql
+++ b/infrastructure/sqlite/sql/session_lineage.sql
@@ -36,29 +36,38 @@ WITH RECURSIVE
     JOIN lineage ON lineage.session_id = e.session_id
     GROUP BY e.session_id
   ),
-  latest_events AS (
-    SELECT session_id, id AS latest_event_id, created_at AS latest_event_at, kind AS latest_event_kind, latest_event_body
+  latest_event_ids AS (
+    SELECT session_id, id, created_at, kind
     FROM (
       SELECT
         e.session_id,
         e.id,
         e.created_at,
         e.kind,
-        COALESCE(
-          NULLIF(e.body, ''),
-          CASE WHEN COALESCE(a.command_codec, 'identity') = 'identity'
-               THEN a.command_text END,
-          ''
-        ) AS latest_event_body,
         ROW_NUMBER() OVER (
           PARTITION BY e.session_id
-          ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+          ORDER BY e.created_at_norm DESC, e.id DESC
         ) AS rn
       FROM events e
       JOIN lineage ON lineage.session_id = e.session_id
-      LEFT JOIN command_audits a ON a.event_id = e.id
     )
     WHERE rn = 1
+  ),
+  latest_events AS (
+    SELECT
+      lei.session_id,
+      lei.id AS latest_event_id,
+      lei.created_at AS latest_event_at,
+      lei.kind AS latest_event_kind,
+      COALESCE(
+        NULLIF(e.body, ''),
+        CASE WHEN COALESCE(a.command_codec, 'identity') = 'identity'
+             THEN a.command_text END,
+        ''
+      ) AS latest_event_body
+    FROM latest_event_ids lei
+    JOIN events e ON e.id = lei.id
+    LEFT JOIN command_audits a ON a.event_id = e.id
   )
 SELECT
   s.session_id,


### PR DESCRIPTION
## Summary
- Rank lineage/tree latest events by `created_at_norm` and join only that row's body.
- Query-plan tests require the session/created_at_norm index and forbid `ts_norm(created_at)` ranking.

Closes #2011
Leaves parent #2025 open.

## Test plan
- [x] `go test ./infrastructure/sqlite/ -run 'TestDatasource_Lineage|TestDatasource_List|TestDatasource_Tree|TestSessionLineageLatestEvent|TestSessionTreeLatestEvent'`