### PR TITLE
fix: bound timeline and replay walks on created_at_norm

### DIFF
--- a/application/types/timeline_block.go
+++ b/application/types/timeline_block.go
@@ -86,6 +86,7 @@ type TimelineBlock struct {
 	eventCount         int
 	agents             []string
 	workspaceBreakdown []TimelineWorkspaceBreakdown
+	scanTruncated      bool
 }
 
 // TimelineBlockOf creates a TimelineBlock.
@@ -120,6 +121,16 @@ func (b TimelineBlock) Agents() []string { return slices.Clone(b.agents) }
 // WorkspaceBreakdown returns per-workspace activity inside the block.
 func (b TimelineBlock) WorkspaceBreakdown() []TimelineWorkspaceBreakdown {
 	return slices.Clone(b.workspaceBreakdown)
+}
+
+// ScanTruncated reports whether the newest-first metadata walk hit its scan
+// cap. JSON renderers must ignore this; it is a text-coverage signal only.
+func (b TimelineBlock) ScanTruncated() bool { return b.scanTruncated }
+
+// WithScanTruncated returns a copy marked as truncated by the event scan cap.
+func (b TimelineBlock) WithScanTruncated(truncated bool) TimelineBlock {
+	b.scanTruncated = truncated
+	return b
 }
 
 // Workspaces returns the distinct workspaces involved in the block, derived

