### PR TITLE
fix: drop failed-to-execute wrapper on diagnostic CLI exits

### DIFF
--- a/main.go
+++ b/main.go
@@ -278,7 +278,7 @@ func run() error {
 	rootCmd.SetContext(commandCtx)
 
 	if err := rootCmd.Execute(); err != nil {
-		return xerrors.Errorf("failed to execute CLI command: %w", err)
+		return wrapCLIExecuteError(err)
 	}
 
 	return nil
@@ -426,6 +426,20 @@ func main() {
 
 func isSilentCLIExitError(err error) bool {
 	return cli.IsBrokenPipeError(err)
+}
+
+// wrapCLIExecuteError keeps Cobra's generic wrapper off diagnostic
+// exit-code errors (doctor warn/fail, hook consolidation). Those already
+// carry the operator-facing message and an ExitCode.
+func wrapCLIExecuteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var exitCoder cliExitCoder
+	if errors.As(err, &exitCoder) {
+		return err
+	}
+	return xerrors.Errorf("failed to execute CLI command: %w", err)
 }
 
 func writeCLIError(output io.Writer, err error) error {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"runtime/debug"
 	"syscall"
@@ -205,7 +206,7 @@ func TestWrapCLIExecuteError_SkipsDiagnosticExitCodes(t *testing.T) {
 			t.Fatalf("wrapCLIExecuteError() = %q, want the diagnostic message without the execute wrapper", err.Error())
 		}
 		var exitCoder cliExitCoder
-		if !xerrors.As(err, &exitCoder) || exitCoder.ExitCode() != 2 {
+		if !errors.As(err, &exitCoder) || exitCoder.ExitCode() != 2 {
 			t.Fatalf("wrapped diagnostic lost ExitCode(); err=%v", err)
 		}
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -184,6 +184,44 @@ type testError string
 
 func (e testError) Error() string { return string(e) }
 
+type diagnosticExitError struct {
+	message  string
+	exitCode int
+}
+
+func (e diagnosticExitError) Error() string { return e.message }
+func (e diagnosticExitError) ExitCode() int { return e.exitCode }
+
+func TestWrapCLIExecuteError_SkipsDiagnosticExitCodes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keeps doctor-style diagnostic message unwrapped", func(t *testing.T) {
+		t.Parallel()
+		err := wrapCLIExecuteError(diagnosticExitError{message: "doctor found warning checks", exitCode: 2})
+		if err == nil {
+			t.Fatal("wrapCLIExecuteError() = nil")
+		}
+		if err.Error() != "doctor found warning checks" {
+			t.Fatalf("wrapCLIExecuteError() = %q, want the diagnostic message without the execute wrapper", err.Error())
+		}
+		var exitCoder cliExitCoder
+		if !xerrors.As(err, &exitCoder) || exitCoder.ExitCode() != 2 {
+			t.Fatalf("wrapped diagnostic lost ExitCode(); err=%v", err)
+		}
+	})
+
+	t.Run("wraps ordinary command failures", func(t *testing.T) {
+		t.Parallel()
+		err := wrapCLIExecuteError(testError("database query failed"))
+		if err == nil {
+			t.Fatal("wrapCLIExecuteError() = nil")
+		}
+		if err.Error() != "failed to execute CLI command: database query failed" {
+			t.Fatalf("wrapCLIExecuteError() = %q", err.Error())
+		}
+	})
+}
+
 func TestIsSilentCLIExitError(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/store_reduction_commands_test.go
+++ b/presentation/cli/store_reduction_commands_test.go
@@ -77,3 +77,16 @@ func TestSearchProjectionIndexFamilyBytesHelpNamesRebuildPeak(t *testing.T) {
 		t.Fatalf("usage=%q, want it to say the budget is not a rebuild-peak cap", flag.Usage)
 	}
 }
+
+func TestStoreSearchProjectionShortIsLocalized(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "ja")
+	resetConfiguredCLILanguageCacheForTest()
+	root := NewRootCLI().Command()
+	projection := findCommandOrNil(findCommandOrNil(root, "store"), "search-projection")
+	if projection == nil {
+		t.Fatal("store search-projection is not registered")
+	}
+	if !strings.Contains(projection.Short, "派生") {
+		t.Fatalf("search-projection short = %q, want Japanese pairing", projection.Short)
+	}
+}

--- a/presentation/cli/store_search_projection.go
+++ b/presentation/cli/store_search_projection.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:wrapcheck // Cobra boundary intentionally preserves typed usecase errors.
 func (c *RootCLI) newStoreSearchProjectionCommand() *cobra.Command {
-	group := &cobra.Command{Use: "search-projection", Short: "Manage the derived search projection's fingerprint prefilter and session tier"}
+	group := &cobra.Command{Use: "search-projection", Short: Localize("Manage the derived search projection's fingerprint prefilter and session tier", "派生 search projection の fingerprint prefilter と session tier を管理する")}
 	group.AddCommand(c.newStoreSearchProjectionRunCommand("start", true), c.newStoreSearchProjectionRunCommand("resume", false))
 	group.AddCommand(&cobra.Command{Use: "abort", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error {
 		if c.searchProjection == nil {


### PR DESCRIPTION
## Summary
- Skip the `failed to execute CLI command` wrapper for errors that already carry ExitCode (doctor warn/fail).
- Localize `store search-projection` short help.

Closes #2024
Leaves parent #2025 open.

## Test plan
- [x] `go test . ./presentation/cli/ -run 'TestWrapCLIExecuteError|TestStoreSearchProjectionShortIsLocalized'`