### PR TITLE
fix: accept camelCase Claude usage counters and document host limits

### DIFF
--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -46,6 +46,17 @@
 
 > **Grok native runtime:** `traceary hooks install --client grok` は `.grok/hooks/traceary.json`（`--global` では `~/.grok/hooks/traceary.json`）へ書き込みます。core と compact event は `client=hook`、`agent=grok` で保存します。`Stop` は turn 境界のままです。subagent capture は parent/child identifier payload を検証するまで利用不可です。
 
+### トークン usage の取得（2026-08-16 実測、live store）
+
+ライフサイクル hook ではなく、additive な `usage_observations` の経路です。
+
+| Host | Additive 源 | 実測 coverage | 判断 |
+|---|---|---|---|
+| Codex | `rollout_jsonl` | 連続して取得できている | 維持 |
+| Claude | `transcript_calls`（Stop-hook の transcript 走査） | 8/1 以降の Claude session 666 に対し additive 25 行 | extractor は camelCase の `inputTokens`/`outputTokens` も読む。対話 transcript は usage 自体を省略することが多く、その turn は availability-only のまま。bare zero にはせず `report` が excluded/unavailable を開示する（#2018）。 |
+| Grok | `headless_stream` のみ | additive 3 行、2026-07-23 以降なし。7/24 以降の Grok session は 287 | Grok `Stop` は per-turn トークンを出さない。`stop_hook` 行は availability-only。additive は headless stream に限る。 |
+| Kimi | `main_wire` | 最終行 2026-08-13 は最終 Kimi session と一致 | 回帰ではない。known token の `main_wire` は stop_hook との二重計上を避けるため excluded。 |
+
 ### Traceary 未配線のホスト hook
 
 上のライフサイクルマトリクスに既出の hook はここでは省略している。

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -46,6 +46,17 @@ Relationship to the machine-readable [host contract](./host-contract.json): cont
 
 > **Grok native runtime:** `traceary hooks install --client grok` writes `.grok/hooks/traceary.json` (or `~/.grok/hooks/traceary.json` with `--global`). Core and compact events are stored with `client=hook`, `agent=grok`. `Stop` remains a turn boundary. Subagent capture remains unavailable (no dedicated parent/child hook payload observed on 0.2.101).
 