--- a/application/usecase/replay_usecase_impl.go
+++ b/application/usecase/replay_usecase_impl.go
@@ -210,7 +210,9 @@ func (u *replayUsecase) loadFailureHotspots(ctx context.Context, criteria apptyp
 	// Widen the underlying scan so the top-N cluster count is
 	// statistically meaningful; the limit applied in ListRecent is the
 	// number of raw failure events we look at, not the number of
-	// clusters we emit.
+	// clusters we emit. Timeline/hotspot collection stays on the
+	// created_at_norm listing path (ListRecent) with this hard cap so
+	// replay cannot walk the whole store (#2014).
 	const hotspotScanMultiplier = 20
 	scanLimit := limit * hotspotScanMultiplier
 	events, err := u.eventQuery.ListRecent(

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -531,6 +531,7 @@ func (d *EventDatasource) ListTimelineBlocks(
 		workspace.String(), workspace.String(),
 		fromValue, fromValue,
 		toValue, toValue,
+		timelineEventScanCap(limit),
 		gapSeconds,
 		limit,
 	)
@@ -659,6 +660,23 @@ func (d *EventDatasource) ListTimelineBlocks(
 	}
 
 	return blocks, nil
+}
+
+// timelineEventScanCap bounds the newest-first metadata walk so an unbounded
+// default window cannot read every event body. It is large enough to fill the
+// requested block quota on typical work, and small enough that a 36 GiB store
+// does not pay a full-table window function.
+func timelineEventScanCap(limit int) int {
+	if limit < 1 {
+		limit = 1
+	}
+	const perBlock = 250
+	const floor = 2000
+	scanCap := limit * perBlock
+	if scanCap < floor {
+		return floor
+	}
+	return scanCap
 }
 
 // firstNonBlankCandidate decodes ranked candidate ids in order and returns the

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -525,13 +525,14 @@ func (d *EventDatasource) ListTimelineBlocks(
 		toValue = formatTimestamp(to)
 	}
 
+	scanCap := timelineEventScanCap(limit)
 	rows, err := db.QueryContext(
 		ctx,
 		listTimelineBlocksQuery,
 		workspace.String(), workspace.String(),
 		fromValue, fromValue,
 		toValue, toValue,
-		timelineEventScanCap(limit),
+		scanCap,
 		gapSeconds,
 		limit,
 	)
@@ -566,6 +567,7 @@ func (d *EventDatasource) ListTimelineBlocks(
 
 	var blockOrder []int
 	blockMap := make(map[int]*blockAccumulator)
+	var scannedEventCount int
 
 	for rows.Next() {
 		var (
@@ -581,6 +583,7 @@ func (d *EventDatasource) ListTimelineBlocks(
 			promptIDsJSON     string
 			compactIDsJSON    string
 			transcriptIDsJSON string
+			rowScannedCount   int
 		)
 		if err := rows.Scan(
 			&blockNum,
@@ -595,9 +598,11 @@ func (d *EventDatasource) ListTimelineBlocks(
 			&promptIDsJSON,
 			&compactIDsJSON,
 			&transcriptIDsJSON,
+			&rowScannedCount,
 		); err != nil {
 			return nil, xerrors.Errorf("failed to scan timeline block: %w", err)
 		}
+		scannedEventCount = rowScannedCount
 		firstPromptBody, err := d.firstNonBlankCandidate(ctx, db, promptIDsJSON, hasCodec)
 		if err != nil {
 			return nil, err
@@ -647,16 +652,21 @@ func (d *EventDatasource) ListTimelineBlocks(
 		return nil, xerrors.Errorf("failed to iterate timeline blocks: %w", err)
 	}
 
+	scanTruncated := scannedEventCount == scanCap
 	blocks := make([]apptypes.TimelineBlock, 0, len(blockOrder))
 	for _, num := range blockOrder {
 		accum := blockMap[num]
-		blocks = append(blocks, apptypes.TimelineBlockOf(
+		block := apptypes.TimelineBlockOf(
 			accum.blockStart,
 			accum.blockEnd,
 			accum.eventCount,
 			accum.agents,
 			accum.breakdown,
-		))
+		)
+		if scanTruncated {
+			block = block.WithScanTruncated(true)
+		}
+		blocks = append(blocks, block)
 	}
 
 	return blocks, nil

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -160,7 +160,8 @@ SELECT
   COALESCE(wr.ws_agents, '') AS ws_agents,
   COALESCE(wr.first_prompt_ids, '[]') AS first_prompt_ids,
   COALESCE(wr.compact_summary_ids, '[]') AS compact_summary_ids,
-  COALESCE(wr.first_transcript_ids, '[]') AS first_transcript_ids
+  COALESCE(wr.first_transcript_ids, '[]') AS first_transcript_ids,
+  (SELECT COUNT(*) FROM newest_events) AS scanned_event_count
 FROM top_blocks tb
 JOIN ws_rows wr ON wr.block_num = tb.block_num
 ORDER BY tb.block_start DESC, wr.ws_event_count DESC, wr.workspace

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -1,42 +1,42 @@
 -- Gap-based work block detection with per-workspace breakdown.
 --
+-- newest_events walks created_at_norm newest-first with a scan cap so an
+-- unbounded default window cannot materialize every event (or any body).
+-- Bodies are never selected here; Go decodes ranked candidate ids only.
+--
 -- The CTE chain:
---   ordered_events : filter + LAG over created_at
+--   newest_events  : bounded newest-first metadata (indexed created_at_norm)
+--   ordered_events : LAG over that bounded set only
 --   blocks         : assign block_num using gap threshold
 --   block_summary  : one row per block with aggregates
---   top_blocks    : block_summary ordered DESC + LIMIT N
---   first_prompt   : leading prompt candidate ids per (block, workspace)
---   last_compact   : trailing compact_summary candidate ids per (block, workspace)
---   ws_rows        : one row per (block, workspace) with counts / kinds /
---                    summary candidate ids
---
--- Summary candidates are returned as ranked id lists, never as bodies: an
--- encoded body is a BLOB this query cannot read, so Go decodes in rank order
--- and keeps the first non-blank one (#1685 D6, #1746). TRIM(body) != '' still
--- drops identity whitespace for free. Encoded blanks and tab/newline
--- plaintext survive TRIM, so the list is unbounded — a depth cap would fall
--- through to the next kind instead of the kind's own later candidate.
---
--- The final SELECT returns one row per (block, workspace) for the top N
--- blocks; Go assembles per-block breakdown by grouping on block_num.
---
--- When workspace is filtered, LAG operates only on matching rows (correct).
--- When workspace is empty (all workspaces), cross-workspace gaps are treated
--- as continuous work, which is the intended behavior for overview timelines.
-WITH ordered_events AS (
+--   top_blocks     : block_summary ordered DESC + LIMIT N
+--   first_prompt / last_compact / first_transcript : candidate ids
+--   ws_rows        : one row per (block, workspace)
+WITH newest_events AS (
   SELECT
     e.id,
     e.kind,
     e.agent,
     e.workspace,
-    e.body,
     e.created_at,
-    ts_norm(e.created_at) AS created_at_norm,
-    LAG(e.created_at) OVER (ORDER BY ts_norm(e.created_at), e.id) AS prev_created_at
+    e.created_at_norm
   FROM events e
   WHERE (? = '' OR e.workspace = ?)
-    AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-    AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+    AND (? = '' OR e.created_at_norm >= ?)
+    AND (? = '' OR e.created_at_norm < ?)
+  ORDER BY e.created_at_norm DESC, e.id DESC
+  LIMIT ?
+),
+ordered_events AS (
+  SELECT
+    id,
+    kind,
+    agent,
+    workspace,
+    created_at,
+    created_at_norm,
+    LAG(created_at) OVER (ORDER BY created_at_norm, id) AS prev_created_at
+  FROM newest_events
 ),
 blocks AS (
   SELECT
@@ -72,7 +72,6 @@ prompt_ranked AS (
     ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm, id) AS rn
   FROM blocks
   WHERE kind = 'prompt'
-    AND TRIM(body) != ''
 ),
 first_prompt AS (
   SELECT
@@ -94,7 +93,6 @@ compact_ranked AS (
     ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm DESC, id DESC) AS rn
   FROM blocks
   WHERE kind = 'compact_summary'
-    AND TRIM(body) != ''
 ),
 last_compact AS (
   SELECT
@@ -116,7 +114,6 @@ transcript_ranked AS (
     ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm, id) AS rn
   FROM blocks
   WHERE kind = 'transcript'
-    AND TRIM(body) != ''
 ),
 first_transcript AS (
   SELECT

--- a/infrastructure/sqlite/timeline_query_plan_internal_test.go
+++ b/infrastructure/sqlite/timeline_query_plan_internal_test.go
@@ -1,0 +1,67 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestListTimelineBlocksQueryUsesCreatedAtNormIndex(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows, err := db.QueryContext(
+		ctx,
+		"EXPLAIN QUERY PLAN "+listTimelineBlocksQuery,
+		"", "", "", "", "", "", 2000, 900, 10,
+	)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	t.Cleanup(func() { _ = rows.Close() })
+	var plan []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+	joined := strings.Join(plan, "\n")
+	if !strings.Contains(strings.ToLower(joined), "idx_events_created_at_norm_id_desc") &&
+		!strings.Contains(strings.ToLower(joined), "created_at_norm") {
+		t.Fatalf("query plan does not mention created_at_norm index:\n%s", joined)
+	}
+	if strings.Contains(listTimelineBlocksQuery, "e.body") {
+		t.Fatal("gap-walk SQL still selects e.body")
+	}
+}
+
+func TestTimelineEventScanCapScalesWithLimit(t *testing.T) {
+	t.Parallel()
+	if got := timelineEventScanCap(1); got != 2000 {
+		t.Fatalf("scan cap for limit 1 = %d, want floor 2000", got)
+	}
+	if got := timelineEventScanCap(20); got != 5000 {
+		t.Fatalf("scan cap for limit 20 = %d, want 5000", got)
+	}
+}

--- a/infrastructure/sqlite/timeline_store_test.go
+++ b/infrastructure/sqlite/timeline_store_test.go
@@ -28,13 +28,22 @@ CREATE TABLE events (
     body TEXT NOT NULL,
     body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
+    created_at_norm TEXT,
     source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
 			Data: []byte(`
 ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
-ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
+ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';
+CREATE INDEX idx_events_created_at_norm_id_desc ON events(created_at_norm DESC, id DESC);
+CREATE TRIGGER events_created_at_norm_after_insert
+AFTER INSERT ON events
+FOR EACH ROW
+WHEN NEW.created_at_norm IS NULL
+BEGIN
+    UPDATE events SET created_at_norm = NEW.created_at WHERE id = NEW.id;
+END;`),
 		},
 	}
 

--- a/infrastructure/sqlite/timeline_store_test.go
+++ b/infrastructure/sqlite/timeline_store_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"testing/fstest"
@@ -342,6 +343,31 @@ END;`),
 		}
 		if len(blocks) != 2 {
 			t.Fatalf("len(blocks) = %d, want 2", len(blocks))
+		}
+	})
+
+	t.Run("marks scan truncation when newest-first cap is hit inside one block", func(t *testing.T) {
+		t.Parallel()
+		ds := newDatasource(t)
+		// limit=2 → scan cap 2000. One contiguous block of 2001 events is
+		// fewer than the block limit, so only the scan-cap flag can disclose
+		// that older events were not walked.
+		base := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+		for i := 0; i < 2001; i++ {
+			saveEvent(t, ds, fmt.Sprintf("scan-%04d", i), "ws", base.Add(time.Duration(i)*time.Second))
+		}
+		blocks, err := ds.ListTimelineBlocks(context.Background(), types.Workspace(""), time.Time{}, time.Time{}, 900, 2)
+		if err != nil {
+			t.Fatalf("ListTimelineBlocks() error = %v", err)
+		}
+		if len(blocks) != 1 {
+			t.Fatalf("len(blocks) = %d, want 1", len(blocks))
+		}
+		if !blocks[0].ScanTruncated() {
+			t.Fatal("ScanTruncated() = false, want true when the newest-first cap is full")
+		}
+		if blocks[0].EventCount() != 2000 {
+			t.Fatalf("EventCount() = %d, want 2000 scanned events", blocks[0].EventCount())
 		}
 	})
 }

--- a/presentation/cli/timeline.go
+++ b/presentation/cli/timeline.go
@@ -118,11 +118,24 @@ func (c *RootCLI) runTimeline(ctx context.Context, output io.Writer, input timel
 	if err := writeTimelineText(output, blocks, textOpts); err != nil {
 		return err
 	}
-	if input.limit > 0 && len(blocks) == input.limit {
-		if _, err := fmt.Fprintln(output, Localize(
-			"coverage=partial (block limit)",
-			"coverage=partial (block limit)",
-		)); err != nil {
+	scanTruncated := false
+	for _, block := range blocks {
+		if block.ScanTruncated() {
+			scanTruncated = true
+			break
+		}
+	}
+	coverage := ""
+	switch {
+	case input.limit > 0 && len(blocks) == input.limit && scanTruncated:
+		coverage = "coverage=partial (block limit; scan cap)"
+	case input.limit > 0 && len(blocks) == input.limit:
+		coverage = "coverage=partial (block limit)"
+	case scanTruncated:
+		coverage = "coverage=partial (scan cap)"
+	}
+	if coverage != "" {
+		if _, err := fmt.Fprintln(output, Localize(coverage, coverage)); err != nil {
 			return xerrors.Errorf("failed to print timeline coverage: %w", err)
 		}
 	}

--- a/presentation/cli/timeline.go
+++ b/presentation/cli/timeline.go
@@ -115,7 +115,18 @@ func (c *RootCLI) runTimeline(ctx context.Context, output io.Writer, input timel
 	}
 
 	textOpts := eventTextFormatOptions{utc: input.utc, location: input.location}
-	return writeTimelineText(output, blocks, textOpts)
+	if err := writeTimelineText(output, blocks, textOpts); err != nil {
+		return err
+	}
+	if input.limit > 0 && len(blocks) == input.limit {
+		if _, err := fmt.Fprintln(output, Localize(
+			"coverage=partial (block limit)",
+			"coverage=partial (block limit)",
+		)); err != nil {
+			return xerrors.Errorf("failed to print timeline coverage: %w", err)
+		}
+	}
+	return nil
 }
 
 func computeKindCounts(kinds []string) map[string]int {

--- a/presentation/cli/timeline_test.go
+++ b/presentation/cli/timeline_test.go
@@ -203,4 +203,73 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 			t.Fatalf("Execute() error = nil, want error for invalid date")
 		}
 	})
+
+	t.Run("prints scan-cap coverage when the newest-first walk is truncated", func(t *testing.T) {
+		t.Parallel()
+
+		block := apptypes.TimelineBlockOf(
+			time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+			time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC),
+			2000,
+			[]string{"claude"},
+			[]apptypes.TimelineWorkspaceBreakdown{
+				apptypes.TimelineWorkspaceBreakdownOf(
+					"ws",
+					2000,
+					[]string{"command_executed"},
+					[]string{"claude"},
+					"",
+					apptypes.TimelineSummarySourceKindCounts,
+				),
+			},
+		).WithScanTruncated(true)
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(&eventUsecaseStub{
+				timelineBlocks: []apptypes.TimelineBlock{block},
+			}),
+		).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--utc"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !strings.Contains(stdout.String(), "coverage=partial (scan cap)") {
+			t.Fatalf("output missing scan-cap coverage, got: %s", stdout.String())
+		}
+	})
+
+	t.Run("JSON output does not include scan-cap coverage text", func(t *testing.T) {
+		t.Parallel()
+
+		block := apptypes.TimelineBlockOf(
+			time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+			time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC),
+			2000,
+			[]string{"claude"},
+			nil,
+		).WithScanTruncated(true)
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(&eventUsecaseStub{
+				timelineBlocks: []apptypes.TimelineBlock{block},
+			}),
+		).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--json"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if strings.Contains(stdout.String(), "coverage=partial") {
+			t.Fatalf("JSON output must not print coverage text, got: %s", stdout.String())
+		}
+	})
 }


### PR DESCRIPTION
Closes #2014

Timeline gap-walk no longer selects event bodies. It pages newest-first on created_at_norm with an internal scan cap and prints coverage=partial when the existing block limit is hit. Replay keeps using the same ListTimelineBlocks path.

Leaves parent #2025 open.