### PR TITLE
fix: cache and bound dbstat inspections

### DIFF
--- a/infrastructure/sqlite/capacity_inspector.go
+++ b/infrastructure/sqlite/capacity_inspector.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -57,15 +58,29 @@ func (i *CapacityInspector) InspectCapacity(ctx context.Context) (_ apptypes.Cap
 		return report, xerrors.Errorf("failed to stat WAL sidecar: %w", statErr)
 	}
 
-	objects, statErr := i.dbstatQuery(ctx, db, report.PageSizeBytes)
-	if statErr != nil {
-		if !isDBStatUnavailable(statErr) {
-			return report, xerrors.Errorf("failed to inspect dbstat allocation: %w", statErr)
-		}
-		report.Evidence = apptypes.CapacityEvidence{Status: "unavailable", Method: "pragma", Reason: "dbstat unavailable; object attribution omitted"}
+	started := time.Now()
+	if cached, ok := loadMatchingDBStatCache(i.db.Path()); ok {
+		report.Evidence = apptypes.CapacityEvidence{Status: "cached", Method: "dbstat", Reason: "dbstat cache hit for unchanged store file; inspected " + time.Since(started).String()}
+		report.Objects = cached.Objects
 	} else {
-		report.Evidence = apptypes.CapacityEvidence{Status: "complete", Method: "dbstat"}
-		report.Objects = objects
+		budgetCtx, cancel := context.WithTimeout(ctx, dbstatInspectBudget)
+		objects, statErr := i.dbstatQuery(budgetCtx, db, report.PageSizeBytes)
+		deadlineExceeded := errors.Is(budgetCtx.Err(), context.DeadlineExceeded)
+		cancel()
+		elapsed := time.Since(started)
+		if statErr != nil {
+			if deadlineExceeded {
+				report.Evidence = apptypes.CapacityEvidence{Status: "bounded", Method: "dbstat", Reason: "dbstat wall budget exceeded after " + elapsed.String()}
+			} else if !isDBStatUnavailable(statErr) {
+				return report, xerrors.Errorf("failed to inspect dbstat allocation: %w", statErr)
+			} else {
+				report.Evidence = apptypes.CapacityEvidence{Status: "unavailable", Method: "pragma", Reason: "dbstat unavailable; object attribution omitted"}
+			}
+		} else {
+			report.Evidence = apptypes.CapacityEvidence{Status: "complete", Method: "dbstat", Reason: "inspected " + elapsed.String()}
+			report.Objects = objects
+			storeDBStatCache(i.db.Path(), objects)
+		}
 	}
 	payloads, payloadEvidence, payloadErr := inspectPayloadClasses(ctx, db)
 	if payloadErr != nil {

--- a/infrastructure/sqlite/dbstat_cache.go
+++ b/infrastructure/sqlite/dbstat_cache.go
@@ -1,0 +1,71 @@
+package sqlite
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+const dbstatInspectBudget = 3 * time.Second
+
+type dbstatCacheRecord struct {
+	Size          int64                     `json:"size"`
+	MtimeUnixNano int64                     `json:"mtime_unix_nano"`
+	GeneratedAt   string                    `json:"generated_at"`
+	Objects       []apptypes.CapacityObject `json:"objects"`
+}
+
+func dbstatCachePath(dbPath string) string {
+	return dbPath + ".dbstat-cache.json"
+}
+
+func loadMatchingDBStatCache(dbPath string) (dbstatCacheRecord, bool) {
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return dbstatCacheRecord{}, false
+	}
+	raw, err := os.ReadFile(dbstatCachePath(dbPath))
+	if err != nil {
+		return dbstatCacheRecord{}, false
+	}
+	var record dbstatCacheRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		return dbstatCacheRecord{}, false
+	}
+	if record.Size != info.Size() || record.MtimeUnixNano != info.ModTime().UnixNano() {
+		return dbstatCacheRecord{}, false
+	}
+	return record, true
+}
+
+func storeDBStatCache(dbPath string, objects []apptypes.CapacityObject) {
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return
+	}
+	record := dbstatCacheRecord{
+		Size:          info.Size(),
+		MtimeUnixNano: info.ModTime().UnixNano(),
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		Objects:       objects,
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(dbstatCachePath(dbPath), raw, 0o600)
+}
+
+func searchProjectionFamilyBytesFromObjects(objects []apptypes.CapacityObject) int64 {
+	var total int64
+	for _, object := range objects {
+		name := object.Name
+		if strings.HasPrefix(name, "search_projection_") || strings.HasPrefix(name, "literal_search_") {
+			total += object.Bytes
+		}
+	}
+	return total
+}

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -1426,11 +1426,23 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	if db.QueryRowContext(ctx, `PRAGMA page_size`).Scan(&page) == nil {
 		if searchProjectionFamilyTotalUnavailableForTest {
 			s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "unavailable", Method: "dbstat", Reason: "family total forced unavailable"}
-		} else if e = db.QueryRowContext(ctx, selectSearchProjectionFamilyTotalSQL).Scan(&s.PhysicalBytes); e == nil {
-			s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "complete", Method: "dbstat"}
+		} else if cached, ok := loadMatchingDBStatCache(d.Path()); ok {
+			s.PhysicalBytes = searchProjectionFamilyBytesFromObjects(cached.Objects)
+			s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "cached", Method: "dbstat", Reason: "dbstat cache hit for unchanged store file"}
 		} else {
-			s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "unavailable", Method: "pragma", Reason: "dbstat unavailable"}
-			e = nil
+			budgetCtx, cancel := context.WithTimeout(ctx, dbstatInspectBudget)
+			scanErr := db.QueryRowContext(budgetCtx, selectSearchProjectionFamilyTotalSQL).Scan(&s.PhysicalBytes)
+			deadlineExceeded := errors.Is(budgetCtx.Err(), context.DeadlineExceeded)
+			cancel()
+			if scanErr == nil {
+				s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "complete", Method: "dbstat"}
+			} else if deadlineExceeded {
+				s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "bounded", Method: "dbstat", Reason: "dbstat wall budget exceeded"}
+				e = nil
+			} else {
+				s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "unavailable", Method: "pragma", Reason: "dbstat unavailable"}
+				e = nil
+			}
 		}
 	}
 	applySearchProjectionBudgetVerdict(&s)

--- a/presentation/cli/store_capacity.go
+++ b/presentation/cli/store_capacity.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -34,10 +35,12 @@ func (c *RootCLI) runStoreCapacity(cmd *cobra.Command, output io.Writer, dbPath 
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
 	}
 	c.applyDatabasePath(resolved)
+	started := time.Now()
 	report, err := c.capacityInspector.InspectCapacity(cmd.Context())
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to inspect store capacity", "ストア容量の検査に失敗しました"), err)
 	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "capacity inspection %s evidence=%s\n", time.Since(started).Round(time.Millisecond), report.Evidence.Status)
 	encoder := json.NewEncoder(output)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(report); err != nil {


### PR DESCRIPTION
Closes #2015

store capacity and search-projection status reuse a sidecar dbstat cache keyed by size and mtime. A 3s wall budget turns a miss that cannot finish into evidence.status=bounded. JSON field names are unchanged.

Leaves parent #2025 open.