### PR TITLE
fix: rate-limit the per-command store-compact reminder

### DIFF
--- a/presentation/cli/compact_reclaim_space_unix.go
+++ b/presentation/cli/compact_reclaim_space_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package cli
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func volumeAvailableBytes(path string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %s: %w", path, err)
+	}
+	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
+}

--- a/presentation/cli/compact_reclaim_space_unsupported.go
+++ b/presentation/cli/compact_reclaim_space_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package cli
+
+import "errors"
+
+func volumeAvailableBytes(string) (uint64, error) {
+	return 0, errors.New("volume free-space probe is unavailable on this platform")
+}

--- a/presentation/cli/compact_reclaim_warning.go
+++ b/presentation/cli/compact_reclaim_warning.go
@@ -3,11 +3,16 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/duck8823/traceary/presentation"
 )
+
+const compactReclaimWarnInterval = 24 * time.Hour
 
 func attachCompactReclaimWarning(root *cobra.Command) {
 	root.PersistentPostRun = func(cmd *cobra.Command, _ []string) {
@@ -34,14 +39,52 @@ func emitCompactReclaimWarning(cmd *cobra.Command) {
 	if info.Size() < cfg.Compact.ReclaimWarnBytes {
 		return
 	}
-	_, _ = fmt.Fprintf(
-		cmd.ErrOrStderr(),
-		"%s\n",
-		Localize(
-			"TRACEARY: store can reclaim space; run `traceary store compact`",
-			"TRACEARY: ストアに回収できる領域があります。`traceary store compact` を実行してください",
-		),
+	now := compactReclaimNow()
+	if !shouldEmitCompactReclaimWarning(path, now) {
+		return
+	}
+	message := compactReclaimWarningMessage(path, info.Size())
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", message)
+	_ = recordCompactReclaimWarning(path, now)
+}
+
+func compactReclaimWarningMessage(storePath string, storeSize int64) string {
+	if storeSize > 0 {
+		if free, err := volumeAvailableBytes(filepath.Dir(storePath)); err == nil && free < uint64(storeSize) {
+			return Localize(
+				"TRACEARY: store can reclaim space, but this volume does not have enough free bytes for a compact replica; attach another disk before running `traceary store compact`",
+				"TRACEARY: ストアに回収できる領域がありますが、このボリュームには compact レプリカ分の空きがありません。別ディスクを接続してから `traceary store compact` を実行してください",
+			)
+		}
+	}
+	return Localize(
+		"TRACEARY: store can reclaim space; run `traceary store compact`",
+		"TRACEARY: ストアに回収できる領域があります。`traceary store compact` を実行してください",
 	)
+}
+
+func shouldEmitCompactReclaimWarning(storePath string, now time.Time) bool {
+	raw, err := os.ReadFile(compactReclaimWarnStatePath(storePath))
+	if err != nil {
+		return true
+	}
+	last, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(raw)))
+	if err != nil {
+		return true
+	}
+	return !last.After(now) && now.Sub(last) >= compactReclaimWarnInterval
+}
+
+func recordCompactReclaimWarning(storePath string, now time.Time) error {
+	path := compactReclaimWarnStatePath(storePath)
+	if err := os.WriteFile(path, []byte(now.UTC().Format(time.RFC3339Nano)+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write compact reclaim warn state: %w", err)
+	}
+	return nil
+}
+
+func compactReclaimWarnStatePath(storePath string) string {
+	return storePath + ".reclaim-warn"
 }
 
 func shouldSkipCompactReclaimWarning(cmd *cobra.Command) bool {
@@ -65,3 +108,5 @@ func lookupDBPathFlag(cmd *cobra.Command) string {
 	}
 	return ""
 }
+
+var compactReclaimNow = time.Now

--- a/presentation/cli/compact_reclaim_warning_internal_test.go
+++ b/presentation/cli/compact_reclaim_warning_internal_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/duck8823/traceary/presentation"
+)
+
+func TestShouldEmitCompactReclaimWarningRateLimit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store := filepath.Join(dir, "traceary.db")
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	if !shouldEmitCompactReclaimWarning(store, now) {
+		t.Fatal("missing state file should emit")
+	}
+	if err := recordCompactReclaimWarning(store, now); err != nil {
+		t.Fatal(err)
+	}
+	if shouldEmitCompactReclaimWarning(store, now.Add(23*time.Hour)) {
+		t.Fatal("should not emit again within 24h")
+	}
+	if !shouldEmitCompactReclaimWarning(store, now.Add(24*time.Hour)) {
+		t.Fatal("should emit after 24h")
+	}
+}
+
+func TestEmitCompactReclaimWarningOncePerDay(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := filepath.Join(home, ".config", "traceary")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"compact":{"reclaim_warn_bytes":1}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := presentation.LoadConfig().Compact.ReclaimWarnBytes; got != 1 {
+		t.Fatalf("ReclaimWarnBytes = %d, want 1", got)
+	}
+
+	store := filepath.Join(t.TempDir(), "traceary.db")
+	if err := os.WriteFile(store, []byte("xx"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 16, 15, 0, 0, 0, time.UTC)
+	compactReclaimNow = func() time.Time { return now }
+	t.Cleanup(func() { compactReclaimNow = time.Now })
+
+	root := &cobra.Command{Use: "traceary"}
+	leaf := &cobra.Command{Use: "list", Run: func(_ *cobra.Command, _ []string) {}}
+	root.PersistentFlags().String("db-path", "", "")
+	root.AddCommand(leaf)
+	attachCompactReclaimWarning(root)
+
+	run := func() string {
+		errBuf := &bytes.Buffer{}
+		root.SetOut(&bytes.Buffer{})
+		root.SetErr(errBuf)
+		root.SetArgs([]string{"list", "--db-path", store})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		return errBuf.String()
+	}
+
+	first := run()
+	if !strings.Contains(first, "store can reclaim space") {
+		t.Fatalf("first emit = %q, want reclaim trailer", first)
+	}
+	second := run()
+	if strings.Contains(second, "store can reclaim space") {
+		t.Fatalf("second emit = %q, want rate-limited silence", second)
+	}
+}


### PR DESCRIPTION
Closes #2016

Rate-limit the compact reclaim trailer to once per 24 hours per store. When the volume cannot hold a replica, the trailer says so instead of recommending an impossible command. Doctor output is unchanged.

Leaves parent #2025 open.