### PR TITLE
fix: page search-projection cleanup and park stalled catch-up

### DIFF
--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -71,6 +71,12 @@ const (
 	SearchProjectionOriginAutomatic = "automatic"
 	SearchProjectionOriginOperator  = "operator"
 	SearchProjectionStartCommand    = "traceary store search-projection start"
+	// SearchProjectionFailureCleanupNoProgress is recorded when automatic
+	// catch-up spends N consecutive cleanup attempts without committing a row.
+	SearchProjectionFailureCleanupNoProgress = "cleanup_no_progress"
+	// SearchProjectionCleanupNoProgressLimit is how many consecutive
+	// zero-progress cleanup catch-up attempts park the generation.
+	SearchProjectionCleanupNoProgressLimit = 3
 )
 
 type SearchProjectionBudget struct {

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -68,6 +68,12 @@ type SearchProjectionVerifyStore interface {
 	VerifySearchProjectionSessionTier(context.Context, string) error
 }
 
+// SearchProjectionCleanupNoProgressStore records consecutive cleanup-phase
+// catch-up attempts that committed no row and parks the generation after N.
+type SearchProjectionCleanupNoProgressStore interface {
+	RecordCleanupNoProgressAttempt(context.Context, string, time.Time) (int, bool, error)
+}
+
 // NewSearchProjectionUsecase constructs the projection workflow.
 func NewSearchProjectionUsecase(store SearchProjectionStore) *SearchProjectionUsecase {
 	return &SearchProjectionUsecase{store: store}
@@ -382,6 +388,7 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	}
 	out.State = status.State
 	out.Phase = status.Phase
+	out.GenerationID = status.GenerationID
 	out.Checkpoint = status.Checkpoint
 	out.CutoverIndexFamily = status.CutoverIndexFamily
 	out.CutoverFamilyBytesBefore = status.CutoverFamilyBytesBefore
@@ -468,10 +475,12 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	}
 	// A failed generation is parked, not retried. Every failure class this store
 	// can record is deterministic — an oversize row exceeds the same budget on
-	// every open, session_tier_unverified fails the same query, and abandoned is
-	// an operator decision. Auto-starting a replacement would fail identically
-	// and add a lifecycle row per open, forever. If a genuinely transient class
-	// is ever introduced, this is where it gets its exception.
+	// every open, session_tier_unverified fails the same query, abandoned is
+	// an operator decision, and cleanup_no_progress already spent N catch-up
+	// attempts without a durable cleanup row. Auto-starting a replacement
+	// would fail identically and add a lifecycle row per open, forever. If a
+	// genuinely transient class is ever introduced, this is where it gets its
+	// exception.
 	if status.State == "failed" {
 		out.Action = "skipped"
 		// Naming the recovery command matters: neither resume nor abort clears
@@ -513,9 +522,70 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	// failure. Oversized rows retain the existing explicit failure transition.
 	progress, resumeErr := u.resumeCatchUpBatch(ctx, b, now.UTC())
 	if resumeErr != nil {
-		return u.refreshCatchUpPosition(ctx, out), resumeErr
+		out = u.refreshCatchUpPosition(ctx, out)
+		parked, parkErr := u.maybeParkCleanupNoProgress(ctx, out, progress, resumeErr, now.UTC())
+		if parkErr != nil {
+			return out, parkErr
+		}
+		if parked {
+			out.Action = "skipped"
+			out.SkippedReason = "parked after generation failure " + apptypes.SearchProjectionFailureCleanupNoProgress +
+				"; run 'traceary store search-projection start' to replace the generation"
+			return u.refreshCatchUpPosition(ctx, out), nil
+		}
+		return out, resumeErr
 	}
 	return u.finishCatchUpProgress(ctx, out, progress)
+}
+
+func (u *SearchProjectionUsecase) maybeParkCleanupNoProgress(ctx context.Context, out apptypes.SearchProjectionCatchUpResult, progress apptypes.SearchProjectionProgress, resumeErr error, now time.Time) (bool, error) {
+	if out.Phase != "cleanup" || !isCleanupCatchUpNoProgress(progress, resumeErr) {
+		return false, nil
+	}
+	store, ok := u.store.(SearchProjectionCleanupNoProgressStore)
+	if !ok {
+		return false, nil
+	}
+	generation := out.GenerationID
+	if generation == "" {
+		generation = progress.GenerationID
+	}
+	if generation == "" {
+		return false, nil
+	}
+	recordCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	_, parked, err := store.RecordCleanupNoProgressAttempt(recordCtx, generation, now)
+	if err != nil {
+		return false, xerrors.Errorf("record cleanup no-progress attempt: %w", err)
+	}
+	return parked, nil
+}
+
+func isCleanupCatchUpNoProgress(progress apptypes.SearchProjectionProgress, err error) bool {
+	if err == nil || progress.Written > 0 || progress.Cleaned > 0 {
+		return false
+	}
+	var drift *apptypes.SearchProjectionDriftError
+	if errors.As(err, &drift) {
+		return false
+	}
+	var oversized *apptypes.SearchProjectionOversizeError
+	if errors.As(err, &oversized) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var noProgress *apptypes.SearchProjectionNoProgressError
+	if !errors.As(err, &noProgress) {
+		return false
+	}
+	switch noProgress.Code {
+	case apptypes.SearchProjectionNoProgressLockDurationCap, apptypes.SearchProjectionNoProgressSingleRowLockDurationCap, apptypes.SearchProjectionNoProgressRowWorkCap:
+		return true
+	}
+	return strings.Contains(noProgress.Reason, "wall") || strings.Contains(noProgress.Reason, "exhausted")
 }
 
 // refreshCatchUpPosition re-reads where the projection actually stands before a
