### PR TITLE
fix: add external work-dir and in-place compact paths

### DIFF
--- a/application/compact.go
+++ b/application/compact.go
@@ -14,18 +14,31 @@ type CompactInput struct {
 	Force    bool
 	KeepDays int
 	Now      time.Time
+	// WorkDir, when set, holds the copy-filter work file on another volume
+	// so the source volume only needs dest-sized free space for VACUUM INTO.
+	WorkDir string
 }
+
+// Compact strategies recorded in CompactResult.CompactStrategy.
+const (
+	CompactStrategyReplica   = "replica"
+	CompactStrategyExternal  = "external"
+	CompactStrategyDestSized = "dest_sized"
+	CompactStrategyInPlace   = "in_place"
+)
 
 // CompactResult is the operator-visible outcome of one rewrite.
 type CompactResult struct {
-	Run                      domain.CompactionRun
-	BytesBefore              int64
-	BytesAfter               int64
-	UnrefinedRemaining       int
-	UnrefinedBytes           int64
-	MechanicalSummaries      bool
-	ReleasedCommandBodyRows  int
-	ReleasedCommandBodyBytes int64
+	Run                       domain.CompactionRun
+	BytesBefore               int64
+	BytesAfter                int64
+	UnrefinedRemaining        int
+	UnrefinedBytes            int64
+	MechanicalSummaries       bool
+	ReleasedCommandBodyRows   int
+	ReleasedCommandBodyBytes  int64
+	EstimatedReclaimableBytes int64
+	CompactStrategy           string
 }
 
 // CommandBodyReclaim is the measured set of duplicated command_executed
@@ -44,6 +57,8 @@ type CompactFilter struct {
 	// folded enough of the oldest backlog to let CollectGarbage proceed even
 	// when unrelated, newer-than-cutoff material is still unfolded (#1721).
 	AfterClone func(ctx context.Context, work string, cutoff time.Time) error
+	// WorkDir stages the source-sized work copy on another volume (#2008).
+	WorkDir string
 }
 
 // BodyGate classifies discardable-age transcript bodies on the source.

--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/duck8823/traceary/application"
@@ -52,7 +53,7 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 	}
 	cutoff := application.CompactCutoff(in.Now, in.KeepDays)
 	if setter, ok := u.builder.(compactFilterSetter); ok {
-		filter := application.CompactFilter{Cutoff: cutoff}
+		filter := application.CompactFilter{Cutoff: cutoff, WorkDir: strings.TrimSpace(in.WorkDir)}
 		if in.Force && u.cover != nil {
 			filter.AfterClone = u.cover
 		}
@@ -91,8 +92,47 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 		}
 		reclaim = measured
 	}
+	var estimated int64
+	if inspector, ok := u.builder.(reclaimableBytesInspector); ok {
+		measured, inspectErr := inspector.InspectReclaimableBytes(ctx, source, cutoff)
+		if inspectErr != nil {
+			return application.CompactResult{}, inspectErr
+		}
+		estimated = measured
+	} else {
+		estimated = reclaim.Bytes
+	}
+	strategy := application.CompactStrategyReplica
+	if strings.TrimSpace(in.WorkDir) != "" {
+		strategy = application.CompactStrategyExternal
+	}
 	run, err := u.compactLeased(ctx, source)
 	if err != nil {
+		if isInsufficientCompactionSpace(err) && strategy != application.CompactStrategyInPlace {
+			inPlaceErr := u.compactInPlace(ctx, source, cutoff)
+			if inPlaceErr == nil {
+				after, afterErr := os.Stat(source)
+				if afterErr != nil {
+					return application.CompactResult{}, fmt.Errorf("stat compacted store: %w", afterErr)
+				}
+				remaining, remainingBytes := gate.UnrefinedSessions, gate.UnrefinedBytes
+				if in.Force {
+					remaining, remainingBytes = 0, 0
+				}
+				return application.CompactResult{
+					BytesBefore:               before.Size(),
+					BytesAfter:                after.Size(),
+					UnrefinedRemaining:        remaining,
+					UnrefinedBytes:            remainingBytes,
+					MechanicalSummaries:       in.Force && gate.UnrefinedSessions > 0,
+					ReleasedCommandBodyRows:   reclaim.Rows,
+					ReleasedCommandBodyBytes:  reclaim.Bytes,
+					EstimatedReclaimableBytes: estimated,
+					CompactStrategy:           application.CompactStrategyInPlace,
+				}, nil
+			}
+			return application.CompactResult{}, fmt.Errorf("%w\n\testimated reclaimable bytes: %d\n\tattach another volume and retry with --work-dir, or free dest-sized space on this volume", err, estimated)
+		}
 		return application.CompactResult{}, err
 	}
 	after, afterErr := os.Stat(source)
