### PR TITLE
docs: pin install clones to the running CLI version

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -80,7 +80,7 @@ codex   # Codex 内で /plugins を開き、Traceary Plugins から Traceary を
 **Kimi Code** ([ガイド](./docs/integrations/kimi.ja.md))
 
 ```sh
-git clone --depth 1 --branch v0.29.0 https://github.com/duck8823/traceary ~/src/traceary
+git clone --depth 1 --branch "v$(traceary -v | awk '{print $2}')" https://github.com/duck8823/traceary ~/src/traceary
 cd ~/src/traceary
 ./scripts/install-kimi-plugin.sh
 ```

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The `traceary integration codex install` helper was retired in v0.14.0 and the c
 **Kimi Code** ([guide](./docs/integrations/kimi.md))
 
 ```sh
-git clone --depth 1 --branch v0.29.0 https://github.com/duck8823/traceary ~/src/traceary
+git clone --depth 1 --branch "v$(traceary -v | awk '{print $2}')" https://github.com/duck8823/traceary ~/src/traceary
 cd ~/src/traceary
 ./scripts/install-kimi-plugin.sh
 ```

--- a/docs/integrations/grok-plugin.ja.md
+++ b/docs/integrations/grok-plugin.ja.md
@@ -100,7 +100,7 @@ traceary doctor --client grok --project-dir . --json
 matching release tag から常に利用できます。installer は検証・置換・inventory 表示を行います。
 
 ```sh
-git clone --branch v0.27.0 --depth 1 https://github.com/duck8823/traceary.git
+git clone --depth 1 --branch "v$(traceary -v | awk '{print $2}')" https://github.com/duck8823/traceary.git
 cd traceary
 ./scripts/install-grok-plugin.sh
 ```

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -104,7 +104,7 @@ installed inventory. It intentionally leaves a legacy package named `traceary`
 untouched because that name can belong to another host integration.
 
 ```sh
-git clone --branch v0.27.0 --depth 1 https://github.com/duck8823/traceary.git
+git clone --depth 1 --branch "v$(traceary -v | awk '{print $2}')" https://github.com/duck8823/traceary.git
 cd traceary
 ./scripts/install-grok-plugin.sh
 ```

--- a/docs/integrations/kimi.ja.md
+++ b/docs/integrations/kimi.ja.md
@@ -83,7 +83,7 @@ brew install traceary
 2. 対応する Traceary の release tag の checkout から、plugin をインストールします（packaged hook の互換性を保つため、Traceary CLI と一致する tag を指定してください）。
 
 ```sh
-git clone --depth 1 --branch v0.29.0 https://github.com/duck8823/traceary
+git clone --depth 1 --branch "v$(traceary -v | awk '{print $2}')" https://github.com/duck8823/traceary
 cd traceary
 ./scripts/install-kimi-plugin.sh
 ```

--- a/docs/integrations/kimi.md
+++ b/docs/integrations/kimi.md
@@ -92,7 +92,7 @@ brew install traceary
    tag that matches your Traceary CLI so the packaged hooks stay compatible):
 
 ```sh
-git clone --depth 1 --branch v0.29.0 https://github.com/duck8823/traceary
+git clone --depth 1 --branch "v$(traceary -v | awk '{print $2}')" https://github.com/duck8823/traceary
 cd traceary
 ./scripts/install-kimi-plugin.sh
 ```


### PR DESCRIPTION
## Summary
- Replace hardcoded v0.27.0 / v0.29.0 clone examples with `v$(traceary -v)`.
- Covers grok/kimi install guides (EN+JA) and README install snippets.

Closes #2023
Leaves parent #2025 open.

## Test plan
- [x] ripgrep confirms no remaining `git clone --branch v0.` pins in docs/README