### PR TITLE
fix: disclose excluded usage observations in report text

### DIFF
--- a/application/types/report.go
+++ b/application/types/report.go
@@ -208,6 +208,18 @@ type ReportWindow struct {
 	Commands []ReportCommandRecord
 	Usage    []ReportUsageRecord
 	Extents  ReportSourceExtents
+	// UsageWorkspaceTally is a metadata-only count of finalized observations
+	// for the workspace/client filter (no time bound). Text output uses it
+	// when the windowed usage page is empty.
+	UsageWorkspaceTally ReportUsageWorkspaceTally
+}
+
+// ReportUsageWorkspaceTally counts workspace-scoped usage rows so the text
+// report can distinguish "capture is unwired" from "only excluded evidence".
+type ReportUsageWorkspaceTally struct {
+	Excluded          int
+	Unavailable       int
+	KimiMainWireKnown int
 }
 
 // ReportAggregation describes overall and per-source aggregate completeness.
@@ -373,4 +385,6 @@ type ReportSnapshot struct {
 	EventScanCount   int                       `json:"event_scan_count"`
 	SessionScanCount int                       `json:"session_scan_count"`
 	UsageScanCount   int                       `json:"usage_scan_count"`
+	// UsageScanNote is text-only. It must never be serialized to --json.
+	UsageScanNote string `json:"-"`
 }

--- a/application/usecase/report_usecase.go
+++ b/application/usecase/report_usecase.go
@@ -157,7 +157,49 @@ func buildReportSnapshot(
 		TopCommands: commands, FailureLoops: loops, Usage: usage,
 		EventScanCount: len(window.Events), SessionScanCount: len(window.Sessions),
 		UsageScanCount: len(window.Usage),
+		UsageScanNote:  reportUsageScanNote(usage, window.UsageWorkspaceTally),
 	}, nil
+}
+
+func reportUsageScanNote(usage apptypes.ReportUsageSnapshot, tally apptypes.ReportUsageWorkspaceTally) string {
+	var accounted, excluded, unavailable int
+	for _, row := range usage.Aggregates {
+		accounted += row.Accounted
+		excluded += row.Excluded
+		unavailable += row.Unavailable
+	}
+	if accounted > 0 {
+		return ""
+	}
+	if excluded == 0 && unavailable == 0 {
+		excluded = tally.Excluded
+		unavailable = tally.Unavailable
+	}
+	if excluded == 0 && unavailable == 0 && tally.KimiMainWireKnown == 0 {
+		return ""
+	}
+	note := formatExcludedUsageNote(excluded, unavailable)
+	if tally.KimiMainWireKnown > 0 {
+		note += "; kimi main_wire rows excluded (double-count protection vs stop_hook)"
+	}
+	return note
+}
+
+func formatExcludedUsageNote(excluded, unavailable int) string {
+	switch {
+	case excluded > 0 && unavailable > 0:
+		return "0 additive (" + itoaReport(excluded) + " excluded: token states unavailable)"
+	case excluded > 0:
+		return "0 additive (" + itoaReport(excluded) + " excluded)"
+	case unavailable > 0:
+		return "0 additive (token states unavailable)"
+	default:
+		return "0 additive"
+	}
+}
+
+func itoaReport(value int) string {
+	return strconv.Itoa(value)
 }
 
 type reportUsageKey struct {

--- a/application/usecase/report_usecase_test.go
+++ b/application/usecase/report_usecase_test.go
@@ -487,3 +487,46 @@ func reportWindow(
 		},
 	}
 }
