### PR TITLE
fix: stamp stop_hook usage observations with wall time

### DIFF
--- a/application/usecase/antigravity_usage_capture.go
+++ b/application/usecase/antigravity_usage_capture.go
@@ -180,7 +180,10 @@ func (u *antigravityUsageCaptureUsecase) CaptureStopUnavailable(
 	if err != nil {
 		return AntigravityUsageCaptureResult{}, xerrors.Errorf("invalid Antigravity Stop usage source: %w", err)
 	}
-	observedAt := time.Unix(0, 0).UTC()
+	observedAt, err := resolveUnavailableObservationTime(ctx, u.repository, id, time.Time{})
+	if err != nil {
+		return AntigravityUsageCaptureResult{}, err
+	}
 	descriptor, err := model.NewUsageObservationDescriptor(
 		id, input.SessionID, source, types.UsageScopeCall, types.UsageAccountingExcluded, observedAt,
 	)

--- a/application/usecase/claude_usage_capture.go
+++ b/application/usecase/claude_usage_capture.go
@@ -170,7 +170,10 @@ func (u *claudeUsageCaptureUsecase) recordUnavailableBoundary(
 	if mode == application.ClaudeUsageModeOneShotStream {
 		scope = types.UsageScopeRun
 	}
-	now := time.Unix(0, 0).UTC()
+	now, err := resolveUnavailableObservationTime(ctx, u.repository, id, time.Time{})
+	if err != nil {
+		return err
+	}
 	descriptor, err := model.NewUsageObservationDescriptor(
 		id, input.SessionID, source, scope, types.UsageAccountingExcluded, now,
 	)

--- a/application/usecase/claude_usage_capture_test.go
+++ b/application/usecase/claude_usage_capture_test.go
@@ -146,6 +146,7 @@ func TestClaudeUsageCaptureUsecase_RecordsStableUnavailableBoundary(t *testing.T
 			observation.Counters().Availability() != types.UsageAvailabilityUnavailable {
 			t.Fatalf("unavailable observation = %+v", observation)
 		}
+		assertUnavailableObservationNotEpoch(t, observation)
 	}
 }
 

--- a/application/usecase/codex_usage_capture.go
+++ b/application/usecase/codex_usage_capture.go
@@ -172,10 +172,10 @@ func (u *codexUsageCaptureUsecase) recordUnavailableBoundary(
 	if err != nil {
 		return xerrors.Errorf("invalid Codex unavailable source: %w", err)
 	}
-	// A body-free Stop delivery has no authoritative event timestamp. Use one
-	// deterministic sentinel so exact replays are reconciled by the domain
-	// aggregate instead of an adapter-local equality rule.
-	now := time.Unix(0, 0).UTC()
+	now, err := resolveUnavailableObservationTime(ctx, u.repository, id, time.Time{})
+	if err != nil {
+		return err
+	}
 	descriptor, err := model.NewUsageObservationDescriptor(
 		id, input.SessionID, source, types.UsageScopeCall, types.UsageAccountingExcluded, now,
 	)

--- a/application/usecase/codex_usage_capture_test.go
+++ b/application/usecase/codex_usage_capture_test.go
@@ -150,6 +150,7 @@ func TestCodexUsageCaptureUsecase_RecordsStableUnavailableBoundary(t *testing.T)
 		if observation.Counters().Availability() != types.UsageAvailabilityUnavailable || observation.Descriptor().Accounting() != types.UsageAccountingExcluded || !present || terminal != types.UsageTerminalUnknown {
 			t.Fatalf("unavailable observation = availability %s accounting %s", observation.Counters().Availability(), observation.Descriptor().Accounting())
 		}
+		assertUnavailableObservationNotEpoch(t, observation)
 	}
 }
 

--- a/application/usecase/gemini_usage_capture.go
+++ b/application/usecase/gemini_usage_capture.go
@@ -19,6 +19,10 @@ type GeminiUsageCaptureInput struct {
 	SessionID        types.SessionID
 	DeliveryID       string
 	FallbackTerminal types.UsageTerminalCode
+	// EventTime is the hook payload's own event timestamp, when the caller has
+	// one. It is used as observed_at/finalized_at instead of the hook wall
+	// clock so that idempotent delivery replays keep the same descriptor.
+	EventTime time.Time
 }
 
 // GeminiUsageCaptureResult exposes idempotent write outcomes.