+### Token usage capture (measured 2026-08-16, live store)
+
+This is not a lifecycle hook. It is the additive `usage_observations` path.
+
+| Host | Additive source | Measured coverage | Decision |
+|---|---|---|---|
+| Codex | `rollout_jsonl` | Healthy / continuous | Keep |
+| Claude | `transcript_calls` (Stop-hook transcript walk) | 25 additive rows vs 666 Claude sessions since Aug 1 | Extractor now also accepts camelCase `inputTokens`/`outputTokens`. Interactive transcripts often omit both snake_case and camelCase usage; those turns stay availability-only. Not a silent zero — `report` discloses excluded/unavailable rows (#2018). |
+| Grok | `headless_stream` only | 3 additive rows, none since 2026-07-23; 287 Grok sessions since Jul 24 | Grok `Stop` does not expose per-turn token counters. `stop_hook` rows are availability-only. Additive usage is limited to headless stream capture. |
+| Kimi | `main_wire` | Last row 2026-08-13 matches last Kimi session | Not a regression. Known-token `main_wire` rows are excluded to avoid double-count vs stop_hook. |
+
 ### Other host hooks Traceary does not wire today
 
 This list excludes hooks that already appear in the lifecycle matrix above.

--- a/infrastructure/filesystem/claude_usage_source.go
+++ b/infrastructure/filesystem/claude_usage_source.go
@@ -219,9 +219,13 @@ type claudeAssistantMessage struct {
 
 type claudeRawUsageCounters struct {
 	InputTokens         *int64 `json:"input_tokens"`
+	InputTokensCamel    *int64 `json:"inputTokens"`
 	CacheReadTokens     *int64 `json:"cache_read_input_tokens"`
+	CacheReadCamel      *int64 `json:"cacheReadInputTokens"`
 	CacheCreationTokens *int64 `json:"cache_creation_input_tokens"`
+	CacheCreationCamel  *int64 `json:"cacheCreationInputTokens"`
 	OutputTokens        *int64 `json:"output_tokens"`
+	OutputTokensCamel   *int64 `json:"outputTokens"`
 }
 
 func parseClaudeUsageJSONL(
@@ -403,22 +407,33 @@ func decodeClaudeUsage(raw json.RawMessage) (application.ClaudeUsageCounters, bo
 	if err := json.Unmarshal(raw, &counters); err != nil {
 		return application.ClaudeUsageCounters{}, false, xerrors.Errorf("invalid Claude usage counters")
 	}
-	for _, counter := range []*int64{
-		counters.InputTokens, counters.CacheReadTokens, counters.CacheCreationTokens, counters.OutputTokens,
-	} {
+	input := firstInt64(counters.InputTokens, counters.InputTokensCamel)
+	cacheRead := firstInt64(counters.CacheReadTokens, counters.CacheReadCamel)
+	cacheWrite := firstInt64(counters.CacheCreationTokens, counters.CacheCreationCamel)
+	output := firstInt64(counters.OutputTokens, counters.OutputTokensCamel)
+	for _, counter := range []*int64{input, cacheRead, cacheWrite, output} {
 		if counter != nil && *counter < 0 {
 			return application.ClaudeUsageCounters{}, false, xerrors.Errorf("invalid negative Claude usage counter")
 		}
 	}
-	if counters.InputTokens == nil || counters.OutputTokens == nil {
+	if input == nil || output == nil {
 		return application.ClaudeUsageCounters{}, false, xerrors.Errorf("incomplete Claude usage counters")
 	}
 	return application.ClaudeUsageCounters{
-		InputTokens:           counters.InputTokens,
-		CachedInputTokens:     counters.CacheReadTokens,
-		CacheWriteInputTokens: counters.CacheCreationTokens,
-		OutputTokens:          counters.OutputTokens,
+		InputTokens:           input,
+		CachedInputTokens:     cacheRead,
+		CacheWriteInputTokens: cacheWrite,
+		OutputTokens:          output,
 	}, true, nil
+}
+
+func firstInt64(values ...*int64) *int64 {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
 }
 
 func claudeObservedAt(raw string, available bool, fallback time.Time) (time.Time, error) {

--- a/infrastructure/filesystem/claude_usage_source_test.go
+++ b/infrastructure/filesystem/claude_usage_source_test.go
@@ -52,6 +52,34 @@ func TestClaudeUsageSource_DeduplicatesRequestAndMessageIdentityWithoutPrivateBo
 	}
 }
 
+func TestClaudeUsageSource_AcceptsCamelCaseUsageCounters(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session-claude-camel"
+	writeClaudeUsageFixture(t, home, sessionID, strings.Join([]string{
+		`{"type":"assistant","sessionId":"session-claude-camel","requestId":"req-camel","timestamp":"2026-08-16T01:00:00Z","message":{"id":"msg-1","model":"claude-opus-4-1","usage":{"inputTokens":9,"cacheReadInputTokens":2,"cacheCreationInputTokens":1,"outputTokens":4}}}`,
+	}, "\n")+"\n")
+	result, err := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if result.Mode != application.ClaudeUsageModeTranscriptCalls || len(result.Samples) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	sample := result.Samples[0]
+	if sample.Counters.InputTokens == nil || *sample.Counters.InputTokens != 9 {
+		t.Fatalf("input = %+v", sample.Counters.InputTokens)
+	}
+	if sample.Counters.OutputTokens == nil || *sample.Counters.OutputTokens != 4 {
+		t.Fatalf("output = %+v", sample.Counters.OutputTokens)
+	}
+	if sample.Counters.CachedInputTokens == nil || *sample.Counters.CachedInputTokens != 2 {
+		t.Fatalf("cached = %+v", sample.Counters.CachedInputTokens)
+	}
+}
+
 func TestClaudeUsageSource_LegacyResultWinsWhileRetainingCallEvidence(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	home := t.TempDir()


### PR DESCRIPTION
Closes #2019

Claude transcript_calls accepts camelCase token fields. Host-coverage docs record measured additive limits: Grok Stop is availability-only; Claude interactive transcripts often omit usage.

Leaves parent #2025 open.