### PR TITLE
fix: drop remember-intent candidates that are code or doc fragments

### DIFF
--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -184,7 +184,7 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 		// (#1169): they are never durable memories and previously flooded the
 		// candidate inbox as extracted-hidden rows. Explicit remember-intent is
 		// exempt so a user-driven `remember this: +foo` still lands.
-		if !spec.intent.explicitRemember && isDroppableExtractionFragment(spec.lowQualityReasons) {
+		if shouldDropMemoryCandidate(spec.fact, spec.lowQualityReasons, spec.intent.explicitRemember) {
 			continue
 		}
 		source := spec.source
@@ -266,6 +266,7 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 	type candidateDecision struct {
 		segmentIndex      int
 		key               string
+		fact              string
 		score             int
 		explicitRemember  bool
 		lowQualityReasons []string
@@ -306,6 +307,7 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 		candidates = append(candidates, candidateDecision{
 			segmentIndex:      segmentIndex,
 			key:               key,
+			fact:              spec.fact,
 			score:             spec.signalScore,
 			explicitRemember:  spec.intent.explicitRemember,
 			lowQualityReasons: slices.Clone(spec.lowQualityReasons),
@@ -366,6 +368,7 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 			candidates = append(candidates, candidateDecision{
 				segmentIndex:      segmentIndex,
 				key:               key,
+				fact:              spec.fact,
 				score:             spec.signalScore,
 				explicitRemember:  spec.intent.explicitRemember,
 				lowQualityReasons: slices.Clone(spec.lowQualityReasons),
@@ -392,7 +395,7 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 		// removed before they can consume a candidate-limit slot, so this
 		// accounting matches Extract, where the drop precedes the limit break.
 		best := candidates[bestIndex]
-		if !best.explicitRemember && isDroppableExtractionFragment(best.lowQualityReasons) {
+		if shouldDropMemoryCandidate(best.fact, best.lowQualityReasons, best.explicitRemember) {
 			continue
 		}
 		if emittedCandidates >= criteria.CandidateLimit() {
@@ -415,7 +418,7 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 			decision.Reason = "duplicate_in_run"
 			continue
 		}
-		if !candidate.explicitRemember && isDroppableExtractionFragment(candidate.lowQualityReasons) {
+		if shouldDropMemoryCandidate(candidate.fact, candidate.lowQualityReasons, candidate.explicitRemember) {
 			// Mirror the Extract drop (#1169): obvious code/diff fragments are
 			// not persisted at all, so report them as dropped rather than
 			// hidden. Checked before the candidate-limit and score / low-quality

--- a/application/usecase/memory_extraction_quality.go
+++ b/application/usecase/memory_extraction_quality.go
@@ -235,6 +235,48 @@ func isDroppableExtractionFragment(reasons []string) bool {
 	return false
 }
 
+// shouldDropMemoryCandidate reports whether a candidate fact must be discarded
+// before it can enter the inbox. Unified-diff headers stay droppable only
+// when remember-intent is absent (a user can still pin "+foo"). Structural
+// non-prose — hunk headers, struct tags, heading-only lines, flag
+// definitions — is dropped even for remember-intent so code/doc fragments
+// about the memory feature cannot flood the inbox (#2020).
+func shouldDropMemoryCandidate(fact string, reasons []string, explicitRemember bool) bool {
+	if isStructurallyNonProseFact(fact) {
+		return true
+	}
+	return !explicitRemember && isDroppableExtractionFragment(reasons)
+}
+
+var (
+	hunkHeaderStartPattern = regexp.MustCompile(`^@@ -\d`)
+	goStructTagPattern     = regexp.MustCompile("(?s)\\[\\].*`[^`]*json:\"")
+	markdownHeadingPattern = regexp.MustCompile(`^#{1,6}\s+\S`)
+	flagDefinitionPattern  = regexp.MustCompile("`--[a-z0-9-]+`")
+)
+
+// isStructurallyNonProseFact reports whether the fact is source code, a
+// unified-diff hunk, a markdown heading, or a flag-definition fragment
+// rather than an operator-written durable sentence.
+func isStructurallyNonProseFact(fact string) bool {
+	trimmed := strings.TrimSpace(fact)
+	if trimmed == "" {
+		return false
+	}
+	switch {
+	case hunkHeaderStartPattern.MatchString(trimmed):
+		return true
+	case goStructTagPattern.MatchString(trimmed):
+		return true
+	case markdownHeadingPattern.MatchString(trimmed):
+		return true
+	case flagDefinitionPattern.MatchString(trimmed):
+		return true
+	default:
+		return false
+	}
+}
+
 // isFragmentLikeNoise reports whether the noise reasons mark a mechanical
 // code/diff fragment for the candidate-hygiene diagnostic (fragment_like_count,
 // #1169). This is intentionally broader than the drop set: it also counts

--- a/application/usecase/memory_extraction_quality_test.go
+++ b/application/usecase/memory_extraction_quality_test.go
@@ -248,3 +248,31 @@ func TestIsStandaloneCommand_RejectsProseSentences(t *testing.T) {
 		})
 	}
 }
+
+func TestIsStructurallyNonProseFact(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		fact string
+		want bool
+	}{
+		{name: "dogfood struct tag", fact: "MemoryIDs []string `json:\"memory_ids\" jsonschema:\"candidate durable memory ident`", want: true},
+		{name: "dogfood hunk header", fact: "@@ -135,85 +135,85 @@ Durable memory に紐づく artifact ref です。", want: true},
+		{name: "dogfood markdown heading", fact: "## Durable memory commands", want: true},
+		{name: "dogfood flag definition", fact: "`--preset` (optional): apply a built-in retrieval preset (`resume` / …", want: true},
+		{name: "durable remember-intent prose", fact: "run the compact reminder only once per day", want: false},
+		{name: "plus-foo still not structural", fact: "+foo", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isStructurallyNonProseFact(tc.fact); got != tc.want {
+				t.Fatalf("isStructurallyNonProseFact(%q) = %t, want %t", tc.fact, got, tc.want)
+			}
+			if tc.want && !shouldDropMemoryCandidate(tc.fact, nil, true) {
+				t.Fatalf("remember-intent must still drop non-prose fact %q", tc.fact)
+			}
+		})
+	}
+}

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -2296,6 +2296,49 @@ func TestMemoryUsecase_Extract_KeepsExplicitRememberVisibleEvenWhenNoisy(t *test
 	}
 }
 
+func TestMemoryUsecase_Extract_DropsRememberIntentCodeFragments(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-nonprose-remember"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.None[time.Time](),
+		"ended",
+		1,
+		0,
+		[]string{"codex"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	promptEvent := mustExtractionEvent(t,
+		"event-nonprose-remember",
+		domtypes.EventKindPrompt,
+		"Remember this: MemoryIDs []string `json:\"memory_ids\" jsonschema:\"candidate durable memory ident`",
+	)
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-nonprose-remember")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(1).
+			CandidateLimit(10).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 0 {
+		t.Fatalf("proposeCalls = %d, want 0 so code fragments never enter the inbox", len(memoryUsecase.proposeCalls))
+	}
+}
+
 // TestMemoryUsecase_ExplainExtraction_ReportsLowQualityReasons verifies that
 // `memory extract --debug-signals` surfaces the deterministic noise reason
 // for each segment so operators can audit why a candidate was hidden (#857).


### PR DESCRIPTION
Closes #2020

Drop hunk headers, struct tags, heading-only lines, and flag-definition fragments even when remember-intent fires. Durable `remember this:` prose still lands. JSON contracts unchanged.

Leaves parent #2025 open.