@@ -122,7 +126,10 @@ func (u *geminiUsageCaptureUsecase) recordUnavailable(
 	if err != nil {
 		return xerrors.Errorf("invalid Gemini unavailable source: %w", err)
 	}
-	observedAt := time.Unix(0, 0).UTC()
+	observedAt, err := resolveUnavailableObservationTime(ctx, u.repository, id, input.EventTime)
+	if err != nil {
+		return err
+	}
 	descriptor, err := model.NewUsageObservationDescriptor(
 		id, input.SessionID, source, scope, types.UsageAccountingExcluded, observedAt,
 	)

--- a/application/usecase/google_usage_capture_test.go
+++ b/application/usecase/google_usage_capture_test.go
@@ -134,6 +134,7 @@ func TestGeminiUsageCapture_RecordsUnavailableRunAndInteractiveCall(t *testing.T
 		if observation.Counters().Availability() != types.UsageAvailabilityUnavailable {
 			t.Fatalf("availability = %q", observation.Counters().Availability())
 		}
+		assertUnavailableObservationNotEpoch(t, observation)
 	}
 	if runCount != 1 || callCount != 1 {
 		t.Fatalf("run = %d call = %d", runCount, callCount)
@@ -246,6 +247,9 @@ func TestAntigravityUsageCapture_RecordsUnavailableStopBoundaryIdempotently(t *t
 	if err != nil || second.AlreadyApplied != 1 || second.Unavailable != 0 ||
 		len(repository.observations) != 1 {
 		t.Fatalf("second = (%+v, %v), observations = %d", second, err, len(repository.observations))
+	}
+	for _, observation := range repository.observations {
+		assertUnavailableObservationNotEpoch(t, observation)
 	}
 }
 

--- a/application/usecase/grok_usage_capture.go
+++ b/application/usecase/grok_usage_capture.go
@@ -209,7 +209,10 @@ func (u *grokUsageCaptureUsecase) recordUnavailable(
 	if err != nil {
 		return result, xerrors.Errorf("invalid Grok unavailable source: %w", err)
 	}
-	observedAt := time.Unix(0, 0).UTC()
+	observedAt, err := resolveUnavailableObservationTime(ctx, u.repository, id, time.Time{})
+	if err != nil {
+		return result, err
+	}
 	descriptor, err := model.NewUsageObservationDescriptor(
 		id, input.SessionID, source, scope, types.UsageAccountingExcluded, observedAt,
 	)

--- a/application/usecase/grok_usage_capture_test.go
+++ b/application/usecase/grok_usage_capture_test.go
@@ -124,6 +124,7 @@ func TestGrokUsageCapture_RecordsUnavailableRunAndStableHookCall(t *testing.T) {
 			observation.Counters().Availability() != types.UsageAvailabilityUnavailable {
 			t.Fatalf("unavailable observation = %+v", observation)
 		}
+		assertUnavailableObservationNotEpoch(t, observation)
 	}
 	if runCount != 1 || callCount != 1 {
 		t.Fatalf("run = %d call = %d", runCount, callCount)

--- a/application/usecase/kimi_usage_capture.go
+++ b/application/usecase/kimi_usage_capture.go
@@ -127,7 +127,10 @@ func (u *kimiUsageCaptureUsecase) recordUnavailable(
 	if err != nil {
 		return xerrors.Errorf("invalid Kimi unavailable source: %w", err)
 	}
-	observedAt := time.Unix(0, 0).UTC()
+	observedAt, err := resolveUnavailableObservationTime(ctx, u.repository, id, time.Time{})
+	if err != nil {
+		return err
+	}
 	descriptor, err := model.NewUsageObservationDescriptor(
 		id,
 		input.SessionID,

--- a/application/usecase/kimi_usage_capture_test.go
+++ b/application/usecase/kimi_usage_capture_test.go
@@ -108,6 +108,9 @@ func TestKimiUsageCapture_RecordsPartialExcludedRowsAndUnavailableBoundary(t *te
 		if descriptor.Accounting() != types.UsageAccountingExcluded || descriptor.Scope() != types.UsageScopeCall {
 			t.Fatalf("descriptor = %+v", descriptor)
 		}
+		if descriptor.Source().Name() == "stop_hook" || descriptor.Source().Name() == "session_end_hook" {
+			assertUnavailableObservationNotEpoch(t, observation)
+		}
 		if descriptor.Source().Name() == "main_wire" {
 			counters := observation.Counters()
 			if value, known := counters.Input().Value(); !known || value != 0 {
@@ -148,6 +151,9 @@ func TestKimiUsageCapture_SeparatesStopAndSessionEndAvailability(t *testing.T) {
 	}
 	if len(repository.observations) != 2 {
 		t.Fatalf("boundary observations = %d, want 2", len(repository.observations))
+	}
+	for _, observation := range repository.observations {
+		assertUnavailableObservationNotEpoch(t, observation)
 	}
 }
 

--- a/application/usecase/usage_unavailable_time.go
+++ b/application/usecase/usage_unavailable_time.go
@@ -1,0 +1,37 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// resolveUnavailableObservationTime stamps a stop-hook-family unavailable
+// observation. A later exact replay must reuse the first write's time so
+// descriptor identity still reconciles. Unix epoch is never a first-write
+// stamp: period-windowed reports treat it as outside every real interval.
+func resolveUnavailableObservationTime(
+	ctx context.Context,
+	repo model.UsageObservationRepository,
+	id types.UsageObservationID,
+	preferred time.Time,
+) (time.Time, error) {
+	if repo == nil {
+		return time.Time{}, xerrors.Errorf("usage repository must be configured")
+	}
+	existing, err := repo.FindByID(ctx, id)
+	if err != nil {
+		return time.Time{}, xerrors.Errorf("failed to inspect existing usage observation: %w", err)
+	}
+	if current, present := existing.Value(); present {
+		return current.Descriptor().ObservedAt(), nil
+	}
+	if preferred.Unix() > 0 {
+		return preferred.UTC(), nil
+	}
+	return time.Now().UTC(), nil
+}

--- a/application/usecase/usage_unavailable_time_test.go
+++ b/application/usecase/usage_unavailable_time_test.go
@@ -1,0 +1,108 @@
+package usecase_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+)
+
+func assertUnavailableObservationNotEpoch(t *testing.T, observation *model.UsageObservation) {
+	t.Helper()
+	if observation == nil {
+		t.Fatal("observation is nil")
+	}
+	epoch := time.Unix(0, 0).UTC()
+	observedAt := observation.Descriptor().ObservedAt()
+	if !observedAt.After(epoch) {
+		t.Fatalf("observed_at = %s, want after Unix epoch", observedAt)
+	}
+	finalizedAt, present := observation.FinalizedAt().Value()
+	if !present || !finalizedAt.After(epoch) {
+		t.Fatalf("finalized_at = (%s, %t), want after Unix epoch", finalizedAt, present)
+	}
+}
+
+func TestGeminiUsageCapture_PrefersNonEpochEventTime(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGeminiUsageCaptureUsecase(repository)
+	eventTime := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	result, err := capture.CaptureInteractiveUnavailable(
+		t.Context(),
+		usecase.GeminiUsageCaptureInput{
+			SessionID:  "session-1",
+			DeliveryID: "timestamp:2026-08-16T12:00:00Z",
+			EventTime:  eventTime,
+		},
+	)
+	if err != nil || result.Unavailable != 1 {
+		t.Fatalf("CaptureInteractiveUnavailable() = (%+v, %v)", result, err)
+	}
+	for _, observation := range repository.observations {
+		if !observation.Descriptor().ObservedAt().Equal(eventTime) {
+			t.Fatalf("observed_at = %s, want event time %s", observation.Descriptor().ObservedAt(), eventTime)
+		}
+		assertUnavailableObservationNotEpoch(t, observation)
+	}
+	replayed, err := capture.CaptureInteractiveUnavailable(
+		t.Context(),
+		usecase.GeminiUsageCaptureInput{
+			SessionID:  "session-1",
+			DeliveryID: "timestamp:2026-08-16T12:00:00Z",
+			EventTime:  eventTime.Add(time.Minute),
+		},
+	)
+	if err != nil || replayed.AlreadyApplied != 1 {
+		t.Fatalf("replay = (%+v, %v)", replayed, err)
+	}
+	for _, observation := range repository.observations {
+		if !observation.Descriptor().ObservedAt().Equal(eventTime) {
+			t.Fatalf("replay mutated observed_at = %s", observation.Descriptor().ObservedAt())
+		}
+	}
+}
+
+func TestGeminiUsageCapture_TreatsEpochEventTimeAsMissing(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGeminiUsageCaptureUsecase(repository)
+	result, err := capture.CaptureInteractiveUnavailable(
+		t.Context(),
+		usecase.GeminiUsageCaptureInput{
+			SessionID:  "session-1",
+			DeliveryID: "delivery-1",
+			EventTime:  time.Unix(0, 0).UTC(),
+		},
+	)
+	if err != nil || result.Unavailable != 1 {
+		t.Fatalf("CaptureInteractiveUnavailable() = (%+v, %v)", result, err)
+	}
+	for _, observation := range repository.observations {
+		assertUnavailableObservationNotEpoch(t, observation)
+	}
+}
+
+func TestGrokUsageCapture_ReusesFirstWriteTimeOnReplay(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGrokUsageCaptureUsecase(repository)
+	input := usecase.GrokUsageCaptureInput{SessionID: "session-1", DeliveryID: "prompt_id:prompt-1"}
+	first, err := capture.CaptureHookUnavailable(t.Context(), input)
+	if err != nil || first.Unavailable != 1 {
+		t.Fatalf("first = (%+v, %v)", first, err)
+	}
+	var firstObserved time.Time
+	for _, observation := range repository.observations {
+		assertUnavailableObservationNotEpoch(t, observation)
+		firstObserved = observation.Descriptor().ObservedAt()
+	}
+	time.Sleep(2 * time.Millisecond)
+	replayed, err := capture.CaptureHookUnavailable(t.Context(), input)
+	if err != nil || replayed.AlreadyApplied != 1 {
+		t.Fatalf("replay = (%+v, %v)", replayed, err)
+	}
+	for _, observation := range repository.observations {
+		if !observation.Descriptor().ObservedAt().Equal(firstObserved) {
+			t.Fatalf("replay observed_at = %s, want %s", observation.Descriptor().ObservedAt(), firstObserved)
+		}
+	}
+}

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -493,6 +493,8 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string, allowOffli
 		projectionCatchUp, projectionCatchUpErr := catchUpSearchProjection(ctx, d)
 		logSearchProjectionCatchUp(projectionCatchUp, projectionCatchUpErr)
 	}
+	usageRepairResult, usageRepairErr := catchUpEpochZeroHookUsage(ctx, db, epochZeroHookUsageRepairBatchSize)
+	logEpochZeroHookUsageRepair(usageRepairResult, usageRepairErr)
 	catchUpResult, catchUpErr := catchUpWorkspaceObservations(ctx, db, workspaceObservationCatchUpBatchSize)
 	if catchUpErr != nil {
 		// Catch-up is additive diagnostic coverage. A malformed historical row

--- a/infrastructure/sqlite/usage_epoch_repair.go
+++ b/infrastructure/sqlite/usage_epoch_repair.go
@@ -1,0 +1,213 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const epochZeroHookUsageRepairBatchSize = 1000
+
+const epochZeroHookUsageObservedAt = "1970-01-01T00:00:00.000000000Z"
+
+const epochZeroHookUsageSourceFilter = `
+    source_name IN ('stop_hook', 'session_end_hook', 'after_agent_hook')`
+
+const selectEpochZeroHookUsageBatch = `
+SELECT observation.observation_id,
+       observation.session_id,
+       observation.finalized_at,
+       COALESCE(
+           (SELECT event.created_at
+              FROM events AS event
+             WHERE event.session_id = observation.session_id
+               AND event.kind IN ('session_ended', 'session_started')
+             ORDER BY ts_norm(event.created_at) DESC, event.id DESC
+             LIMIT 1),
+           (SELECT event.created_at
+              FROM events AS event
+             WHERE event.session_id = observation.session_id
+             ORDER BY ts_norm(event.created_at) DESC, event.id DESC
+             LIMIT 1),
+           (SELECT session.ended_at
+              FROM sessions AS session
+             WHERE session.session_id = observation.session_id
+               AND session.ended_at IS NOT NULL
+               AND length(trim(session.ended_at)) > 0),
+           (SELECT session.started_at
+              FROM sessions AS session
+             WHERE session.session_id = observation.session_id)
+       )
+  FROM usage_observations AS observation
+ WHERE ts_norm(observation.observed_at) = ?
+   AND ` + epochZeroHookUsageSourceFilter + `
+ ORDER BY observation.observation_id
+ LIMIT ?`
+
+const updateEpochZeroHookUsageTimes = `
+UPDATE usage_observations
+   SET observed_at = ?,
+       finalized_at = CASE
+           WHEN finalized_at IS NOT NULL
+            AND ts_norm(finalized_at) = ?
+           THEN ?
+           ELSE finalized_at
+       END
+ WHERE observation_id = ?
+   AND ts_norm(observed_at) = ?`
+
+// usageObservationsRejectDescriptorUpdateSQL is the production trigger from
+// migration 000027. The repair drops it only inside one transaction so
+// observed_at can be rewritten for epoch-zero hook rows.
+const usageObservationsRejectDescriptorUpdateSQL = `
+CREATE TRIGGER usage_observations_reject_descriptor_update
+BEFORE UPDATE OF observation_id, session_id, host, source_name, source_version,
+    provider, model, scope, accounting, observed_at, snapshot_series,
+    snapshot_revision, supersedes_id
+ON usage_observations
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'usage observation descriptor is immutable');
+END;`
+
+// EpochZeroHookUsageRepairResult is the bounded outcome of one repair pass.
+type EpochZeroHookUsageRepairResult struct {
+	Selected    int
+	Repaired    int
+	Skipped     int
+	MorePending bool
+}
+
+// RepairEpochZeroHookUsageObservations backfills a bounded batch of
+// stop-hook-family rows whose observed_at is Unix epoch.
+func RepairEpochZeroHookUsageObservations(ctx context.Context, db *sql.DB, batchSize int) (EpochZeroHookUsageRepairResult, error) {
+	if batchSize <= 0 {
+		batchSize = epochZeroHookUsageRepairBatchSize
+	}
+	return catchUpEpochZeroHookUsage(ctx, db, batchSize)
+}
+
+func catchUpEpochZeroHookUsage(ctx context.Context, db *sql.DB, batchSize int) (EpochZeroHookUsageRepairResult, error) {
+	if batchSize <= 0 {
+		return EpochZeroHookUsageRepairResult{}, xerrors.Errorf("epoch-zero hook usage repair batch size must be positive")
+	}
+	exists, err := sqliteTableExists(ctx, db, "usage_observations")
+	if err != nil {
+		return EpochZeroHookUsageRepairResult{}, err
+	}
+	if !exists {
+		return EpochZeroHookUsageRepairResult{}, nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return EpochZeroHookUsageRepairResult{}, xerrors.Errorf("failed to begin epoch-zero hook usage repair: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DROP TRIGGER IF EXISTS usage_observations_reject_descriptor_update`); err != nil {
+		return EpochZeroHookUsageRepairResult{}, xerrors.Errorf("failed to drop usage descriptor trigger for repair: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, selectEpochZeroHookUsageBatch, epochZeroHookUsageObservedAt, batchSize+1)
+	if err != nil {
+		return EpochZeroHookUsageRepairResult{}, xerrors.Errorf("failed to query epoch-zero hook usage observations: %w", err)
+	}
+
+	type repairRow struct {
+		observationID string
+		sessionID     string
+		finalizedAt   sql.NullString
+		repairAt      sql.NullString
+	}
+	batch := make([]repairRow, 0, batchSize)
+	for rows.Next() {
+		var row repairRow
+		if err := rows.Scan(&row.observationID, &row.sessionID, &row.finalizedAt, &row.repairAt); err != nil {
+			_ = rows.Close()
+			return EpochZeroHookUsageRepairResult{}, xerrors.Errorf("failed to scan epoch-zero hook usage observation: %w", err)
+		}
+		batch = append(batch, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return EpochZeroHookUsageRepairResult{}, xerrors.Errorf("failed to iterate epoch-zero hook usage observations: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return EpochZeroHookUsageRepairResult{}, xerrors.Errorf("failed to close epoch-zero hook usage rows: %w", err)
+	}
+
+	result := EpochZeroHookUsageRepairResult{Selected: len(batch)}
+	if len(batch) > batchSize {
+		result.MorePending = true
+		batch = batch[:batchSize]
+		result.Selected = batchSize
+	}
+
+	for _, row := range batch {
+		repairedAt, ok := usableSessionRepairTime(row.repairAt.String)
+		if !ok {
+			result.Skipped++
+			continue
+		}
+		stamp := formatTimestamp(repairedAt)
+		if _, err := tx.ExecContext(
+			ctx,
+			updateEpochZeroHookUsageTimes,
+			stamp,
+			epochZeroHookUsageObservedAt,
+			stamp,
+			row.observationID,
+			epochZeroHookUsageObservedAt,
+		); err != nil {
+			return result, xerrors.Errorf("failed to backfill epoch-zero hook usage %s: %w", row.observationID, err)
+		}
+		result.Repaired++
+	}
+
+	if _, err := tx.ExecContext(ctx, usageObservationsRejectDescriptorUpdateSQL); err != nil {
+		return result, xerrors.Errorf("failed to restore usage descriptor trigger after repair: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return result, xerrors.Errorf("failed to commit epoch-zero hook usage repair: %w", err)
+	}
+	return result, nil
+}
+
+func usableSessionRepairTime(raw string) (time.Time, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, trimmed)
+	if err != nil || parsed.Unix() <= 0 {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}
+
+func logEpochZeroHookUsageRepair(result EpochZeroHookUsageRepairResult, err error) {
+	if err != nil {
+		slog.Error("epoch-zero hook usage repair incomplete; retrying on next initialization",
+			"selected", result.Selected,
+			"repaired", result.Repaired,
+			"skipped", result.Skipped,
+			"more_pending", result.MorePending,
+			"error", err,
+		)
+		return
+	}
+	if result.Selected == 0 {
+		return
+	}
+	slog.Info("repaired epoch-zero hook usage observation timestamps",
+		"selected", result.Selected,
+		"repaired", result.Repaired,
+		"skipped", result.Skipped,
+		"more_pending", result.MorePending,
+	)
+}

--- a/infrastructure/sqlite/usage_epoch_repair_test.go
+++ b/infrastructure/sqlite/usage_epoch_repair_test.go
@@ -1,0 +1,362 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestRepairEpochZeroHookUsage_BackfillsFromSessionBoundary(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	store := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(store).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	conn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	sessionTime := time.Date(2026, 8, 15, 18, 30, 0, 0, time.UTC)
+	seedEpochUsageFixture(t, conn, epochUsageFixture{
+		observationID: "grok:stop_hook:repaired",
+		sessionID:     "session-repaired",
+		host:          "grok",
+		sourceName:    "stop_hook",
+		sessionTime:   sessionTime,
+		withEvent:     true,
+	})
+	seedEpochUsageFixture(t, conn, epochUsageFixture{
+		observationID: "antigravity:stop_hook:repaired",
+		sessionID:     "session-repaired",
+		host:          "antigravity",
+		sourceName:    "stop_hook",
+		sessionTime:   sessionTime,
+	})
+	seedEpochUsageFixture(t, conn, epochUsageFixture{
+		observationID: "kimi:session_end_hook:repaired",
+		sessionID:     "session-repaired",
+		host:          "kimi",
+		sourceName:    "session_end_hook",
+		sessionTime:   sessionTime,
+	})
+	seedEpochUsageFixture(t, conn, epochUsageFixture{
+		observationID: "gemini:after_agent_hook:repaired",
+		sessionID:     "session-repaired",
+		host:          "gemini",
+		sourceName:    "after_agent_hook",
+		sessionTime:   sessionTime,
+	})
+	seedEpochUsageFixture(t, conn, epochUsageFixture{
+		observationID: "grok:headless_stream:leave",
+		sessionID:     "session-repaired",
+		host:          "grok",
+		sourceName:    "headless_stream",
+		sessionTime:   sessionTime,
+	})
+	seedEpochUsageFixture(t, conn, epochUsageFixture{
+		observationID: "grok:stop_hook:orphan",
+		sessionID:     "session-missing",
+		host:          "grok",
+		sourceName:    "stop_hook",
+	})
+
+	result, err := sqlite.RepairEpochZeroHookUsageObservations(ctx, conn, 10)
+	if err != nil {
+		t.Fatalf("RepairEpochZeroHookUsageObservations() error = %v", err)
+	}
+	if result.Repaired != 4 || result.Skipped != 1 || result.MorePending {
+		t.Fatalf("repair result = %+v, want repaired=4 skipped=1", result)
+	}
+
+	want := sessionTime.UTC().Format(time.RFC3339Nano)
+	for _, id := range []string{
+		"grok:stop_hook:repaired",
+		"antigravity:stop_hook:repaired",
+		"kimi:session_end_hook:repaired",
+		"gemini:after_agent_hook:repaired",
+	} {
+		assertUsageTimes(t, conn, id, want, want)
+	}
+	epoch := time.Unix(0, 0).UTC().Format(time.RFC3339Nano)
+	assertUsageTimes(t, conn, "grok:headless_stream:leave", epoch, epoch)
+	assertUsageTimes(t, conn, "grok:stop_hook:orphan", epoch, epoch)
+
+	rerun, err := sqlite.RepairEpochZeroHookUsageObservations(ctx, conn, 10)
+	if err != nil {
+		t.Fatalf("rerun error = %v", err)
+	}
+	if rerun.Repaired != 0 || rerun.Skipped != 1 || rerun.Selected != 1 {
+		t.Fatalf("rerun = %+v, want only the unrepairable orphan", rerun)
+	}
+
+	_, err = conn.Exec(`UPDATE usage_observations SET observed_at = ? WHERE observation_id = ?`,
+		time.Date(2026, 8, 16, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), "grok:stop_hook:repaired")
+	if err == nil {
+		t.Fatal("descriptor trigger did not reject observed_at update after repair")
+	}
+}
+
+func TestRepairEpochZeroHookUsage_HonorsBatchBound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	store := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(store).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	conn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	sessionTime := time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC)
+	for _, id := range []string{"grok:stop_hook:a", "grok:stop_hook:b", "grok:stop_hook:c"} {
+		seedEpochUsageFixture(t, conn, epochUsageFixture{
+			observationID: id,
+			sessionID:     "session-batch",
+			host:          "grok",
+			sourceName:    "stop_hook",
+			sessionTime:   sessionTime,
+			withEvent:     id == "grok:stop_hook:a",
+		})
+	}
+
+	first, err := sqlite.RepairEpochZeroHookUsageObservations(ctx, conn, 2)
+	if err != nil {
+		t.Fatalf("first batch error = %v", err)
+	}
+	if first.Selected != 2 || first.Repaired != 2 || !first.MorePending {
+		t.Fatalf("first batch = %+v, want selected=2 repaired=2 more_pending", first)
+	}
+	second, err := sqlite.RepairEpochZeroHookUsageObservations(ctx, conn, 2)
+	if err != nil {
+		t.Fatalf("second batch error = %v", err)
+	}
+	if second.Repaired != 1 || second.MorePending {
+		t.Fatalf("second batch = %+v, want repaired=1", second)
+	}
+}
+
+func TestInitialize_RepairsEpochZeroHookUsage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	store := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(store).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	conn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	sessionTime := time.Date(2026, 8, 13, 7, 0, 0, 0, time.UTC)
+	seedEpochUsageFixture(t, conn, epochUsageFixture{
+		observationID: "claude:stop_hook:init",
+		sessionID:     "session-init",
+		host:          "claude",
+		sourceName:    "stop_hook",
+		sessionTime:   sessionTime,
+		withEvent:     true,
+	})
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if err := sqlite.NewStoreManagementDatasource(store).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(repair) error = %v", err)
+	}
+	conn, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open(reopen) error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	want := sessionTime.UTC().Format(time.RFC3339Nano)
+	assertUsageTimes(t, conn, "claude:stop_hook:init", want, want)
+}
+
+func TestUsageCaptureUsecases_WriteNonEpochUnavailableObservations(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	store := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(store).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	repo := sqlite.NewUsageObservationDatasource(store)
+	epoch := time.Unix(0, 0).UTC()
+
+	if _, err := usecase.NewGrokUsageCaptureUsecase(repo).CaptureHookUnavailable(ctx, usecase.GrokUsageCaptureInput{
+		SessionID: "session-1", DeliveryID: "prompt_id:1",
+	}); err != nil {
+		t.Fatalf("grok capture error = %v", err)
+	}
+	if _, err := usecase.NewAntigravityUsageCaptureUsecase(nil, repo).CaptureStopUnavailable(ctx, usecase.AntigravityUsageStopInput{
+		SessionID: "session-1", BoundaryID: "turn:1",
+	}); err != nil {
+		t.Fatalf("antigravity capture error = %v", err)
+	}
+	if _, err := usecase.NewClaudeUsageCaptureUsecase(claudeUsageSourceEmpty{}, repo).Capture(ctx, usecase.ClaudeUsageCaptureInput{
+		SessionID: "session-1", DeliveryID: "event_id:stop-1",
+	}); err != nil {
+		t.Fatalf("claude capture error = %v", err)
+	}
+	if _, err := usecase.NewCodexUsageCaptureUsecase(codexUsageSourceEmpty{}, repo).Capture(ctx, usecase.CodexUsageCaptureInput{
+		SessionID: "session-1", DeliveryID: "event_id:stop-1",
+	}); err != nil {
+		t.Fatalf("codex capture error = %v", err)
+	}
+	eventTime := time.Date(2026, 8, 16, 11, 0, 0, 0, time.UTC)
+	if _, err := usecase.NewGeminiUsageCaptureUsecase(repo).CaptureInteractiveUnavailable(ctx, usecase.GeminiUsageCaptureInput{
+		SessionID: "session-1", DeliveryID: "after-agent-1", EventTime: eventTime,
+	}); err != nil {
+		t.Fatalf("gemini capture error = %v", err)
+	}
+	if _, err := usecase.NewKimiUsageCaptureUsecase(kimiUsageSourceEmpty{}, repo).Capture(ctx, usecase.KimiUsageCaptureInput{
+		SessionID: "session-1", ProviderSessionID: "provider-1", Boundary: usecase.KimiUsageBoundaryStop,
+	}); err != nil {
+		t.Fatalf("kimi capture error = %v", err)
+	}
+
+	conn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	rows, err := conn.Query(`SELECT observation_id, observed_at, finalized_at, source_name FROM usage_observations`)
+	if err != nil {
+		t.Fatalf("query usage_observations: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	count := 0
+	for rows.Next() {
+		var id, observedAt, finalizedAt, sourceName string
+		if err := rows.Scan(&id, &observedAt, &finalizedAt, &sourceName); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		count++
+		parsed, err := time.Parse(time.RFC3339Nano, observedAt)
+		if err != nil || !parsed.After(epoch) {
+			t.Fatalf("%s observed_at = %s, want after epoch", id, observedAt)
+		}
+		parsedFinal, err := time.Parse(time.RFC3339Nano, finalizedAt)
+		if err != nil || !parsedFinal.After(epoch) {
+			t.Fatalf("%s finalized_at = %s, want after epoch", id, finalizedAt)
+		}
+		if sourceName == "after_agent_hook" && !parsed.Equal(eventTime) {
+			t.Fatalf("gemini observed_at = %s, want %s", observedAt, eventTime)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if count != 6 {
+		t.Fatalf("observations = %d, want 6 host writes", count)
+	}
+}
+
+type claudeUsageSourceEmpty struct{}
+
+func (claudeUsageSourceEmpty) Load(
+	context.Context,
+	application.ClaudeUsageLoadCriteria,
+) (application.ClaudeUsageLoadResult, error) {
+	return application.ClaudeUsageLoadResult{Mode: application.ClaudeUsageModeTranscriptCalls}, nil
+}
+
+type codexUsageSourceEmpty struct{}
+
+func (codexUsageSourceEmpty) Load(
+	context.Context,
+	application.CodexUsageLoadCriteria,
+) (application.CodexUsageLoadResult, error) {
+	return application.CodexUsageLoadResult{}, nil
+}
+
+type kimiUsageSourceEmpty struct{}
+
+func (kimiUsageSourceEmpty) Load(context.Context, string) (application.KimiUsageLoadResult, error) {
+	return application.KimiUsageLoadResult{}, nil
+}
+
+type epochUsageFixture struct {
+	observationID string
+	sessionID     string
+	host          string
+	sourceName    string
+	sessionTime   time.Time
+	withEvent     bool
+}
+
+func seedEpochUsageFixture(t *testing.T, db *sql.DB, fixture epochUsageFixture) {
+	t.Helper()
+	epoch := time.Unix(0, 0).UTC().Format(time.RFC3339Nano)
+	if !fixture.sessionTime.IsZero() {
+		if _, err := db.Exec(`
+INSERT OR IGNORE INTO sessions (session_id, started_at, ended_at, client, agent, workspace)
+VALUES (?, ?, ?, 'test', 'test', 'ws')`,
+			fixture.sessionID, fixture.sessionTime.Add(-time.Hour).UTC().Format(time.RFC3339Nano), fixture.sessionTime.UTC().Format(time.RFC3339Nano),
+		); err != nil {
+			t.Fatalf("insert session: %v", err)
+		}
+	}
+	if fixture.withEvent {
+		if _, err := db.Exec(`
+INSERT INTO events (id, kind, agent, session_id, body, created_at, client, workspace)
+VALUES (?, 'session_ended', 'test', ?, 'session ended', ?, 'test', 'ws')`,
+			"event-"+fixture.observationID, fixture.sessionID, fixture.sessionTime.UTC().Format(time.RFC3339Nano),
+		); err != nil {
+			t.Fatalf("insert event: %v", err)
+		}
+	}
+	if _, err := db.Exec(`
+INSERT INTO usage_observations (
+    observation_id, session_id, host, source_name, source_version,
+    scope, accounting, status, observed_at, finalized_at, terminal_code,
+    input_state, cached_input_state, cache_write_input_state,
+    output_state, reasoning_output_state, total_state, cost_state
+) VALUES (?, ?, ?, ?, 'schema-v1',
+    'call', 'excluded', 'finalized', ?, ?, 'unknown',
+    'unavailable', 'unavailable', 'unavailable',
+    'unavailable', 'unavailable', 'unavailable', 'unavailable')`,
+		fixture.observationID, fixture.sessionID, fixture.host, fixture.sourceName, epoch, epoch,
+	); err != nil {
+		t.Fatalf("insert usage observation %s: %v", fixture.observationID, err)
+	}
+}
+
+func assertUsageTimes(t *testing.T, db *sql.DB, id, wantObserved, wantFinalized string) {
+	t.Helper()
+	var observedAt, finalizedAt string
+	if err := db.QueryRow(
+		`SELECT observed_at, finalized_at FROM usage_observations WHERE observation_id = ?`,
+		id,
+	).Scan(&observedAt, &finalizedAt); err != nil {
+		t.Fatalf("load %s: %v", id, err)
+	}
+	if observedAt != wantObserved || finalizedAt != wantFinalized {
+		t.Fatalf("%s times = (%s, %s), want (%s, %s)", id, observedAt, finalizedAt, wantObserved, wantFinalized)
+	}
+}
+
+var _ = types.SessionID("")

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -459,8 +459,14 @@ func (c *RootCLI) runHookUsage(
 			return xerrors.Errorf("failed to capture Claude usage: %w", err)
 		}
 	case "gemini":
+		var eventTime time.Time
+		if raw, ok := canonicalGeminiHookTimestamp(hookPayloadString(payload, "timestamp", "")); ok {
+			if parsed, parseErr := time.Parse(time.RFC3339Nano, raw); parseErr == nil {
+				eventTime = parsed
+			}
+		}
 		_, err = c.geminiUsage.CaptureInteractiveUnavailable(ctx, usecase.GeminiUsageCaptureInput{
-			SessionID: sessionID, DeliveryID: deliveryID,
+			SessionID: sessionID, DeliveryID: deliveryID, EventTime: eventTime,
 		})
 		if err != nil {
 			return xerrors.Errorf("failed to capture Gemini usage availability: %w", err)


### PR DESCRIPTION
## Summary
- Stop-hook-family unavailable writers stamp wall clock (or payload event time), never Unix epoch 0.
- Store Initialize backfills existing epoch-zero hook rows from the session's nearest event or boundary.

Closes #2013
Leaves parent #2025 open.

## Test plan
- [x] `go test ./application/usecase/ ./infrastructure/sqlite/ -run 'TestGrokUsageCapture_|TestClaudeUsageCapture_|TestRepairEpochZero|TestInitialize_RepairsEpochZero|TestUsageCaptureUsecases_WriteNonEpoch'`