### PR TITLE
fix: GC stale per-PID hook state and aged SessionEnd markers

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -307,6 +307,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		// reported via directory entry counts and byte sizes only (pending /
 		// stale inflight / dead-letter).
 		report.Checks = append(report.Checks, inspectHookSpoolFilesystemMetadata())
+		report.Checks = append(report.Checks, inspectHookStateResidueMetadata(time.Now().UTC()))
 		// Host package identity (installed plugin/manifest version, native
 		// grok/kimi activation state) reads only host manifests, host plugin
 		// caches, and host CLI probes, so it stays available in the bounded
@@ -387,6 +388,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		report.Checks,
 		c.inspectHookSpoolDiagnosticsFromScan(spoolRecords, spoolUnreadable, spoolErr),
 	)
+	report.Checks = append(report.Checks, inspectHookStateResidueMetadata(time.Now().UTC()))
 	report.Checks = append(report.Checks, c.inspectHookMemoryExtractDiagnostics(time.Now().UTC()))
 	report.Checks = append(report.Checks, c.inspectMemoryInboxSaturation(ctx))
 	report.Checks = append(report.Checks, c.inspectHookGrokTranscriptDiagnostics(time.Now().UTC()))

--- a/presentation/cli/doctor_filesystem_host.go
+++ b/presentation/cli/doctor_filesystem_host.go
@@ -20,6 +20,7 @@ func (c *RootCLI) appendFilesystemHostDoctorChecks(
 		return
 	}
 	now := time.Now().UTC()
+	report.Checks = append(report.Checks, inspectHookStateResidueMetadata(now))
 	report.Checks = append(report.Checks, inspectDoctorConfig())
 	report.Checks = append(report.Checks, c.inspectHookMemoryExtractDiagnostics(now))
 	report.Checks = append(report.Checks, c.inspectHookGrokTranscriptDiagnostics(now))

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -61,6 +61,9 @@ func (c *RootCLI) newHookCommand() *cobra.Command {
 		Use:    "hook",
 		Short:  "Runtime entrypoints used by packaged Traceary hooks",
 		Hidden: true,
+		PersistentPreRun: func(*cobra.Command, []string) {
+			maybeGCHookStateResidues()
+		},
 	}
 	hookCmd.AddCommand(c.newHookSessionCommand())
 	hookCmd.AddCommand(c.newHookAuditCommand())

