### PR TITLE
docs: document public store, session, bundle, and memory-decay commands

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -1094,7 +1094,7 @@ portable な session/memory bundle を export / import します。契約は `do
 
 ### `traceary memory decay`
 
-古い durable-memory candidate を expire / supersede します。まず preview し、scan を確認してから apply フラグを使います。
+古い durable memory を expire / supersede します。まず preview し、scan を確認してから apply フラグを使います。
 
 ## Integration コマンド
 

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -1064,6 +1064,38 @@ preview ではなく、in-place `VACUUM` でもありません。成功後は `t
 
 成功した書き換えが残した rollback inode から、compact 前のストアを戻します。
 
+### `traceary store archive create|restore|verify`
+
+オフライン archive segment の作成・復元・検証です。公開されている store 管理コマンドであり、`store compact` の代替ではありません。
+
+### `traceary store capacity`
+
+メタデータのみの容量レポートです。大きいストアでは検査が bounded で、`evidence=cached` / `evidence=bounded` になることがあります。
+
+### `traceary store retention files plan|apply`
+
+ホスト側 artifact の file-retention を計画または適用します。`apply` は operator 同意が必要で、既定 hook 経路には入りません。
+
+### `traceary store search-projection start|resume|status|abort|probe`
+
+search-projection rebuild を管理します。`status` は読み取り専用、`start` / `resume` / `abort` が状態を変えます。大きいストアの catch-up は page され、進まないときは park します。
+
+### `traceary session gc`
+
+stale な未終了 session を閉じます。`session` 名前空間配下の admin 向け入口です。
+
+### `traceary session repair-one-shot`
+
+レビュー済みの one-shot session-repair 証拠ファイル（`--evidence-file`）を適用します。`--apply` で書き込み、無いときは dry preview です。
+
+### `traceary bundle export|import`
+
+portable な session/memory bundle を export / import します。契約は `docs/cli-stability.md` を参照してください。
+
+### `traceary memory decay`
+
+古い durable-memory candidate を expire / supersede します。まず preview し、scan を確認してから apply フラグを使います。
+
 ## Integration コマンド
 
 > `integration` コマンド subtree 全体（`integration` 親と `codex` group）は v0.20.0 時点で `traceary --help` から非表示になり、v0.21.0 で完全削除予定です。以下は移行メモとしてのみ掲載しています。非表示の stub は引き続き非ゼロで終了し、Codex 公式の `/plugins` flow を案内します。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1073,6 +1073,38 @@ Useful flags:
 
 Restore the pre-compact store from the rollback inode published by a successful rewrite.
 
+### `traceary store archive create|restore|verify`
+
+Create, restore, or verify an offline archive segment. These are public store-administration commands; they do not replace `store compact`.
+
+### `traceary store capacity`
+
+Print a metadata-only capacity report (page/freelist/dbstat evidence). On large stores the inspection is bounded and may report `evidence=cached` or `evidence=bounded`.
+
+### `traceary store retention files plan|apply`
+
+Plan or apply file-retention actions for host-side artifacts. `apply` is operator-consented and is not part of the default hook path.
+
+### `traceary store search-projection start|resume|status|abort|probe`
+
+Manage the search-projection rebuild. `status` is the safe read; `start` / `resume` / `abort` change rebuild state. Catch-up on large stores is paged and may park when it cannot advance.
+
+### `traceary session gc`
+
+Close stale still-open sessions. Admin-tier maintenance under the `session` namespace.
+
+### `traceary session repair-one-shot`
+
+Apply a reviewed one-shot session-repair evidence file (`--evidence-file`). `--apply` writes; without it the command is a dry preview.
+
+### `traceary bundle export|import`
+
+Export or import a portable session/memory bundle. See `docs/cli-stability.md` for the supported contract.
+
+### `traceary memory decay`
+
+Expire or supersede aged durable-memory candidates. Preview-first; use the documented apply flags only after reviewing the scan.
+
 ## Integration commands
 
 > The entire `integration` command subtree (the `integration` parent and the `codex` group) is hidden from `traceary --help` as of v0.20.0 and is scheduled for full removal in v0.21.0. The entries below are kept only as migration notes; the hidden stubs still exit non-zero with a pointer to Codex's official `/plugins` flow.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1103,7 +1103,7 @@ Export or import a portable session/memory bundle. See `docs/cli-stability.md` f
 
 ### `traceary memory decay`
 
-Expire or supersede aged durable-memory candidates. Preview-first; use the documented apply flags only after reviewing the scan.
+Expire or supersede aged durable memories. Preview-first; use the documented apply flags only after reviewing the scan.
 
 ## Integration commands
 


### PR DESCRIPTION
Closes #2004

Add first-class CLI reference sections for the public commands that official help already exposes.

Leaves parent #2025 open.