+
+func TestReportUsecaseGenerate_DisclosesExcludedUsageWhenAdditiveIsZero(t *testing.T) {
+	t.Parallel()
+	criteria := reportCriteria(t, 0)
+	unavailable := types.UnavailableUsageValue()
+	excludedCounters, err := types.UsageCountersOf(
+		unavailable, unavailable, unavailable, unavailable, unavailable, unavailable,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAt := time.Date(2026, 8, 15, 2, 0, 0, 0, time.UTC)
+	window := reportWindow(t, criteria, nil, nil, nil, false)
+	window.Usage = []apptypes.ReportUsageRecord{{
+		ObservationID: "usage-excluded-only", ObservedAt: observedAt, Engine: "claude",
+		Accounting: types.UsageAccountingExcluded, TerminalCode: types.UsageTerminalUnknown,
+		Counters: excludedCounters, Cost: types.UnavailableUsageCost(),
+	}}
+	usageExtent, err := apptypes.ReportSourceExtentOf([]time.Time{observedAt}, criteria.PageSize(), criteria.ResultCap(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	window.Extents.Usage = usageExtent
+	window.UsageWorkspaceTally = apptypes.ReportUsageWorkspaceTally{Excluded: 1, Unavailable: 1, KimiMainWireKnown: 2}
+
+	got, err := usecase.NewReportUsecase(&reportQueryStub{window: window}).Generate(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got.UsageScanNote == "" || !strings.Contains(got.UsageScanNote, "0 additive") || !strings.Contains(got.UsageScanNote, "excluded") {
+		t.Fatalf("UsageScanNote = %q, want excluded disclosure", got.UsageScanNote)
+	}
+	if !strings.Contains(got.UsageScanNote, "kimi main_wire") {
+		t.Fatalf("UsageScanNote = %q, want kimi main_wire disclosure", got.UsageScanNote)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "UsageScanNote") || strings.Contains(string(encoded), "0 additive") {
+		t.Fatalf("JSON must omit the text-only usage note: %s", encoded)
+	}
+}

--- a/infrastructure/sqlite/report_query.go
+++ b/infrastructure/sqlite/report_query.go
@@ -21,6 +21,9 @@ var listReportSessionsQuery string
 //go:embed sql/list_report_usage.sql
 var listReportUsageQuery string
 
+//go:embed sql/count_report_usage_workspace.sql
+var countReportUsageWorkspaceQuery string
+
 var _ queryservice.ReportQueryService = (*ReportDatasource)(nil)
 
 // ReportDatasource loads all report projections through one SQLite snapshot.
@@ -96,6 +99,10 @@ func (d *ReportDatasource) LoadReportWindow(ctx context.Context, criteria apptyp
 	if err != nil {
 		return apptypes.ReportWindow{}, xerrors.Errorf("failed to load report usage: %w", err)
 	}
+	tally, err := queryReportUsageWorkspaceTally(ctx, tx, criteria)
+	if err != nil {
+		return apptypes.ReportWindow{}, xerrors.Errorf("failed to load report usage workspace tally: %w", err)
+	}
 
 	extents, err := buildReportSourceExtents(
 		criteria,
@@ -112,6 +119,7 @@ func (d *ReportDatasource) LoadReportWindow(ctx context.Context, criteria apptyp
 	}
 	return apptypes.ReportWindow{
 		Sessions: sessions, Events: events, Commands: commands, Usage: usage, Extents: extents,
+		UsageWorkspaceTally: tally,
 	}, nil
 }
 
@@ -254,6 +262,24 @@ func queryReportUsagePage(
 		return nil, xerrors.Errorf("failed to iterate report usage rows: %w", err)
 	}
 	return result, nil
+}
+
+func queryReportUsageWorkspaceTally(
+	ctx context.Context,
+	tx *sql.Tx,
+	criteria apptypes.ReportCriteria,
+) (apptypes.ReportUsageWorkspaceTally, error) {
+	var tally apptypes.ReportUsageWorkspaceTally
+	err := tx.QueryRowContext(
+		ctx,
+		countReportUsageWorkspaceQuery,
+		criteria.Workspace().String(), criteria.Workspace().String(),
+		criteria.Client().String(), criteria.Client().String(),
+	).Scan(&tally.Excluded, &tally.Unavailable, &tally.KimiMainWireKnown)
+	if err != nil {
+		return apptypes.ReportUsageWorkspaceTally{}, xerrors.Errorf("failed to count workspace usage observations: %w", err)
+	}
+	return tally, nil
 }
 
 func scanReportUsageRecord(scanner interface{ Scan(...any) error }) (apptypes.ReportUsageRecord, error) {

--- a/infrastructure/sqlite/sql/count_report_usage_workspace.sql
+++ b/infrastructure/sqlite/sql/count_report_usage_workspace.sql
@@ -1,0 +1,10 @@
+SELECT
+  COALESCE(SUM(CASE WHEN observation.accounting = 'excluded' THEN 1 ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN observation.input_state = 'unavailable' OR observation.total_state = 'unavailable' THEN 1 ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN observation.host = 'kimi' AND observation.source_name = 'main_wire' AND observation.accounting = 'excluded' AND observation.input_state = 'known' THEN 1 ELSE 0 END), 0)
+  FROM usage_observations AS observation
+  LEFT JOIN sessions AS session
+    ON session.session_id = observation.session_id
+ WHERE observation.status = 'finalized'
+   AND (? = '' OR session.workspace = ?)
+   AND (? = '' OR session.client = ?)

--- a/presentation/cli/report.go
+++ b/presentation/cli/report.go
@@ -163,7 +163,11 @@ func writeReportText(output io.Writer, report apptypes.ReportSnapshot) error {
 	if report.ClientFilter != "" {
 		fmt.Fprintf(&b, "Client: %s\n", report.ClientFilter)
 	}
-	fmt.Fprintf(&b, "Scanned: %d sessions, %d events, %d usage observations\n\n", report.SessionScanCount, report.EventScanCount, report.UsageScanCount)
+	usageScan := fmt.Sprintf("%d usage observations", report.UsageScanCount)
+	if report.UsageScanNote != "" {
+		usageScan = report.UsageScanNote
+	}
+	fmt.Fprintf(&b, "Scanned: %d sessions, %d events, %s\n\n", report.SessionScanCount, report.EventScanCount, usageScan)
 	b.WriteString("## sessions\n")
 	if len(report.Sessions) == 0 {
 		b.WriteString("(none)\n")

--- a/presentation/cli/report_test.go
+++ b/presentation/cli/report_test.go
@@ -314,6 +314,31 @@ func TestRootCLI_Report_TextMakesUsageAvailabilityAndCostOriginExplicit(t *testi
 	}
 }
 
+func TestRootCLI_Report_TextDisclosesExcludedUsageWhenAdditiveIsZero(t *testing.T) {
+	t.Parallel()
+	stub := &reportUsecaseStub{result: apptypes.ReportSnapshot{
+		Period:         apptypes.ReportPeriod{Timezone: "UTC", EffectiveFromInclusive: "2026-08-15T00:00:00Z", EffectiveToExclusive: "2026-08-16T00:00:00Z", SnapshotAt: "2026-08-16T00:00:00Z"},
+		Aggregation:    apptypes.ReportAggregation{Coverage: apptypes.ReportCoverageComplete, PageSize: 10},
+		Failures:       apptypes.ReportFailures{ByClient: map[string]int{}, ByReason: map[string]int{}},
+		UsageScanCount: 0,
+		UsageScanNote:  "0 additive (12 excluded: token states unavailable); kimi main_wire rows excluded (double-count protection vs stop_hook)",
+	}}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{}), cli.WithReport(stub)).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"report", "--db-path", "/tmp/test-traceary.db"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "0 additive (12 excluded: token states unavailable)") {
+		t.Fatalf("report text missing excluded disclosure:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "kimi main_wire") {
+		t.Fatalf("report text missing kimi disclosure:\n%s", stdout.String())
+	}
+}
+
 func reportSnapshotForCriteria(criteria apptypes.ReportCriteria) apptypes.ReportSnapshot {
 	interval := criteria.Interval()
 	formatNano := func(value time.Time) string { return value.UTC().Format(time.RFC3339Nano) }


### PR DESCRIPTION
Closes #2018

When additive usage for the workspace window is zero, text report prints 0 additive (N excluded...) instead of a bare zero. JSON is unchanged. Kimi main_wire exclusions are named when present.

Leaves parent #2025 open.