--- a/presentation/cli/hook_state_gc.go
+++ b/presentation/cli/hook_state_gc.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	hookStatePIDAgeFloor      = 24 * time.Hour
+	hookStateResidueRetention = 14 * 24 * time.Hour
+	hookStateGCHookBudget     = 20
+	hookStateGCDoctorBudget   = 200
+	hookStateResidueCheckName = "hook-state-residue"
+)
+
+var hookPerPIDStateName = regexp.MustCompile(`^(claude|codex|antigravity|grok|kimi|gemini)-(\d+)(-repo)?$`)
+
+type hookStateResidueStats struct {
+	PerPID      int
+	StalePerPID int
+	Diagnostics int
+	Ended       int
+}
+
+func inspectHookStateResidueMetadata(now time.Time) doctorCheck {
+	stats, err := inspectHookStateResidueStats(now)
+	if err != nil {
+		return doctorCheck{
+			Name:    hookStateResidueCheckName,
+			Status:  doctorStatusFail,
+			Message: localizef("failed to inspect hook state residue: %v", "hook state 残渣の検査に失敗しました: %v", err),
+		}
+	}
+	if stats.PerPID == 0 && stats.Diagnostics == 0 && stats.Ended == 0 {
+		return doctorCheck{
+			Name:    hookStateResidueCheckName,
+			Status:  doctorStatusPass,
+			Message: Localize("no leftover hook state, diagnostics, or ended markers", "hook state / diagnostics / ended marker の残渣はありません"),
+		}
+	}
+	status := doctorStatusPass
+	if stats.StalePerPID > 0 || stats.Diagnostics > 0 || stats.Ended > 0 {
+		status = doctorStatusWarn
+	}
+	check := doctorCheck{
+		Name:   hookStateResidueCheckName,
+		Status: status,
+		Message: localizef(
+			"hook state residue: per_pid=%d stale_pid=%d diagnostics=%d ended=%d",
+			"hook state 残渣: per_pid=%d stale_pid=%d diagnostics=%d ended=%d",
+			stats.PerPID, stats.StalePerPID, stats.Diagnostics, stats.Ended,
+		),
+		Hint: Localize(
+			"killed host processes leave per-PID state files; SessionEnd diagnostics and ended markers accumulate. Later hooks prune a bounded batch. Run `traceary doctor --fix` to catch up. Does not touch spool/ or spool/dead/.",
+			"異常終了した host は per-PID state を残します。SessionEnd diagnostics と ended marker も蓄積します。後続 hook が bounded batch で掃除し、`traceary doctor --fix` で一括できます。spool/ と spool/dead/ は対象外です。",
+		),
+	}
+	if status == doctorStatusWarn {
+		check.FixCommand = "traceary doctor --fix"
+		check.AutoFixAvailable = true
+		check.FixFunc = func(_ context.Context, dryRun bool) (string, error) {
+			result, err := gcHookStateResidues(now, hookStateGCDoctorBudget, dryRun)
+			if err != nil {
+				return "", err
+			}
+			return localizef(
+				"pruned hook state residue: removed=%d remaining_stale=%d",
+				"hook state 残渣を prune しました: removed=%d remaining_stale=%d",
+				result.Removed, result.Remaining,
+			), nil
+		}
+		check.StructuredFixFunc = func(_ context.Context, dryRun bool) (doctorFixResult, error) {
+			result, err := gcHookStateResidues(now, hookStateGCDoctorBudget, dryRun)
+			if err != nil {
+				return doctorFixResult{}, err
+			}
+			return doctorFixResult{
+				Action: localizef(
+					"pruned hook state residue: removed=%d remaining_stale=%d",
+					"hook state 残渣を prune しました: removed=%d remaining_stale=%d",
+					result.Removed, result.Remaining,
+				),
+				Metrics: map[string]int{"removed": result.Removed, "remaining": result.Remaining},
+			}, nil
+		}
+	}
+	return check
+}
+
+type hookStateGCResult struct {
+	Removed   int
+	Remaining int
+}
+
+func inspectHookStateResidueStats(now time.Time) (hookStateResidueStats, error) {
+	var stats hookStateResidueStats
+	candidates, err := listHookStateResidueCandidates(now)
+	if err != nil {
+		return stats, err
+	}
+	for _, candidate := range candidates {
+		switch candidate.kind {
+		case hookResiduePerPID:
+			stats.PerPID++
+			if candidate.stale {
+				stats.StalePerPID++
+			}
+		case hookResidueDiagnostics:
+			stats.Diagnostics++
+		case hookResidueEnded:
+			stats.Ended++
+		}
+	}
+	return stats, nil
+}
+
+type hookResidueKind int
+
+const (
+	hookResiduePerPID hookResidueKind = iota
+	hookResidueDiagnostics
+	hookResidueEnded
+)
+
+type hookResidueCandidate struct {
+	path  string
+	kind  hookResidueKind
+	stale bool
+}
+
+func listHookStateResidueCandidates(now time.Time) ([]hookResidueCandidate, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(stateDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read hook state directory: %w", err)
+	}
+	var candidates []hookResidueCandidate
+	for _, entry := range entries {
+		name := entry.Name()
+		path := filepath.Join(stateDir, name)
+		if entry.IsDir() {
+			switch name {
+			case "diagnostics":
+				aged, listErr := listAgedFiles(path, now, hookStateResidueRetention, hookResidueDiagnostics)
+				if listErr != nil {
+					return nil, listErr
+				}
+				candidates = append(candidates, aged...)
+			case "ended":
+				aged, listErr := listAgedFiles(path, now, hookStateResidueRetention, hookResidueEnded)
+				if listErr != nil {
+					return nil, listErr
+				}
+				candidates = append(candidates, aged...)
+			}
+			continue
+		}
+		matches := hookPerPIDStateName.FindStringSubmatch(name)
+		if matches == nil {
+			continue
+		}
+		pid, convErr := strconv.Atoi(matches[2])
+		if convErr != nil {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return nil, xerrors.Errorf("failed to inspect hook state file: %w", infoErr)
+		}
+		stale := !hookProcessAlive(pid) && now.Sub(info.ModTime()) >= hookStatePIDAgeFloor
+		candidates = append(candidates, hookResidueCandidate{path: path, kind: hookResiduePerPID, stale: stale})
+	}
+	return candidates, nil
+}
+
+func listAgedFiles(dir string, now time.Time, retention time.Duration, kind hookResidueKind) ([]hookResidueCandidate, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read %s: %w", dir, err)
+	}
+	var out []hookResidueCandidate
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return nil, xerrors.Errorf("failed to inspect %s: %w", entry.Name(), infoErr)
+		}
+		if now.Sub(info.ModTime()) < retention {
+			continue
+		}
+		out = append(out, hookResidueCandidate{path: filepath.Join(dir, entry.Name()), kind: kind, stale: true})
+	}
+	return out, nil
+}
+
+func gcHookStateResidues(now time.Time, budget int, dryRun bool) (hookStateGCResult, error) {
+	if budget < 1 {
+		budget = hookStateGCHookBudget
+	}
+	candidates, err := listHookStateResidueCandidates(now)
+	if err != nil {
+		return hookStateGCResult{}, err
+	}
+	var result hookStateGCResult
+	for _, candidate := range candidates {
+		if !candidate.stale {
+			continue
+		}
+		if result.Removed >= budget {
+			result.Remaining++
+			continue
+		}
+		if dryRun {
+			result.Removed++
+			continue
+		}
+		if removeErr := os.Remove(candidate.path); removeErr != nil && !os.IsNotExist(removeErr) {
+			return result, xerrors.Errorf("failed to remove hook state residue: %w", removeErr)
+		}
+		result.Removed++
+	}
+	return result, nil
+}
+
+func maybeGCHookStateResidues() {
+	_, _ = gcHookStateResidues(time.Now().UTC(), hookStateGCHookBudget, false)
+}