@@ -104,15 +144,44 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 		remaining, remainingBytes = 0, 0
 	}
 	return application.CompactResult{
-		Run:                      run,
-		BytesBefore:              before.Size(),
-		BytesAfter:               after.Size(),
-		UnrefinedRemaining:       remaining,
-		UnrefinedBytes:           remainingBytes,
-		MechanicalSummaries:      in.Force && gate.UnrefinedSessions > 0,
-		ReleasedCommandBodyRows:  reclaim.Rows,
-		ReleasedCommandBodyBytes: reclaim.Bytes,
+		Run:                       run,
+		BytesBefore:               before.Size(),
+		BytesAfter:                after.Size(),
+		UnrefinedRemaining:        remaining,
+		UnrefinedBytes:            remainingBytes,
+		MechanicalSummaries:       in.Force && gate.UnrefinedSessions > 0,
+		ReleasedCommandBodyRows:   reclaim.Rows,
+		ReleasedCommandBodyBytes:  reclaim.Bytes,
+		EstimatedReclaimableBytes: estimated,
+		CompactStrategy:           strategy,
 	}, nil
+}
+
+type reclaimableBytesInspector interface {
+	InspectReclaimableBytes(ctx context.Context, source string, cutoff time.Time) (int64, error)
+}
+
+type inPlaceCompactor interface {
+	CompactInPlace(ctx context.Context, source string, filter application.CompactFilter) error
+}
+
+func (u *storeCompactionUsecase) compactInPlace(ctx context.Context, source string, cutoff time.Time) error {
+	compactor, ok := u.builder.(inPlaceCompactor)
+	if !ok {
+		return fmt.Errorf("in-place compact is not supported by this builder")
+	}
+	filter := application.CompactFilter{Cutoff: cutoff}
+	if u.cover != nil {
+		filter.AfterClone = u.cover
+	}
+	return compactor.CompactInPlace(ctx, source, filter)
+}
+
+func isInsufficientCompactionSpace(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "insufficient free space")
 }
 
 func (u *storeCompactionUsecase) compactLeased(ctx context.Context, source string) (domain.CompactionRun, error) {

--- a/docs/operations/store-compact-disk-cost.ja.md
+++ b/docs/operations/store-compact-disk-cost.ja.md
@@ -3,12 +3,23 @@
 [English](store-compact-disk-cost.md)
 
 `traceary store compact` は、source database と `VACUUM INTO` が書き出す
-candidate のために空き容量を必要とします。開始前の preflight は、store
-size の **1.1 倍**（および operation 固有の temporary budget）を予約します。
-これは意図的な worst-case reservation です。SQLite は書き込み前に
-candidate のサイズを報告できないため、安全側に倒して compact 後の store
-が source と同じ大きさになると仮定します。実際の compact 結果はもっと小さく
-なる場合がありますが、その小さい値を事前予約に使うのは安全ではありません。
+candidate のために空き容量を必要とします。このボリュームに source サイズの
+work copy を置けるときは、preflight は従来どおり store size の **1.1 倍**
+を予約します。置けないときは dest サイズ（source から metadata-only の
+回収見積もりを引いた値。下限は source の 10%）だけを予約し、それも足りなければ
+in-place の filter + `PRAGMA incremental_vacuum` に落ちます（rollback inode
+はありません）。
+
+source サイズの work copy を別ディスクへ置くには `--work-dir` を使います。
+
+```text
+traceary store compact --work-dir /volumes/external/traceary-compact
+```
+
+candidate は live store の隣に書かれます（live ボリュームには dest サイズの
+空きが必要です）。rollback は source 隣の `<db>.rollback-<run id>` です。
+in-place 実行だけは `compact_strategy=in_place` で `rollback_retained=false`
+になります。
 
 この予約がディスク容量の全コストではありません。実行が成功した後も、元の
 database は recovery copy として残ります。

--- a/docs/operations/store-compact-disk-cost.md
+++ b/docs/operations/store-compact-disk-cost.md
@@ -3,12 +3,24 @@
 [日本語](store-compact-disk-cost.ja.md)
 
 `traceary store compact` needs free disk space for the source database and the
-candidate that `VACUUM INTO` writes. Its preflight reserves **1.1 times the
-store size** (plus any operation-specific temporary budget) before it starts.
-This is a deliberate worst-case reservation: SQLite cannot report the
-candidate size before writing it, so the safe assumption is that the compacted
-store may be as large as the source. In practice, compaction can produce a
-much smaller file, but that smaller result is not safe to reserve in advance.
+candidate that `VACUUM INTO` writes. When this volume can hold a source-sized
+work copy, preflight still reserves **1.1 times the store size**. When it
+cannot, preflight falls back to a dest-sized reservation (source minus a
+metadata-only reclaimable-bytes estimate, with a 10% floor) and, if even that
+replica cannot fit, an in-place filter plus `PRAGMA incremental_vacuum`
+(no rollback inode).
+
+To keep the source-sized work copy off the live volume, pass `--work-dir`
+on another disk that can hold the current store:
+
+```text
+traceary store compact --work-dir /volumes/external/traceary-compact
+```
+
+The candidate is still written beside the live store (dest-sized free space
+on the live volume), then exchanged. Rollback remains `<db>.rollback-<run id>`
+next to the source except for in-place runs (`compact_strategy=in_place`,
+`rollback_retained=false`).
 
 The reservation is not the complete disk cost. After a successful run, the
 original database remains as the recovery copy:

--- a/infrastructure/sqlite/compaction_copy_filter.go
+++ b/infrastructure/sqlite/compaction_copy_filter.go
@@ -333,6 +333,68 @@ AND (length(CAST(body AS BLOB)) > 0`
 	return predicate + `)`
 }
 
+// InspectReclaimableBytes is a bounded metadata-only estimate of bytes
+// compact can drop: discardable projection rows older than cutoff plus
+// free pages. It does not walk event bodies.
+func (SQLiteCompactionBuilder) InspectReclaimableBytes(ctx context.Context, source string, cutoff time.Time) (int64, error) {
+	return inspectReclaimableBytes(ctx, source, cutoff)
+}
+
+func inspectReclaimableBytes(ctx context.Context, source string, cutoff time.Time) (int64, error) {
+	db, err := openDirectReadOnly(ctx, source)
+	if err != nil {
+		return 0, fmt.Errorf("open source for reclaimable estimate: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	var pageSize, freePages int64
+	if err := db.QueryRowContext(ctx, `PRAGMA page_size`).Scan(&pageSize); err != nil {
+		return 0, fmt.Errorf("read page size for reclaimable estimate: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, `PRAGMA freelist_count`).Scan(&freePages); err != nil {
+		return 0, fmt.Errorf("read freelist for reclaimable estimate: %w", err)
+	}
+	var discarded int64
+	if !cutoff.IsZero() {
+		var exists int
+		if err := db.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='event_metadata_projection'`).Scan(&exists); err != nil {
+			return 0, fmt.Errorf("inspect metadata projection for reclaimable estimate: %w", err)
+		}
+		if exists > 0 {
+			if err := db.QueryRowContext(ctx, `
+SELECT COALESCE(SUM(body_stored_bytes), 0)
+  FROM event_metadata_projection
+ WHERE created_at_norm < ?
+   AND kind IN ('transcript', 'compact_summary')`, formatTimestamp(cutoff)).Scan(&discarded); err != nil {
+				return 0, fmt.Errorf("sum discardable projection bytes: %w", err)
+			}
+		}
+	}
+	return discarded + pageSize*freePages, nil
+}
+
+// CompactInPlace applies the copy-filter on the leased source and runs
+// incremental_vacuum so a dest replica is not required.
+func (b SQLiteCompactionBuilder) CompactInPlace(ctx context.Context, source string, filter application.CompactFilter) error {
+	if filter.AfterClone != nil {
+		if err := filter.AfterClone(ctx, source, filter.Cutoff); err != nil {
+			return fmt.Errorf("compact force cover: %w", err)
+		}
+	}
+	if err := applyCopyFilters(ctx, source, filter); err != nil {
+		return err
+	}
+	db, err := sql.Open("sqlite", directSQLiteRWDSN(source))
+	if err != nil {
+		return fmt.Errorf("open source for incremental vacuum: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, `PRAGMA incremental_vacuum`); err != nil {
+		return fmt.Errorf("incremental vacuum: %w", err)
+	}
+	return nil
+}
+
 // InspectCommandBodyReclaim measures stored bytes of duplicated
 // command_executed bodies on the source. Compact reports this sum.
 func (SQLiteCompactionBuilder) InspectCommandBodyReclaim(ctx context.Context, source string) (application.CommandBodyReclaim, error) {

--- a/infrastructure/sqlite/compaction_copy_filter_test.go
+++ b/infrastructure/sqlite/compaction_copy_filter_test.go
@@ -834,6 +834,54 @@ func saveHistoricalCommandExecuted(t *testing.T, events *sqlite.EventDatasource,
 	}
 }
 
+func TestInspectReclaimableBytesUsesMetadataProjection(t *testing.T) {
+	t.Parallel()
+	dbPath, events, _ := prepareDiscardGCFixture(t)
+	old := newGCEventFixture(t, "event-old-transcript", types.EventKindTranscript, strings.Repeat("x", 4000), time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), old); err != nil {
+		t.Fatal(err)
+	}
+	got, err := (sqlite.SQLiteCompactionBuilder{}).InspectReclaimableBytes(
+		context.Background(),
+		dbPath,
+		time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("InspectReclaimableBytes: %v", err)
+	}
+	if got < 4000 {
+		t.Fatalf("InspectReclaimableBytes = %d, want at least the discarded transcript bytes", got)
+	}
+}
+
+func TestCompactInPlaceDropsDuplicatedCommandBodies(t *testing.T) {
+	t.Parallel()
+	dbPath, events, _ := prepareDiscardGCFixture(t)
+	saveHistoricalCommandExecuted(t, events, "cmd-a", strings.Repeat("same-body", 200), true)
+	saveHistoricalCommandExecuted(t, events, "cmd-b", strings.Repeat("same-body", 200), true)
+	before, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := (sqlite.SQLiteCompactionBuilder{}).CompactInPlace(context.Background(), dbPath, application.CompactFilter{}); err != nil {
+		t.Fatalf("CompactInPlace: %v", err)
+	}
+	after, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Size() <= 0 || before.Size() <= 0 {
+		t.Fatalf("unexpected sizes before=%d after=%d", before.Size(), after.Size())
+	}
+	reclaim, err := (sqlite.SQLiteCompactionBuilder{}).InspectCommandBodyReclaim(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("InspectCommandBodyReclaim: %v", err)
+	}
+	if reclaim.Rows != 0 {
+		t.Fatalf("duplicated command bodies remaining: %+v", reclaim)
+	}
+}
+
 func dropRetiredSearchFamily(t *testing.T, db *sql.DB) {
 	t.Helper()
 	for _, name := range []string{"event_search_documents", "event_search_fts", "event_search_backfill_state"} {

--- a/infrastructure/sqlite/compaction_files.go
+++ b/infrastructure/sqlite/compaction_files.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/duck8823/traceary/application"
 	"github.com/duck8823/traceary/domain"
 )
 
@@ -446,22 +447,33 @@ func (f PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.Compacti
 	if err != nil {
 		return run, err
 	}
-	available, err := availableBytes(filepath.Dir(run.SourcePath))
+	available, err := availableBytes(filepath.Dir(run.CandidatePath))
 	if err != nil {
 		return run, err
 	}
 	temporary := uint64(0)
+	destination := id.Size
 	if run.Operation == domain.PreparedStoreUpgradeOperationPayloadRehearsalMigration {
 		if ^uint64(0)-run.Budget.WALByteLimit < run.Budget.TemporaryByteLimit {
 			return run, errors.New("prepared upgrade resource size overflow")
 		}
 		temporary = run.Budget.WALByteLimit + run.Budget.TemporaryByteLimit
 	} else if id.Size > 0 {
-		// Work copy lives beside the source for the copy-filter. Peak disk is
-		// source + work + candidate (~3×); free space must cover work + candidate.
-		temporary = uint64(id.Size)
+		estimate, estimateErr := inspectReclaimableBytes(ctx, run.SourcePath, time.Now().UTC().AddDate(0, 0, -application.DefaultCompactKeepDays))
+		if estimateErr == nil && estimate > 0 && estimate < id.Size {
+			destination = id.Size - estimate
+			if destination < id.Size/10 {
+				destination = id.Size / 10
+			}
+		}
+		if available >= uint64(id.Size) {
+			// Work copy lives beside the source for the copy-filter when the
+			// volume can hold a source-sized replica.
+			temporary = uint64(id.Size)
+			destination = id.Size
+		}
 	}
-	required, margin, err := compactionRequiredBytes(id.Size, temporary)
+	required, margin, err := compactionRequiredBytes(destination, temporary)
 	if err != nil {
 		return run, err
 	}
@@ -484,7 +496,7 @@ func (f PreparedStoreUpgradeFiles) Plan(ctx context.Context, run domain.Compacti
 	} else {
 		leaseCapability = probeStoreLeaseCapability(ctx, run.SourcePath) == nil
 	}
-	run.Resources = domain.CompactionResourcePlan{RequiredBytes: required, DestinationBytes: uint64(id.Size), TemporaryBytes: temporary, SafetyMarginBytes: margin, AvailableBytes: available, FilesystemDevice: id.Device, LeaseCapability: leaseCapability, ExchangeCapability: exchangeCapability}
+	run.Resources = domain.CompactionResourcePlan{RequiredBytes: required, DestinationBytes: uint64(destination), TemporaryBytes: temporary, SafetyMarginBytes: margin, AvailableBytes: available, FilesystemDevice: id.Device, LeaseCapability: leaseCapability, ExchangeCapability: exchangeCapability}
 	if !run.Resources.ExchangeCapability {
 		return run, errors.New("atomic exchange capability unavailable")
 	}

--- a/infrastructure/sqlite/compaction_sqlite.go
+++ b/infrastructure/sqlite/compaction_sqlite.go
@@ -56,7 +56,11 @@ func (b SQLiteCompactionBuilder) Build(ctx context.Context, source, candidate st
 	if err := sourceDB.Close(); err != nil {
 		return err
 	}
-	work := candidate + ".work"
+	workParent := filepathDir(candidate)
+	if dir := strings.TrimSpace(b.Filter.WorkDir); dir != "" {
+		workParent = dir
+	}
+	work := joinCompactionPath(workParent, filepathBase(candidate)+".work")
 	_ = os.Remove(work)
 	removeSQLiteSidecars(work)
 	if err := copyRegularFile(source, work); err != nil {
@@ -655,4 +659,26 @@ func filepathDir(path string) string {
 		return "."
 	}
 	return path[:idx]
+}
+
+func filepathBase(path string) string {
+	idx := strings.LastIndexAny(path, "/\\")
+	if idx < 0 {
+		return path
+	}
+	return path[idx+1:]
+}
+
+func joinCompactionPath(dir, name string) string {
+	if dir == "" || dir == "." {
+		return name
+	}
+	sep := "/"
+	if strings.Contains(dir, "\\") && !strings.Contains(dir, "/") {
+		sep = "\\"
+	}
+	if strings.HasSuffix(dir, "/") || strings.HasSuffix(dir, "\\") {
+		return dir + name
+	}
+	return dir + sep + name
 }

--- a/infrastructure/sqlite/sqlite_open_inventory_test.go
+++ b/infrastructure/sqlite/sqlite_open_inventory_test.go
@@ -17,7 +17,7 @@ func TestRuntimeSQLiteOpenInventoryIsExplicit(t *testing.T) {
 		"infrastructure/filesystem/file_retention_datasource_unix.go": 1, // copied backup FD verification.
 		"infrastructure/sqlite/archive_segment.go":                    2, // owned offline candidate plus O_NOFOLLOW-pinned immutable segment; never Hot.
 		"infrastructure/sqlite/compaction_sqlite.go":                  2, // EX-held source/candidate only.
-		"infrastructure/sqlite/compaction_copy_filter.go":             1, // EX-held work copy only; never the live source.
+		"infrastructure/sqlite/compaction_copy_filter.go":             2, // EX-held work copy plus EX-held in-place incremental vacuum.
 		"infrastructure/sqlite/database.go":                           1, // in-memory driver probe only.
 		"infrastructure/sqlite/payload_rehearsal.go":                  7, // copied rehearsal targets only.
 		"infrastructure/sqlite/payload_rehearsal_migration.go":        1, // copied migration target.

--- a/presentation/cli/store_compaction.go
+++ b/presentation/cli/store_compaction.go
@@ -16,6 +16,7 @@ func (c *RootCLI) newStoreCompactionCommand() *cobra.Command {
 		path     string
 		force    bool
 		keepDays int
+		workDir  string
 	)
 	cmd := &cobra.Command{
 		Use:   "compact",
@@ -30,6 +31,7 @@ func (c *RootCLI) newStoreCompactionCommand() *cobra.Command {
 				Source:   resolved,
 				Force:    force,
 				KeepDays: keepDays,
+				WorkDir:  workDir,
 			})
 			if err != nil {
 				var unrefined application.UnrefinedMaterialError
@@ -48,16 +50,19 @@ func (c *RootCLI) newStoreCompactionCommand() *cobra.Command {
 				"mechanical_summaries":        result.MechanicalSummaries,
 				"released_command_body_rows":  result.ReleasedCommandBodyRows,
 				"released_command_body_bytes": result.ReleasedCommandBodyBytes,
+				"estimated_reclaimable_bytes": result.EstimatedReclaimableBytes,
+				"compact_strategy":            result.CompactStrategy,
 				"rollback_path":               result.Run.RollbackPath,
 				// Apply-time VerifyPair is not in-use proof. The operator
 				// deletes this file when they accept the rewrite (#1827).
-				"rollback_retained": true,
+				"rollback_retained": result.CompactStrategy != application.CompactStrategyInPlace,
 			})
 		},
 	}
 	cmd.Flags().StringVar(&path, "db-path", "", dbPathFlagUsage())
 	cmd.Flags().BoolVar(&force, "force", false, Localize("write mechanical summaries for unrefined discardable sessions and discard those bodies", "未 refine の破棄対象へ機械要約を書いて本文を捨てる"))
 	cmd.Flags().IntVar(&keepDays, "keep-days", application.DefaultCompactKeepDays, Localize("retain bodies newer than this many days", "この日数より新しい本文は保持する"))
+	cmd.Flags().StringVar(&workDir, "work-dir", "", Localize("stage the source-sized work copy on another volume when this volume cannot hold a replica", "このボリュームにレプリカを置けないとき、source サイズの work copy を別ボリュームに置く"))
 	cmd.AddCommand(c.newStoreCompactionRollbackCommand())
 	return cmd
 }


### PR DESCRIPTION
Closes #2008

Adds --work-dir so the source-sized work copy can live on another volume, a dest-sized preflight when a replica cannot fit, a metadata-only estimated_reclaimable_bytes field, and in-place filter plus incremental_vacuum when even a dest replica cannot fit. Bilingual compact disk-cost docs describe the external-volume runbook.

Leaves parent #2025 open.