### PR TITLE
docs: add Grok and Kimi to the landing host matrix

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -2,7 +2,7 @@
 
 [日本語](./README.ja.md)
 
-Traceary ships native integration packages for Claude Code, Codex, Gemini CLI (legacy), Antigravity, and Grok Build.
+Traceary ships native integration packages for Claude Code, Codex, Gemini CLI (legacy), Antigravity, Grok Build, and Kimi Code.
 
 > **v0.21.1 note:** Gemini CLI is the legacy Google AI agent host. **Antigravity** (`/Applications/Antigravity.app`) is the active successor. As of v0.21.1, Traceary supports Antigravity as a real hook client with a packaged plugin against the documented public hook surface. See the [Antigravity hooks and plugin guide](./antigravity.md).
 

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -45,7 +45,7 @@
       <div>
         <span class="hero-eyebrow"><span class="dot"></span>v0.40 · local-first · OSS</span>
         <h1>Memory substrate for <span class="accent">AI coding agents</span>.</h1>
-        <p class="lead">Traceary records session lifecycle, shell command audits, and — where the host hooks expose them — prompts and compact summaries from Claude Code and Codex (plus legacy Gemini CLI compatibility) into a single local SQLite store, so context survives <code class="inl">/clear</code>, <code class="inl">/compact</code>, and the gaps between agents.</p>
+        <p class="lead">Traceary records session lifecycle, shell command audits, and — where the host hooks expose them — prompts and compact summaries from Claude Code, Codex, Gemini CLI, Antigravity, Grok Build, and Kimi Code into a single local SQLite store, so context survives <code class="inl">/clear</code>, <code class="inl">/compact</code>, and the gaps between agents.</p>
         <div class="hero-ctas">
           <a class="btn btn-primary btn-mono" href="#install">$ brew install traceary</a>
           <a class="btn btn-ghost" href="https://github.com/duck8823/traceary" target="_blank" rel="noopener">
@@ -178,7 +178,7 @@ go install github.com/duck8823/traceary@latest</pre>
           <div class="step-head">
             <div class="step-num">STEP <span>02</span></div>
             <h3 class="step-title">Wire your agent</h3>
-            <p class="step-desc">Active packages for Claude Code, Codex, and Antigravity; legacy Gemini CLI compatibility.</p>
+            <p class="step-desc">Active packages for Claude Code, Codex, Antigravity, Grok Build, and Kimi Code; legacy Gemini CLI compatibility.</p>
           </div>
           <div id="install-tabs-mount"></div>
         </div>
@@ -232,28 +232,44 @@ traceary search boom --json</pre>
             <td>SessionStart + Stop</td>
             <td>Tool hooks</td>
             <td><span class="check">●</span></td>
-            <td><span class="dash">—</span></td>
+            <td>Pre/PostCompact markers</td>
             <td><span class="tier partial">PARTIAL</span></td>
           </tr>
           <tr>
             <td class="host">Gemini CLI <span style="font-size:0.75em;opacity:0.6;">(legacy)</span></td>
             <td>SessionStart + End</td>
             <td>Tool hooks</td>
-            <td><span class="dash">—</span></td>
-            <td><span class="dash">—</span></td>
+            <td>BeforeAgent</td>
+            <td>PreCompress marker</td>
             <td><span class="tier basic">BASIC</span></td>
           </tr>
           <tr>
             <td class="host">Antigravity</td>
             <td>PreInvocation + Stop</td>
             <td>run_command hooks</td>
+            <td>recovered at Stop</td>
             <td><span class="dash">—</span></td>
-            <td><span class="dash">—</span></td>
+            <td><span class="tier partial">PARTIAL</span></td>
+          </tr>
+          <tr>
+            <td class="host">Grok Build</td>
+            <td>SessionStart + Stop</td>
+            <td>Pre/PostToolUse</td>
+            <td><span class="check">●</span></td>
+            <td>Pre/PostCompact markers</td>
+            <td><span class="tier partial">PARTIAL</span></td>
+          </tr>
+          <tr>
+            <td class="host">Kimi Code</td>
+            <td>SessionStart + End</td>
+            <td>PostToolUse</td>
+            <td><span class="check">●</span></td>
+            <td>Pre/PostCompact markers</td>
             <td><span class="tier partial">PARTIAL</span></td>
           </tr>
         </tbody>
       </table>
-      <p style="margin-top:0.75rem;font-size:0.85rem;opacity:0.6;">Gemini CLI details are legacy compatibility for existing installs. Antigravity uses the documented public hook/plugin surface only.</p>
+      <p style="margin-top:0.75rem;font-size:0.85rem;opacity:0.6;">Gemini CLI details are legacy compatibility for existing installs. Grok <code>Stop</code> is a turn boundary (no SessionEnd). Compact cells are markers unless the host exposes a summary body. See the hook coverage matrix.</p>
     </div>
   </section>
 
@@ -277,7 +293,7 @@ traceary search boom --json</pre>
         <a class="doc-card" href="https://github.com/duck8823/traceary/blob/main/docs/integrations/README.md" target="_blank" rel="noopener">
           <span class="arrow"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M7 17 17 7M9 7h8v8"/></svg></span>
           <h4>Native integrations</h4>
-          <p>Claude Code and Codex packages, legacy Gemini CLI compatibility, and Anthropic memory tool.</p>
+          <p>Claude Code, Codex, Antigravity, Grok Build, and Kimi Code packages, plus legacy Gemini CLI compatibility.</p>
         </a>
         <a class="doc-card" href="https://github.com/duck8823/traceary/blob/main/docs/architecture/README.md" target="_blank" rel="noopener">
           <span class="arrow"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M7 17 17 7M9 7h8v8"/></svg></span>


### PR DESCRIPTION
Closes #2005

Landing and integrations overview now include Grok Build and Kimi Code. Prompt/Compact cells follow the hook coverage matrix.

Leaves parent #2025 open.