--- a/presentation/cli/hook_state_gc_test.go
+++ b/presentation/cli/hook_state_gc_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestGCHookStateResiduesRemovesStalePIDAndAgedMarkers(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Now().UTC()
+
+	stalePID := filepath.Join(stateDir, "codex-999999")
+	staleRepo := filepath.Join(stateDir, "codex-999999-repo")
+	livePID := filepath.Join(stateDir, "codex-"+strconv.Itoa(os.Getpid()))
+	if err := os.WriteFile(stalePID, []byte("sess"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(staleRepo, []byte("ws"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(livePID, []byte("live"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := now.Add(-hookStatePIDAgeFloor - time.Hour)
+	if err := os.Chtimes(stalePID, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(staleRepo, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	diagDir := filepath.Join(stateDir, "diagnostics")
+	endedDir := filepath.Join(stateDir, "ended")
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(endedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agedDiag := filepath.Join(diagDir, "old.json")
+	freshDiag := filepath.Join(diagDir, "fresh.json")
+	agedEnded := filepath.Join(endedDir, "old-ended")
+	if err := os.WriteFile(agedDiag, []byte(`{"status":"started"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(freshDiag, []byte(`{"status":"started"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agedEnded, []byte("1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agedAt := now.Add(-hookStateResidueRetention - time.Hour)
+	if err := os.Chtimes(agedDiag, agedAt, agedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(agedEnded, agedAt, agedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	check := inspectHookStateResidueMetadata(now)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q, want warn", check.Status)
+	}
+
+	result, err := gcHookStateResidues(now, hookStateGCDoctorBudget, false)
+	if err != nil {
+		t.Fatalf("gc: %v", err)
+	}
+	if result.Removed < 4 {
+		t.Fatalf("removed=%d, want at least stale pid pair + aged diag + aged ended", result.Removed)
+	}
+	if _, err := os.Stat(stalePID); !os.IsNotExist(err) {
+		t.Fatal("stale per-PID state must be removed")
+	}
+	if _, err := os.Stat(staleRepo); !os.IsNotExist(err) {
+		t.Fatal("stale per-PID repo state must be removed")
+	}
+	if _, err := os.Stat(livePID); err != nil {
+		t.Fatalf("live pid state must remain: %v", err)
+	}
+	if _, err := os.Stat(freshDiag); err != nil {
+		t.Fatalf("fresh diagnostic must remain: %v", err)
+	}
+	if _, err := os.Stat(agedDiag); !os.IsNotExist(err) {
+		t.Fatal("aged diagnostic must be removed")
+	}
+	if _, err := os.Stat(agedEnded); !os.IsNotExist(err) {
+		t.Fatal("aged ended marker must be removed")
+	}
+}

--- a/presentation/cli/hook_state_gc_unix.go
+++ b/presentation/cli/hook_state_gc_unix.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package cli
+
+import "syscall"
+
+func hookProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/presentation/cli/hook_state_gc_unsupported.go
+++ b/presentation/cli/hook_state_gc_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package cli
+
+func hookProcessAlive(pid int) bool {
+	// Without a portable liveness probe, keep per-PID files so a live host
+	// is never deleted. Diagnostics and ended markers still age out.
+	return pid > 0
+}

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -165,6 +165,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "hook-state-residue",
+      "status": "pass",
+      "severity": "PASS",
+      "section": "Hooks",
+      "message": "no leftover hook state, diagnostics, or ended markers",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "hook-memory-extract",
       "status": "pass",
       "severity": "PASS",
@@ -424,6 +434,16 @@
           "auto_fix_available": false
         },
         {
+          "name": "hook-state-residue",
+          "status": "pass",
+          "severity": "PASS",
+          "section": "Hooks",
+          "message": "no leftover hook state, diagnostics, or ended markers",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
           "name": "hook-memory-extract",
           "status": "pass",
           "severity": "PASS",
@@ -487,7 +507,7 @@
     }
   ],
   "summary": {
-    "pass": 22,
+    "pass": 23,
     "warn": 1,
     "fail": 0
   },


### PR DESCRIPTION
Closes #2017

Bounded opportunistic GC on hook invocations plus doctor --fix removes dead-PID state files and aged diagnostics/ended markers. Does not touch spool/.

Leaves parent #2025 open.