@@ -532,6 +602,7 @@ func (u *SearchProjectionUsecase) refreshCatchUpPosition(ctx context.Context, ou
 	}
 	out.State = status.State
 	out.Phase = status.Phase
+	out.GenerationID = status.GenerationID
 	out.Checkpoint = status.Checkpoint
 	return out
 }

--- a/infrastructure/sqlite/migrate_offline_test.go
+++ b/infrastructure/sqlite/migrate_offline_test.go
@@ -51,8 +51,8 @@ func TestStoreInitAppliesOfflineMigrations(t *testing.T) {
 	if err := current.InitializeAuthorized(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 67 {
-		t.Fatalf("schema version=%d, want 67", got)
+	if got := maxSchemaVersion(t, path); got != 68 {
+		t.Fatalf("schema version=%d, want 68", got)
 	}
 }
 
@@ -64,8 +64,8 @@ func TestEmptyStoreReachesCurrentSchemaImplicitly(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 67 {
-		t.Fatalf("schema version=%d, want 67", got)
+	if got := maxSchemaVersion(t, path); got != 68 {
+		t.Fatalf("schema version=%d, want 68", got)
 	}
 }
 

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -105,6 +105,9 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	// (#1744). Same shape as 36 on events: no backfill, no row rewrite; SQLite
 	// ADD COLUMN is O(1) regardless of table size.
 	67: {67, "000067_add_payload_codec_to_event_content_dedupe_archive.sql", "f9f912f21290e64af38dffc86398f86d08503f8345926a99cf459901fff743c2", MigrationConstantInPlace},
+	// 68 adds cleanup_no_progress_attempts to the singleton
+	// search_projection_state row. No store-sized scan.
+	68: {68, "000068_add_search_projection_cleanup_no_progress_attempts.sql", "21d36ae2a63af21c8bfd4688c362aeb555ddcbdb0555e5703ccdf01aa877a526", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 67 || len(plan.Pending) != 32 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 68 || len(plan.Pending) != 33 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -64,6 +64,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		65: MigrationConstantInPlace,
 		66: MigrationConstantInPlace,
 		67: MigrationConstantInPlace,
+		68: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 67 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 68 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/search_projection_catchup.go
+++ b/infrastructure/sqlite/search_projection_catchup.go
@@ -94,16 +94,16 @@ func searchProjectionSchemaComplete(ctx context.Context, db *sql.DB) (bool, stri
 	}
 	// Additive columns land on an existing table, so presence of
 	// search_projection_state alone does not imply a complete schema.
-	// Check the newest required column: a store at 049-054 has
-	// cutover_index_family but not index_family_byte_limit (#1679).
+	// Check the newest required column: a store at 049-067 has
+	// recent_source_bytes but not cleanup_no_progress_attempts (#2010).
 	var columns int
 	if err := db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM pragma_table_info('search_projection_state') WHERE name IN ('index_family_byte_limit','recent_source_bytes')`,
+		`SELECT COUNT(*) FROM pragma_table_info('search_projection_state') WHERE name IN ('index_family_byte_limit','recent_source_bytes','cleanup_no_progress_attempts')`,
 	).Scan(&columns); err != nil {
 		return false, "", xerrors.Errorf("inspect search_projection_state columns: %w", err)
 	}
-	if columns != 2 {
-		return false, "search_projection_state.recent_source_bytes", nil
+	if columns != 3 {
+		return false, "search_projection_state.cleanup_no_progress_attempts", nil
 	}
 	return true, "", nil
 }
@@ -185,7 +185,12 @@ func logSearchProjectionCatchUp(result apptypes.SearchProjectionCatchUpResult, e
 			)
 			return
 		}
-		slog.Error("search projection catch-up incomplete; retrying on next initialization",
+		// Ordinary repeat-incomplete attempts (e.g. wall-time/row-work caps
+		// tripped mid-page) are expected while a large store catches up over
+		// many initializations. Logging these at Error level fires on every
+		// command/hook invocation with no actionable signal, so this stays at
+		// Debug; the two cases above that name a stuck condition remain Error.
+		slog.Debug("search projection catch-up incomplete; retrying on next initialization",
 			"action", result.Action,
 			"state", result.State,
 			"phase", result.Phase,

--- a/infrastructure/sqlite/search_projection_catchup_log_internal_test.go
+++ b/infrastructure/sqlite/search_projection_catchup_log_internal_test.go
@@ -165,6 +165,9 @@ func TestLogSearchProjectionCatchUp_OtherErrorsKeepTheGenericLine(t *testing.T) 
 	if handler.records[0].Message != genericCatchUpIncompleteLine {
 		t.Fatalf("message = %q, want the generic incomplete line", handler.records[0].Message)
 	}
+	if handler.records[0].Level != slog.LevelDebug {
+		t.Fatalf("level = %s, want DEBUG", handler.records[0].Level)
+	}
 }
 
 func forceSQLiteFull(t *testing.T) error {

--- a/infrastructure/sqlite/search_projection_cleanup.go
+++ b/infrastructure/sqlite/search_projection_cleanup.go
@@ -39,7 +39,7 @@ func selectProjectionCleanupPaged(ctx context.Context, db *sql.DB, out apptypes.
 				}
 				return out, nil
 			}
-			return out, err
+			return out, xerrors.Errorf("cleanup leftover discovery cancelled: %w", err)
 		}
 		remaining := want - len(out.Cleanup)
 		if remaining <= 0 {
@@ -56,7 +56,7 @@ func selectProjectionCleanupPaged(ctx context.Context, db *sql.DB, out apptypes.
 				}
 				return out, nil
 			}
-			return out, err
+			return out, xerrors.Errorf("query cleanup leftover page: %w", err)
 		}
 		fetched, scanErr := appendProjectionCleanupRows(rows, &out)
 		_ = rows.Close()
@@ -68,7 +68,7 @@ func selectProjectionCleanupPaged(ctx context.Context, db *sql.DB, out apptypes.
 				}
 				return out, nil
 			}
-			return out, scanErr
+			return out, xerrors.Errorf("read cleanup leftover page: %w", scanErr)
 		}
 		if fetched == remaining {
 			scannedAll = false
@@ -144,12 +144,15 @@ func appendProjectionCleanupRows(rows *sql.Rows, out *apptypes.ProjectionSnapsho
 	for rows.Next() {
 		var c apptypes.ProjectionCleanupCandidate
 		if err := rows.Scan(&c.Class, &c.RowID, &c.LogicalBytes, &c.Address1, &c.Address2, &c.Address3, &c.AddressBlob); err != nil {
-			return fetched, err
+			return fetched, xerrors.Errorf("scan cleanup leftover row: %w", err)
 		}
 		out.Cleanup = append(out.Cleanup, c)
 		fetched++
 	}
-	return fetched, rows.Err()
+	if err := rows.Err(); err != nil {
+		return fetched, xerrors.Errorf("iterate cleanup leftover rows: %w", err)
+	}
+	return fetched, nil
 }
 
 // RecordCleanupNoProgressAttempt increments the durable cleanup stall

--- a/infrastructure/sqlite/search_projection_cleanup.go
+++ b/infrastructure/sqlite/search_projection_cleanup.go
@@ -1,0 +1,209 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// cleanupDiscoveryMinRowTime is a conservative per-row hold budget used to
+// shrink a cleanup page so discovery plus delete can finish inside the
+// remaining wall. It is not a measured SLA; it only keeps a 50ms test open
+// from selecting more leftovers than the write transaction can commit.
+const cleanupDiscoveryMinRowTime = 2 * time.Millisecond
+
+type projectionCleanupBranch struct {
+	query string
+	args  []any
+}
+
+// selectProjectionCleanupPaged addresses each leftover table by its primary
+// key and applies LIMIT inside that table. A UNION ALL of every leftover row
+// before LIMIT can spend the whole wall budget discovering and then commit
+// nothing (#2010). After a page deletes, the next open's LIMIT naturally
+// returns the next leftovers.
+func selectProjectionCleanupPaged(ctx context.Context, db *sql.DB, out apptypes.ProjectionSnapshot, b apptypes.SearchProjectionBudget) (apptypes.ProjectionSnapshot, error) {
+	page := cleanupDiscoveryPageSize(ctx, b)
+	want := page + 1
+	scannedAll := true
+	for _, branch := range projectionCleanupDiscoveryBranches(out, want) {
+		if err := ctx.Err(); err != nil {
+			if len(out.Cleanup) > 0 {
+				out.CleanupDone = false
+				if len(out.Cleanup) > page {
+					out.Cleanup = out.Cleanup[:page]
+				}
+				return out, nil
+			}
+			return out, err
+		}
+		remaining := want - len(out.Cleanup)
+		if remaining <= 0 {
+			scannedAll = false
+			break
+		}
+		branch.args[len(branch.args)-1] = remaining
+		rows, err := db.QueryContext(ctx, branch.query, branch.args...)
+		if err != nil {
+			if ctx.Err() != nil && len(out.Cleanup) > 0 {
+				out.CleanupDone = false
+				if len(out.Cleanup) > page {
+					out.Cleanup = out.Cleanup[:page]
+				}
+				return out, nil
+			}
+			return out, err
+		}
+		fetched, scanErr := appendProjectionCleanupRows(rows, &out)
+		_ = rows.Close()
+		if scanErr != nil {
+			if ctx.Err() != nil && len(out.Cleanup) > 0 {
+				out.CleanupDone = false
+				if len(out.Cleanup) > page {
+					out.Cleanup = out.Cleanup[:page]
+				}
+				return out, nil
+			}
+			return out, scanErr
+		}
+		if fetched == remaining {
+			scannedAll = false
+		}
+	}
+	if scannedAll && len(out.Cleanup) <= page {
+		out.CleanupDone = true
+	} else {
+		out.CleanupDone = false
+		if len(out.Cleanup) > page {
+			out.Cleanup = out.Cleanup[:page]
+		}
+	}
+	return out, nil
+}
+
+func cleanupDiscoveryPageSize(ctx context.Context, b apptypes.SearchProjectionBudget) int {
+	page := b.Rows
+	if page < 1 {
+		page = 1
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return page
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 1
+	}
+	maxByTime := int(remaining / cleanupDiscoveryMinRowTime)
+	if maxByTime < 1 {
+		maxByTime = 1
+	}
+	if maxByTime < page {
+		return maxByTime
+	}
+	return page
+}
+
+func projectionCleanupDiscoveryBranches(out apptypes.ProjectionSnapshot, limit int) []projectionCleanupBranch {
+	if out.CleanupAll {
+		return []projectionCleanupBranch{
+			{`SELECT 'recent',document_id,` + recentCleanupLogicalBytesSQL + `, '','','',X'' FROM search_projection_recent_documents ORDER BY document_id LIMIT ?`, []any{limit}},
+			{`SELECT 'summary',0,` + summaryCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_session_summaries ORDER BY generation_id,session_id LIMIT ?`, []any{limit}},
+			{`SELECT 'aggregate',0,` + aggregateCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_command_aggregates ORDER BY generation_id,session_id LIMIT ?`, []any{limit}},
+			{`SELECT 'keyword',0,` + keywordCleanupLogicalBytesSQL + `, generation_id,session_id,keyword,X'' FROM search_projection_session_keywords ORDER BY generation_id,session_id,keyword LIMIT ?`, []any{limit}},
+			{`SELECT 'fingerprint',0,` + fingerprintCleanupLogicalBytesSQL + `, generation_id,event_id,'',fingerprint FROM literal_search_fingerprints ORDER BY generation_id,event_id,fingerprint LIMIT ?`, []any{limit}},
+			{`SELECT 'exclusion',source_sequence,` + exclusionCleanupLogicalBytesSQL + `, generation_id,'','',X'' FROM search_projection_exclusions ORDER BY generation_id,source_sequence LIMIT ?`, []any{limit}},
+		}
+	}
+	generation := out.Generation.GenerationID
+	// Two range scans per table so generation_id<>current is a PK seek, not a
+	// full leftover materialization. After deletes, the next LIMIT page is
+	// the next keyset.
+	return []projectionCleanupBranch{
+		{`SELECT 'recent',document_id,` + recentCleanupLogicalBytesSQL + `, '','','',X'' FROM search_projection_recent_documents WHERE generation_id<? ORDER BY document_id LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'recent',document_id,` + recentCleanupLogicalBytesSQL + `, '','','',X'' FROM search_projection_recent_documents WHERE generation_id>? ORDER BY document_id LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'summary',0,` + summaryCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_session_summaries WHERE generation_id<? ORDER BY generation_id,session_id LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'summary',0,` + summaryCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_session_summaries WHERE generation_id>? ORDER BY generation_id,session_id LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'aggregate',0,` + aggregateCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_command_aggregates WHERE generation_id<? ORDER BY generation_id,session_id LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'aggregate',0,` + aggregateCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_command_aggregates WHERE generation_id>? ORDER BY generation_id,session_id LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'keyword',0,` + keywordCleanupLogicalBytesSQL + `, generation_id,session_id,keyword,X'' FROM search_projection_session_keywords WHERE generation_id<? ORDER BY generation_id,session_id,keyword LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'keyword',0,` + keywordCleanupLogicalBytesSQL + `, generation_id,session_id,keyword,X'' FROM search_projection_session_keywords WHERE generation_id>? ORDER BY generation_id,session_id,keyword LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'fingerprint',0,` + fingerprintCleanupLogicalBytesSQL + `, generation_id,event_id,'',fingerprint FROM literal_search_fingerprints WHERE generation_id<? ORDER BY generation_id,event_id,fingerprint LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'fingerprint',0,` + fingerprintCleanupLogicalBytesSQL + `, generation_id,event_id,'',fingerprint FROM literal_search_fingerprints WHERE generation_id>? ORDER BY generation_id,event_id,fingerprint LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'exclusion',source_sequence,` + exclusionCleanupLogicalBytesSQL + `, generation_id,'','',X'' FROM search_projection_exclusions WHERE generation_id<? ORDER BY generation_id,source_sequence LIMIT ?`, []any{generation, limit}},
+		{`SELECT 'exclusion',source_sequence,` + exclusionCleanupLogicalBytesSQL + `, generation_id,'','',X'' FROM search_projection_exclusions WHERE generation_id>? ORDER BY generation_id,source_sequence LIMIT ?`, []any{generation, limit}},
+	}
+}
+
+func appendProjectionCleanupRows(rows *sql.Rows, out *apptypes.ProjectionSnapshot) (int, error) {
+	fetched := 0
+	for rows.Next() {
+		var c apptypes.ProjectionCleanupCandidate
+		if err := rows.Scan(&c.Class, &c.RowID, &c.LogicalBytes, &c.Address1, &c.Address2, &c.Address3, &c.AddressBlob); err != nil {
+			return fetched, err
+		}
+		out.Cleanup = append(out.Cleanup, c)
+		fetched++
+	}
+	return fetched, rows.Err()
+}
+
+// RecordCleanupNoProgressAttempt increments the durable cleanup stall
+// counter. After SearchProjectionCleanupNoProgressLimit consecutive attempts
+// that committed no row, the generation is parked as failed so the next open
+// skips instead of retrying forever (#2010).
+func (d *Database) RecordCleanupNoProgressAttempt(ctx context.Context, generation string, now time.Time) (int, bool, error) {
+	if generation == "" {
+		return 0, false, &apptypes.SearchProjectionNoProgressError{Reason: "cleanup no-progress recording requires a generation id"}
+	}
+	db, err := d.open(ctx)
+	if err != nil {
+		return 0, false, xerrors.Errorf("open store for cleanup no-progress: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, false, xerrors.Errorf("begin cleanup no-progress: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	stamp := formatTimestamp(now.UTC())
+	result, err := tx.ExecContext(ctx, `UPDATE search_projection_state SET cleanup_no_progress_attempts=cleanup_no_progress_attempts+1,updated_at=? WHERE generation_id=? AND phase='cleanup' AND state IN ('rebuilding','drifted')`, stamp, generation)
+	if err != nil {
+		return 0, false, xerrors.Errorf("increment cleanup no-progress attempts: %w", err)
+	}
+	if n, rowErr := result.RowsAffected(); rowErr != nil || n != 1 {
+		return 0, false, &apptypes.SearchProjectionDriftError{}
+	}
+	var attempts int
+	if err = tx.QueryRowContext(ctx, `SELECT cleanup_no_progress_attempts FROM search_projection_state WHERE generation_id=?`, generation).Scan(&attempts); err != nil {
+		return 0, false, xerrors.Errorf("read cleanup no-progress attempts: %w", err)
+	}
+	if attempts < apptypes.SearchProjectionCleanupNoProgressLimit {
+		if err = tx.Commit(); err != nil {
+			return 0, false, xerrors.Errorf("commit cleanup no-progress increment: %w", err)
+		}
+		return attempts, false, nil
+	}
+	result, err = tx.ExecContext(ctx, `UPDATE search_projection_state SET state='failed',phase='complete',failure_class=?,updated_at=? WHERE generation_id=? AND state IN ('rebuilding','drifted')`, apptypes.SearchProjectionFailureCleanupNoProgress, stamp, generation)
+	if err != nil {
+		return 0, false, xerrors.Errorf("park cleanup no-progress generation: %w", err)
+	}
+	if n, rowErr := result.RowsAffected(); rowErr != nil || n != 1 {
+		return 0, false, &apptypes.SearchProjectionDriftError{}
+	}
+	result, err = tx.ExecContext(ctx, `UPDATE search_projection_generation_lifecycle SET state='failed' WHERE generation_id=? AND state IN ('rebuilding','drifted')`, generation)
+	if err != nil {
+		return 0, false, xerrors.Errorf("park cleanup no-progress lifecycle: %w", err)
+	}
+	if n, rowErr := result.RowsAffected(); rowErr != nil || n != 1 {
+		return 0, false, &apptypes.SearchProjectionDriftError{}
+	}
+	if err = tx.Commit(); err != nil {
+		return 0, false, xerrors.Errorf("commit cleanup no-progress park: %w", err)
+	}
+	return attempts, true, nil
+}

--- a/infrastructure/sqlite/search_projection_cleanup_internal_test.go
+++ b/infrastructure/sqlite/search_projection_cleanup_internal_test.go
@@ -1,0 +1,232 @@
+package sqlite
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+)
+
+func TestSearchProjectionCleanup_PagedDiscoveryMakesProgressUnderTinyWall(t *testing.T) {
+	store, db := newCapacityTestStore(t, nil)
+	now := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+	generation, err := store.Start(ctx, defaultSearchProjectionCatchUpBudget(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const leftoverCount = 12000
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < leftoverCount; i++ {
+		if _, err = tx.Exec(
+			`INSERT INTO search_projection_session_keywords(generation_id,session_id,keyword,occurrences,keyword_version) VALUES(?,?,?,1,1)`,
+			"old-generation", "sess-old", "leftover-"+strconv.Itoa(i),
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE search_projection_state SET phase='cleanup',checkpoint=0,cleanup_scope='old' WHERE generation_id=?`, generation.GenerationID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE search_projection_inventory_state SET state='complete' WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+
+	budget := defaultSearchProjectionCatchUpBudget()
+	budget.WallTime = 50 * time.Millisecond
+	budget.Rows = 8
+	selectCtx, selectCancel := context.WithTimeout(ctx, budget.WallTime)
+	defer selectCancel()
+	snapshot, err := store.SelectSnapshot(selectCtx, budget, now)
+	if err != nil {
+		t.Fatalf("SelectSnapshot: %v", err)
+	}
+	if len(snapshot.Cleanup) == 0 {
+		t.Fatal("paged cleanup selected no leftovers")
+	}
+	if snapshot.CleanupDone {
+		t.Fatal("CleanupDone=true with thousands of leftovers still present")
+	}
+	plan, err := usecase.PlanProjectionBatch(snapshot, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyCtx, applyCancel := context.WithTimeout(ctx, budget.WallTime)
+	defer applyCancel()
+	progress, err := store.CleanupBatch(applyCtx, plan, budget.LockTime, now)
+	if err != nil {
+		t.Fatalf("CleanupBatch: %v", err)
+	}
+	if progress.Cleaned == 0 {
+		t.Fatal("cleanup committed no rows under the tiny wall budget")
+	}
+
+	var remaining int
+	if err = db.QueryRow(`SELECT COUNT(*) FROM search_projection_session_keywords WHERE generation_id='old-generation'`).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != leftoverCount-progress.Cleaned {
+		t.Fatalf("remaining leftovers=%d, want %d", remaining, leftoverCount-progress.Cleaned)
+	}
+
+	catchBudget := budget
+	catchBudget.WallTime = 50 * time.Millisecond
+	result, catchErr := usecase.NewSearchProjectionUsecase(store).CatchUp(ctx, catchBudget, now)
+	if catchErr != nil {
+		t.Fatalf("CatchUp: %v", catchErr)
+	}
+	if result.Action != "resume" {
+		t.Fatalf("CatchUp action=%q, want resume", result.Action)
+	}
+	status, err := store.SearchProjectionControlStatus(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.State != "rebuilding" || status.Phase != "cleanup" {
+		t.Fatalf("after CatchUp state=%s phase=%s, want rebuilding/cleanup", status.State, status.Phase)
+	}
+	var afterCatchUp int
+	if err = db.QueryRow(`SELECT COUNT(*) FROM search_projection_session_keywords WHERE generation_id='old-generation'`).Scan(&afterCatchUp); err != nil {
+		t.Fatal(err)
+	}
+	if afterCatchUp >= remaining {
+		t.Fatalf("CatchUp leftovers=%d, want fewer than %d", afterCatchUp, remaining)
+	}
+}
+
+func TestSearchProjectionCleanup_ParksAfterConsecutiveZeroProgressAttempts(t *testing.T) {
+	store, db := newCapacityTestStore(t, nil)
+	now := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+	generation, err := store.Start(ctx, defaultSearchProjectionCatchUpBudget(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`
+		INSERT INTO search_projection_session_keywords(generation_id,session_id,keyword,occurrences,keyword_version)
+		VALUES('old-generation','sess-old','stale',1,1);
+		UPDATE search_projection_state SET phase='cleanup',checkpoint=0,cleanup_scope='old' WHERE generation_id=?;
+		UPDATE search_projection_inventory_state SET state='complete' WHERE singleton=1;
+	`, generation.GenerationID); err != nil {
+		t.Fatal(err)
+	}
+
+	for injected := 1; injected < apptypes.SearchProjectionCleanupNoProgressLimit; injected++ {
+		attempts, parked, recErr := store.RecordCleanupNoProgressAttempt(ctx, generation.GenerationID, now)
+		if recErr != nil {
+			t.Fatalf("inject attempt %d: %v", injected, recErr)
+		}
+		if parked {
+			t.Fatalf("inject attempt %d parked early (attempts=%d)", injected, attempts)
+		}
+	}
+	store.afterProjectionLockHeld = func(holdCtx context.Context) error {
+		select {
+		case <-holdCtx.Done():
+			return holdCtx.Err()
+		case <-time.After(80 * time.Millisecond):
+			return context.DeadlineExceeded
+		}
+	}
+	zeroBudget := defaultSearchProjectionCatchUpBudget()
+	zeroBudget.WallTime = 20 * time.Millisecond
+	result, catchErr := usecase.NewSearchProjectionUsecase(store).CatchUp(ctx, zeroBudget, now)
+	if catchErr != nil {
+		t.Fatalf("parking CatchUp: %v", catchErr)
+	}
+	if result.Action != "skipped" {
+		t.Fatalf("parking action=%q, want skipped", result.Action)
+	}
+	if !strings.Contains(result.SkippedReason, apptypes.SearchProjectionFailureCleanupNoProgress) {
+		t.Fatalf("park reason %q does not name %s", result.SkippedReason, apptypes.SearchProjectionFailureCleanupNoProgress)
+	}
+
+	var state, class string
+	if err = db.QueryRow(`SELECT state,failure_class FROM search_projection_state WHERE singleton=1`).Scan(&state, &class); err != nil {
+		t.Fatal(err)
+	}
+	if state != "failed" || class != apptypes.SearchProjectionFailureCleanupNoProgress {
+		t.Fatalf("state=%q class=%q, want failed/%s", state, class, apptypes.SearchProjectionFailureCleanupNoProgress)
+	}
+
+	next, nextErr := catchUpSearchProjection(ctx, store)
+	if nextErr != nil {
+		t.Fatalf("catchUpSearchProjection after park: %v", nextErr)
+	}
+	if next.Action != "skipped" {
+		t.Fatalf("after park action=%q, want skipped", next.Action)
+	}
+	if !strings.Contains(next.SkippedReason, apptypes.SearchProjectionFailureCleanupNoProgress) {
+		t.Fatalf("after park reason %q does not name parked cleanup_no_progress", next.SkippedReason)
+	}
+}
+
+func TestSearchProjectionCleanup_ProgressResetsNoProgressAttempts(t *testing.T) {
+	store, db := newCapacityTestStore(t, nil)
+	now := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+	generation, err := store.Start(ctx, defaultSearchProjectionCatchUpBudget(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`
+		INSERT INTO search_projection_session_keywords(generation_id,session_id,keyword,occurrences,keyword_version)
+		VALUES('old-generation','sess-old','stale',1,1);
+		UPDATE search_projection_state SET phase='cleanup',checkpoint=0,cleanup_scope='old',cleanup_no_progress_attempts=2 WHERE generation_id=?;
+	`, generation.GenerationID); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := store.SelectSnapshot(ctx, defaultSearchProjectionCatchUpBudget(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := usecase.PlanProjectionBatch(snapshot, defaultSearchProjectionCatchUpBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.CleanupBatch(ctx, plan, time.Second, now); err != nil {
+		t.Fatal(err)
+	}
+	var attempts int
+	if err = db.QueryRow(`SELECT cleanup_no_progress_attempts FROM search_projection_state WHERE singleton=1`).Scan(&attempts); err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 0 {
+		t.Fatalf("attempts=%d, want 0 after a cleanup that made progress", attempts)
+	}
+}
+
+func TestLogSearchProjectionCatchUp_RepeatIncompleteIsDebug(t *testing.T) {
+	handler := &catchUpLogHandler{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	logSearchProjectionCatchUp(apptypes.SearchProjectionCatchUpResult{
+		Action: "resume", State: "rebuilding", Phase: "cleanup",
+	}, context.DeadlineExceeded)
+
+	if diff := cmp.Diff(1, len(handler.records)); diff != "" {
+		t.Fatalf("unexpected record count (-want +got):\n%s", diff)
+	}
+	if handler.records[0].Message != genericCatchUpIncompleteLine {
+		t.Fatalf("message=%q, want the generic incomplete line", handler.records[0].Message)
+	}
+	if handler.records[0].Level != slog.LevelDebug {
+		t.Fatalf("level=%s, want DEBUG", handler.records[0].Level)
+	}
+}

--- a/infrastructure/sqlite/search_projection_cutover_evidence_internal_test.go
+++ b/infrastructure/sqlite/search_projection_cutover_evidence_internal_test.go
@@ -251,7 +251,7 @@ func TestSearchProjectionCutoverEvidence_DoesNotOverwriteAReplacementGeneration(
 // and append a lifecycle row per open, forever.
 func TestSearchProjectionCatchUp_ParksDeterministicFailureInsteadOfRestarting(t *testing.T) {
 	ctx := context.Background()
-	for _, failureClass := range []string{"decoded_bytes", "session_tier_unverified", "abandoned"} {
+	for _, failureClass := range []string{"decoded_bytes", "session_tier_unverified", "abandoned", "cleanup_no_progress"} {
 		t.Run(failureClass, func(t *testing.T) {
 			database, _ := newProjectionEvidenceStore(t)
 			raw, err := database.open(ctx)

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -179,7 +179,7 @@ func generationID() string {
 	return hex.EncodeToString(b[:])
 }
 
-const searchProjectionStartStateSQL = `UPDATE search_projection_state SET generation_id=?,config_hash=?,source_revision=?,high_water=?,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='rebuilding',recent_source_bytes=0,recent_age_seconds=?,index_family_byte_limit=?,recent_byte_limit=?,capacity_semantics_version=?,recent_source_ceiling_bytes=?,recent_amplification_ppm=?,non_recent_family_bytes=?,recent_cutoff_norm=?,capacity_evidence_status=?,capacity_evidence_reason=?,index_family_within_budget=-1,cutover_index_family=?,cutover_family_bytes_before=?,cutover_family_bytes_after=0,cutover_before_evidence_status=?,cutover_before_evidence_reason=?,cutover_after_evidence_status='',cutover_after_evidence_reason='',origin=?,capacity_rederived=0,updated_at=? `
+const searchProjectionStartStateSQL = `UPDATE search_projection_state SET generation_id=?,config_hash=?,source_revision=?,high_water=?,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='rebuilding',recent_source_bytes=0,recent_age_seconds=?,index_family_byte_limit=?,recent_byte_limit=?,capacity_semantics_version=?,recent_source_ceiling_bytes=?,recent_amplification_ppm=?,non_recent_family_bytes=?,recent_cutoff_norm=?,capacity_evidence_status=?,capacity_evidence_reason=?,index_family_within_budget=-1,cutover_index_family=?,cutover_family_bytes_before=?,cutover_family_bytes_after=0,cutover_before_evidence_status=?,cutover_before_evidence_reason=?,cutover_after_evidence_status='',cutover_after_evidence_reason='',origin=?,capacity_rederived=0,cleanup_no_progress_attempts=0,updated_at=? `
 
 func (d *Database) measureSearchProjectionStart(ctx context.Context, db *sql.DB, b apptypes.SearchProjectionBudget) (capacityDerivation, string, int64, apptypes.CapacityEvidence) {
 	var lastNonRecent int64
@@ -885,12 +885,8 @@ const keywordCleanupLogicalBytesSQL = `length(CAST(generation_id AS BLOB))+lengt
 const fingerprintCleanupLogicalBytesSQL = `length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16`
 const exclusionCleanupLogicalBytesSQL = `length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(class AS BLOB))+32`
 
-// selectProjectionCleanupSQL addresses each table by its primary key, not
-// rowid. WITHOUT ROWID tables have no rowid; a shared integer address would
-// fail to compile and stall eviction (#1825).
-const selectProjectionCleanupSQL = `SELECT 'recent',document_id,` + recentCleanupLogicalBytesSQL + `, '','','',X'' FROM search_projection_recent_documents UNION ALL SELECT 'summary',0,` + summaryCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_session_summaries UNION ALL SELECT 'aggregate',0,` + aggregateCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_command_aggregates UNION ALL SELECT 'keyword',0,` + keywordCleanupLogicalBytesSQL + `, generation_id,session_id,keyword,X'' FROM search_projection_session_keywords UNION ALL SELECT 'fingerprint',0,` + fingerprintCleanupLogicalBytesSQL + `, generation_id,event_id,'',fingerprint FROM literal_search_fingerprints UNION ALL SELECT 'exclusion',source_sequence,` + exclusionCleanupLogicalBytesSQL + `, generation_id,'','',X'' FROM search_projection_exclusions`
-
-const selectProjectionCleanupOldSQL = `SELECT 'recent',document_id,` + recentCleanupLogicalBytesSQL + `, '','','',X'' FROM search_projection_recent_documents WHERE generation_id<>? UNION ALL SELECT 'summary',0,` + summaryCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_session_summaries WHERE generation_id<>? UNION ALL SELECT 'aggregate',0,` + aggregateCleanupLogicalBytesSQL + `, generation_id,session_id,'',X'' FROM search_projection_command_aggregates WHERE generation_id<>? UNION ALL SELECT 'keyword',0,` + keywordCleanupLogicalBytesSQL + `, generation_id,session_id,keyword,X'' FROM search_projection_session_keywords WHERE generation_id<>? UNION ALL SELECT 'fingerprint',0,` + fingerprintCleanupLogicalBytesSQL + `, generation_id,event_id,'',fingerprint FROM literal_search_fingerprints WHERE generation_id<>? UNION ALL SELECT 'exclusion',source_sequence,` + exclusionCleanupLogicalBytesSQL + `, generation_id,'','',X'' FROM search_projection_exclusions WHERE generation_id<>?`
+// Cleanup discovery is paged per table in search_projection_cleanup.go so a
+// leftover scan cannot UNION-ALL every old-generation row before LIMIT (#2010).
 
 type projectionExecer interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
@@ -928,41 +924,10 @@ func deleteProjectionCleanupRow(ctx context.Context, tx projectionExecer, c appt
 
 //nolint:wrapcheck,errcheck // SQL errors are contextual to this adapter.
 func selectProjectionCleanup(ctx context.Context, db *sql.DB, out apptypes.ProjectionSnapshot, b apptypes.SearchProjectionBudget, now time.Time) (apptypes.ProjectionSnapshot, error) {
-	var q string
-	var args []any
 	if out.Phase == "eviction" {
 		return selectProjectionEviction(ctx, db, out, b, now)
-	} else if out.CleanupAll {
-		q = selectProjectionCleanupSQL + ` LIMIT ?`
-		args = []any{b.Rows + 1}
-	} else {
-		q = selectProjectionCleanupOldSQL + ` LIMIT ?`
-		args = []any{out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, b.Rows + 1}
 	}
-	rows, e := db.QueryContext(ctx, q, args...)
-	if e != nil {
-		return out, e
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var c apptypes.ProjectionCleanupCandidate
-		if out.Phase == "cleanup" {
-			e = rows.Scan(&c.Class, &c.RowID, &c.LogicalBytes, &c.Address1, &c.Address2, &c.Address3, &c.AddressBlob)
-		} else {
-			e = rows.Scan(&c.RowID, &c.LogicalBytes)
-			c.Class = out.Phase
-		}
-		if e != nil {
-			return out, e
-		}
-		out.Cleanup = append(out.Cleanup, c)
-	}
-	if len(out.Cleanup) <= b.Rows {
-		out.CleanupDone = true
-	} else {
-		out.Cleanup = out.Cleanup[:b.Rows]
-	}
-	return out, rows.Err()
+	return selectProjectionCleanupPaged(ctx, db, out, b)
 }
 
 // ApplyBatch acquires the write lock with BEGIN IMMEDIATE under its own
@@ -1237,7 +1202,7 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 	if fenceRecent {
 		fenceRecentInt = 1
 	}
-	r, e := tx.ExecContext(holdCtx, `UPDATE search_projection_state SET checkpoint=?,phase=?,state=?,recent_source_bytes=recent_source_bytes+?,active_generation_id=CASE WHEN ? AND ?='complete' THEN generation_id ELSE active_generation_id END,last_batch_milliseconds=?,updated_at=? WHERE generation_id=? AND source_revision=? AND checkpoint=? AND phase=? AND (? OR EXISTS(SELECT 1 FROM search_projection_source_revision WHERE singleton=1 AND revision=?)) AND (?=0 OR recent_source_bytes=?)`, p.NextCheckpoint, next, state, recentDelta, p.Completed, state, time.Since(started).Milliseconds(), formatTimestamp(now), p.GenerationID, p.ExpectedRevision, p.ExpectedCheckpoint, p.Phase, p.AllowRevisionDrift, p.ExpectedRevision, fenceRecentInt, p.ExpectedRecentSourceBytes)
+	r, e := tx.ExecContext(holdCtx, `UPDATE search_projection_state SET checkpoint=?,phase=?,state=?,recent_source_bytes=recent_source_bytes+?,active_generation_id=CASE WHEN ? AND ?='complete' THEN generation_id ELSE active_generation_id END,last_batch_milliseconds=?,cleanup_no_progress_attempts=CASE WHEN ? IN ('cleanup','eviction') THEN 0 ELSE cleanup_no_progress_attempts END,updated_at=? WHERE generation_id=? AND source_revision=? AND checkpoint=? AND phase=? AND (? OR EXISTS(SELECT 1 FROM search_projection_source_revision WHERE singleton=1 AND revision=?)) AND (?=0 OR recent_source_bytes=?)`, p.NextCheckpoint, next, state, recentDelta, p.Completed, state, time.Since(started).Milliseconds(), p.Phase, formatTimestamp(now), p.GenerationID, p.ExpectedRevision, p.ExpectedCheckpoint, p.Phase, p.AllowRevisionDrift, p.ExpectedRevision, fenceRecentInt, p.ExpectedRecentSourceBytes)
 	if e != nil {
 		return out, e
 	}

--- a/schema/sqlite/migrations/000068_add_search_projection_cleanup_no_progress_attempts.sql
+++ b/schema/sqlite/migrations/000068_add_search_projection_cleanup_no_progress_attempts.sql
@@ -1,0 +1,8 @@
+-- Track consecutive cleanup-phase attempts that commit no row, so automatic
+-- catch-up can park a generation whose cleanup phase cannot make forward
+-- progress instead of retrying the same unwinnable unit of work on every
+-- store open (#2010). Reset to 0 whenever a cleanup attempt does make
+-- progress; incremented on each no-progress attempt.
+
+ALTER TABLE search_projection_state
+    ADD COLUMN cleanup_no_progress_attempts INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary
- Cleanup leftover discovery LIMITs each table so a short Initialize can commit a page.
- Three consecutive zero-progress cleanup catch-up attempts park the generation as `cleanup_no_progress`.
- Repeat incomplete catch-up logs at debug instead of error.

Closes #2010
Leaves parent #2025 open.

## Test plan
- [x] `go test ./infrastructure/sqlite/ -run 'TestSearchProjectionCleanup_|TestLogSearchProjectionCatchUp_|TestSearchProjectionCatchUp_Parks'`