### PR TITLE
fix: end still-open child sessions when the parent ends

### DIFF
--- a/application/usecase/record_session_boundary_test.go
+++ b/application/usecase/record_session_boundary_test.go
@@ -564,6 +564,10 @@ func (s *sessionRepositoryStub) NextChildSpawnOrder(_ context.Context, _ types.S
 	return s.nextChildOrder, nil
 }
 
+func (s *sessionRepositoryStub) FindOpenChildSessionIDs(_ context.Context, _ types.SessionID) ([]types.SessionID, error) {
+	return nil, nil
+}
+
 func (s *sessionRepositoryStub) UpdateModelIfEmpty(_ context.Context, _ types.SessionID, modelName string) (bool, error) {
 	if strings.TrimSpace(modelName) == "" {
 		return false, nil

--- a/application/usecase/session_parent_end_children_test.go
+++ b/application/usecase/session_parent_end_children_test.go
@@ -1,0 +1,102 @@
+package usecase_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	domaintypes "github.com/duck8823/traceary/domain/types"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func newParentEndChildrenTestDatabase(t *testing.T) *sqliteinfra.Database {
+	t.Helper()
+
+	ctx := context.Background()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() failed")
+	}
+	migrations := os.DirFS(filepath.Join(filepath.Dir(sourceFile), "..", "..", "schema", "sqlite", "migrations"))
+	database := sqliteinfra.NewDatabase(filepath.Join(t.TempDir(), "traceary.db"), migrations)
+	if err := sqliteinfra.NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	return database
+}
+
+// TestSessionUsecase_End_ClosesOpenChildSessions drives the real
+// SessionUsecase.End against a fixture DB (parent + still-open child), and
+// asserts the child no longer leaks as an open session that
+// `session latest --active` would keep returning after its parent ended
+// (#2012).
+func TestSessionUsecase_End_ClosesOpenChildSessions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	database := newParentEndChildrenTestDatabase(t)
+	sessions := sqliteinfra.NewSessionDatasource(database)
+	sut := usecase.NewSessionUsecase(nil, sessions, sessions, nil)
+
+	parentEvent, err := sut.Start(ctx, "cli", "claude", "parent-session", "workspace", "")
+	if err != nil {
+		t.Fatalf("Start(parent) error = %v", err)
+	}
+
+	childEvent, err := sut.StartChild(
+		ctx,
+		"parent-session",
+		"child-session",
+		"claude",
+		"workspace",
+		parentEvent.EventID(),
+		"general-purpose",
+		parentEvent.CreatedAt(),
+	)
+	if err != nil {
+		t.Fatalf("StartChild() error = %v", err)
+	}
+	if childEvent == nil {
+		t.Fatal("StartChild() returned nil event")
+	}
+
+	if _, err := sut.End(ctx, "cli", "claude", "parent-session", "workspace", ""); err != nil {
+		t.Fatalf("End(parent) error = %v", err)
+	}
+
+	child, err := sessions.FindByID(ctx, domaintypes.SessionID("child-session"))
+	if err != nil {
+		t.Fatalf("FindByID(child) error = %v", err)
+	}
+	childSession, ok := child.Value()
+	if !ok {
+		t.Fatal("FindByID(child) returned no session")
+	}
+	if _, ended := childSession.EndedAt().Value(); !ended {
+		t.Fatal("child session EndedAt() is not set; want the child to be closed when the parent ends")
+	}
+
+	// `find_active_session.sql` ranks active candidates by start time, so a
+	// leaked open child (started before the parent ended) keeps winning
+	// `session latest --active` for this (client, agent, workspace) bucket
+	// for as long as it stays open, even though the parent it belonged to
+	// has already finished. Once the child is closed too, nothing in this
+	// bucket should report as active.
+	criteria := types.NewSessionLookupCriteriaBuilder().
+		Client("cli").
+		Agent("claude").
+		Workspace("workspace").
+		ActiveOnly(true).
+		Build()
+	active, err := sut.Active(ctx, criteria)
+	if err != nil {
+		t.Fatalf("Active() error = %v", err)
+	}
+	if activeEvent, ok := active.Value(); ok {
+		t.Fatalf("Active() session ID = %q, want no active session (leaked child must not shadow the ended parent)", activeEvent.SessionID())
+	}
+}

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -346,11 +347,82 @@ func (u *sessionUsecase) End(ctx context.Context, client types.Client, agent typ
 	if err := u.sessionRepo.SaveBoundary(ctx, existingSession, event); err != nil {
 		return nil, xerrors.Errorf("failed to save session end: %w", err)
 	}
+	// Best-effort: a parent session ending should not leave its open
+	// descendant sub-sessions dangling with ended_at IS NULL, since
+	// `session latest --active` would keep preferring a leaked child for
+	// up to the gc stale window. `session gc` remains the backstop for
+	// anything this misses.
+	u.endOpenDescendants(ctx, resolvedSessionID, event.CreatedAt())
 	if err := u.writeEndRefinement(ctx, resolvedSessionID, event.EventID(), summary, "cli:session-end"); err != nil {
 		return nil, err
 	}
 
 	return event, nil
+}
+
+// endOpenDescendants closes still-open sub-sessions transitively parented by
+// sessionID, now that sessionID itself has ended. Failures are logged rather
+// than surfaced: the parent boundary already committed, and `session gc`
+// closes anything left behind.
+func (u *sessionUsecase) endOpenDescendants(ctx context.Context, sessionID types.SessionID, endedAt time.Time) {
+	queue := []types.SessionID{sessionID}
+	visited := map[types.SessionID]struct{}{sessionID: {}}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		childIDs, err := u.sessionRepo.FindOpenChildSessionIDs(ctx, current)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to find open child sessions for parent-ended close", "session_id", current.String(), "error", err)
+			continue
+		}
+		for _, childID := range childIDs {
+			if _, seen := visited[childID]; seen {
+				continue
+			}
+			visited[childID] = struct{}{}
+			if err := u.endChildSessionForParentEnd(ctx, childID, endedAt); err != nil {
+				slog.WarnContext(ctx, "failed to end child session for parent-ended close", "session_id", childID.String(), "error", err)
+				continue
+			}
+			queue = append(queue, childID)
+		}
+	}
+}
+
+func (u *sessionUsecase) endChildSessionForParentEnd(ctx context.Context, childID types.SessionID, endedAt time.Time) error {
+	existing, err := u.sessionRepo.FindByID(ctx, childID)
+	if err != nil {
+		return xerrors.Errorf("failed to find child session: %w", err)
+	}
+	childSession, ok := existing.Value()
+	if !ok {
+		return nil
+	}
+	if _, ended := childSession.EndedAt().Value(); ended {
+		return nil
+	}
+
+	event, err := u.buildBoundaryEventAt(
+		ctx,
+		types.EventKindSessionEnded,
+		childSession.Client(),
+		childSession.Agent(),
+		childID,
+		childSession.Workspace(),
+		endedAt,
+		childSessionEndDeliveryFields(childSession.ParentSessionID())...,
+	)
+	if err != nil {
+		return xerrors.Errorf("failed to build child session end event: %w", err)
+	}
+	if err := childSession.End(endedAt, ""); err != nil {
+		return xerrors.Errorf("failed to end child session: %w", err)
+	}
+	if err := u.sessionRepo.SaveBoundary(ctx, childSession, event); err != nil {
+		return xerrors.Errorf("failed to save child session end: %w", err)
+	}
+	return nil
 }
 
 func (u *sessionUsecase) writeEndRefinement(
@@ -623,6 +695,14 @@ func childSessionStartDeliveryFields(parentSessionID types.SessionID, spawnEvent
 
 func sessionEndDeliveryFields(summary string) []string {
 	return []string{"session_end", "summary", summary}
+}
+
+func childSessionEndDeliveryFields(parentSessionID types.SessionID) []string {
+	return []string{
+		"child_session_end",
+		"parent_session_id", parentSessionID.String(),
+		"terminal_reason", "parent_ended",
+	}
 }
 
 // inheritAttribution fills empty caller-provided fields from the stored

--- a/domain/model/session_repository.go
+++ b/domain/model/session_repository.go
@@ -26,4 +26,7 @@ type SessionRepository interface {
 	// value is empty. Host-reported values are never overwritten. Returns true
 	// when a row was updated.
 	UpdateModelIfEmpty(ctx context.Context, sessionID types.SessionID, model string) (bool, error)
+	// FindOpenChildSessionIDs returns the IDs of direct children of
+	// parentSessionID that have not yet ended.
+	FindOpenChildSessionIDs(ctx context.Context, parentSessionID types.SessionID) ([]types.SessionID, error)
 }

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -466,6 +466,47 @@ func (d *SessionDatasource) NextChildSpawnOrder(ctx context.Context, parentSessi
 	return order, nil
 }
 
+// FindOpenChildSessionIDs returns the IDs of direct children of
+// parentSessionID that have not yet ended.
+func (d *SessionDatasource) FindOpenChildSessionIDs(ctx context.Context, parentSessionID types.SessionID) ([]types.SessionID, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for open child session lookup: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT session_id FROM sessions WHERE parent_session_id = ? AND ended_at IS NULL`,
+		parentSessionID.String(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query open child sessions: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	var childIDs []types.SessionID
+	for rows.Next() {
+		var sessionID string
+		if err := rows.Scan(&sessionID); err != nil {
+			return nil, xerrors.Errorf("failed to scan open child session ID: %w", err)
+		}
+		childIDs = append(childIDs, types.SessionID(sessionID))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate open child session IDs: %w", err)
+	}
+	return childIDs, nil
+}
+
 // UpdateModelIfEmpty writes model into sessions.model when empty.
 func (d *SessionDatasource) UpdateModelIfEmpty(ctx context.Context, sessionID types.SessionID, modelName string) (bool, error) {
 	if strings.TrimSpace(sessionID.String()) == "" {


### PR DESCRIPTION
## Summary
- After a parent SessionEnd commits, still-open descendant sub-sessions are ended.
- `session latest --active` no longer prefers a leaked child for the stale-gc window.

Closes #2012
Leaves parent #2025 open.

## Test plan
- [x] `go test ./application/usecase/ ./infrastructure/sqlite/ -run 'TestSessionUsecase_End|TestSessionUsecase_End_ClosesOpenChildSessions|TestDatasource_FindLatest_activeOnly'`