### PR TITLE
fix: emit host hook and config checks on large-store doctor

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -318,8 +318,12 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 				Message: localizef("failed to resolve project directory: %v", "project directory の解決に失敗しました: %v", projectDirErr),
 			})
 			report.Checks = append(report.Checks, c.inspectPluginVersionChecks(input.currentVersion)...)
+			report.Checks = append(report.Checks, inspectDoctorConfig())
+			report.Checks = append(report.Checks, c.inspectHookMemoryExtractDiagnostics(time.Now().UTC()))
+			report.Checks = append(report.Checks, c.inspectHookGrokTranscriptDiagnostics(time.Now().UTC()))
 		} else {
 			report.Checks = append(report.Checks, c.hostPackageIdentityChecks(ctx, resolvedClients, resolvedProjectDir, input.currentVersion)...)
+			c.appendFilesystemHostDoctorChecks(ctx, report, resolvedClients, resolvedProjectDir, resolvedDBPath)
 		}
 		return report, nil
 	}

--- a/presentation/cli/doctor_filesystem_host.go
+++ b/presentation/cli/doctor_filesystem_host.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// appendFilesystemHostDoctorChecks emits host-file hook and config checks
+// that never open the Traceary SQLite store. Large-store doctor uses this
+// so operators still see gemini-config / hook queues / cancellations.
+func (c *RootCLI) appendFilesystemHostDoctorChecks(
+	ctx context.Context,
+	report *doctorReport,
+	clients []string,
+	projectDir, dbPath string,
+) {
+	if report == nil {
+		return
+	}
+	now := time.Now().UTC()
+	report.Checks = append(report.Checks, inspectDoctorConfig())
+	report.Checks = append(report.Checks, c.inspectHookMemoryExtractDiagnostics(now))
+	report.Checks = append(report.Checks, c.inspectHookGrokTranscriptDiagnostics(now))
+	if c.hooksOrchestrator == nil {
+		return
+	}
+	for _, targetClient := range clients {
+		switch targetClient {
+		case "kimi", "antigravity", "grok":
+			// Native package identity already covers these hosts.
+			continue
+		}
+		outputPath, pathErr := c.hooksOrchestrator.ResolveInstallPath(targetClient, projectDir, types.None[string]())
+		if pathErr != nil {
+			report.Checks = append(report.Checks, doctorCheck{
+				Name:    targetClient + "-config",
+				Status:  doctorStatusFail,
+				Message: localizef("failed to resolve %s config path: %v", "%s の設定パス解決に失敗しました: %v", targetClient, pathErr),
+			})
+			continue
+		}
+		var check doctorCheck
+		if targetClient == "codex" {
+			pluginState := c.detectCodexPluginHookFallback()
+			if pluginState.PluginEnabled {
+				trust := codexPluginHookTrustProbeFunc(ctx, projectDir, pluginState.PluginKey, c.hooksInspector.ExtractManagedKeyFromEntry)
+				report.Checks = append(report.Checks, codexPluginHookTrustCheck(trust))
+				check = c.inspectCodexConfigWithHookTrust(ctx, outputPath, projectDir, trust)
+			} else {
+				check = c.inspectClaudeOrConfigFile(ctx, targetClient, outputPath, projectDir)
+			}
+		} else {
+			check = c.inspectClaudeOrConfigFile(ctx, targetClient, outputPath, projectDir)
+		}
+		c.attachDoctorConfigFix(&check, targetClient, outputPath, projectDir)
+		report.Checks = append(report.Checks, check)
+		if targetClient == "claude" {
+			report.Checks = append(report.Checks, c.inspectClaudeHookCancellationDiagnosticsFilesystem(ctx, dbPath, projectDir))
+			if cacheCheck := c.inspectClaudePluginCacheStatus(); cacheCheck != nil {
+				report.Checks = append(report.Checks, *cacheCheck)
+			}
+		}
+		if globalCheck := c.inspectGlobalConfigForClient(targetClient); globalCheck != nil {
+			report.Checks = append(report.Checks, *globalCheck)
+		}
+		report.Checks = append(report.Checks, inspectHostCapabilityGaps(targetClient, outputPath)...)
+	}
+}

--- a/presentation/cli/doctor_host_package_identity_internal_test.go
+++ b/presentation/cli/doctor_host_package_identity_internal_test.go
@@ -443,7 +443,6 @@ func TestDoctorLargeStore_BoundedSetStaysBounded(t *testing.T) {
 		t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
 	}
 	forbidden := []string{
-		"claude-config", "codex-config", "gemini-config",
 		"claude-event-coverage", "codex-event-coverage", "gemini-event-coverage",
 		"memory-inbox", "store-growth-budget", "version",
 	}
@@ -455,5 +454,13 @@ func TestDoctorLargeStore_BoundedSetStaysBounded(t *testing.T) {
 	diagnostics := largeStoreCheckByName(report, "large-store-diagnostics")
 	if diagnostics.Status != doctorStatusWarn {
 		t.Fatalf("large-store-diagnostics = %#v, want warn", diagnostics)
+	}
+	if store.initCalled {
+		t.Fatal("large-store doctor initialized SQLite after filesystem host checks")
+	}
+	for _, name := range []string{"gemini-config", "codex-config", "hook-grok-transcript", "hook-memory-extract"} {
+		if got := largeStoreCheckByName(report, name); got.Name == "" {
+			t.Fatalf("bounded report missing filesystem host check %q", name)
+		}
 	}
 }

--- a/presentation/cli/hook_diagnostics.go
+++ b/presentation/cli/hook_diagnostics.go
@@ -80,6 +80,14 @@ type hookCancellationDiagnosticClassification struct {
 }
 
 func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, dbPath, projectDir string) doctorCheck {
+	return c.inspectClaudeHookCancellationDiagnosticsWithLookup(ctx, dbPath, projectDir, c.session)
+}
+
+func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsFilesystem(ctx context.Context, dbPath, projectDir string) doctorCheck {
+	return c.inspectClaudeHookCancellationDiagnosticsWithLookup(ctx, dbPath, projectDir, nil)
+}
+
+func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsWithLookup(ctx context.Context, dbPath, projectDir string, sessions hookDiagnosticSessionLookup) doctorCheck {
 	const checkName = "claude-hook-cancellations"
 	workspace := resolveDoctorEventCoverageWorkspace(ctx, projectDir)
 	scan, err := scanHookCancellationDiagnostics("claude", "SessionEnd", workspace)
@@ -101,7 +109,7 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, 
 			),
 		}
 	}
-	classification, err := classifyHookCancellationDiagnostics(ctx, scan.Records, c.session, dbPath)
+	classification, err := classifyHookCancellationDiagnostics(ctx, scan.Records, sessions, dbPath)
 	if err != nil {
 		return doctorCheck{
 			Name:    checkName,


### PR DESCRIPTION
Closes #2006

metadata_only_large_store still does not Initialize SQLite. It now emits filesystem-only gemini/codex-config, hook-grok-transcript, hook-memory-extract, claude-hook-cancellations, and claude-plugin-cache so FixCommand is visible on the live 36 GiB store.

Leaves parent #2025 open.