### PR TITLE
fix: skip conflicting Claude assistant usage instead of aborting load

### DIFF
--- a/application/claude_usage_source.go
+++ b/application/claude_usage_source.go
@@ -51,9 +51,10 @@ type ClaudeUsageSample struct {
 // ClaudeUsageLoadResult contains the selected representation and any retained
 // legacy evidence. Empty is a supported explicit outcome.
 type ClaudeUsageLoadResult struct {
-	Mode             ClaudeUsageCaptureMode
-	Samples          []ClaudeUsageSample
-	BoundaryObserved bool
+	Mode                  ClaudeUsageCaptureMode
+	Samples               []ClaudeUsageSample
+	BoundaryObserved      bool
+	ConflictingDuplicates int
 }
 
 // ClaudeUsageRepository persists provider-neutral observations idempotently.

--- a/infrastructure/filesystem/claude_usage_source.go
+++ b/infrastructure/filesystem/claude_usage_source.go
@@ -271,9 +271,8 @@ func parseClaudeUsageJSONL(
 			}
 			if existing, found := seenCalls[identity]; found {
 				if !sameClaudeUsageSample(existing, sample) {
-					return application.ClaudeUsageLoadResult{}, xerrors.Errorf(
-						"conflicting duplicate Claude assistant usage",
-					)
+					// Keep first-seen; one drifting re-emit must not abort the batch.
+					result.ConflictingDuplicates++
 				}
 				continue
 			}

--- a/infrastructure/filesystem/claude_usage_source_test.go
+++ b/infrastructure/filesystem/claude_usage_source_test.go
@@ -33,7 +33,7 @@ func TestClaudeUsageSource_DeduplicatesRequestAndMessageIdentityWithoutPrivateBo
 		t.Fatalf("Load(%s) error = %v", filepath.Base(path), err)
 	}
 	if result.Mode != application.ClaudeUsageModeTranscriptCalls ||
-		!result.BoundaryObserved || len(result.Samples) != 2 {
+		!result.BoundaryObserved || len(result.Samples) != 2 || result.ConflictingDuplicates != 0 {
 		t.Fatalf("result = %+v", result)
 	}
 	first := result.Samples[0]
@@ -168,19 +168,34 @@ func TestClaudeUsageSource_ErrorResultRetainsReportedUsageWithoutInferringSucces
 	}
 }
 
-func TestClaudeUsageSource_RejectsConflictingDuplicateAssistantUsage(t *testing.T) {
+func TestClaudeUsageSource_SkipsConflictingDuplicateAssistantUsageAndKeepsFirstSeen(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	home := t.TempDir()
 	sessionID := "session-conflict"
 	writeClaudeUsageFixture(t, home, sessionID, strings.Join([]string{
 		`{"type":"assistant","sessionId":"session-conflict","requestId":"req-1","timestamp":"2026-07-23T01:00:00Z","message":{"id":"msg-1","usage":{"input_tokens":1,"output_tokens":1}}}`,
 		`{"type":"assistant","sessionId":"session-conflict","requestId":"req-1","timestamp":"2026-07-23T01:00:00Z","message":{"id":"msg-1","usage":{"input_tokens":2,"output_tokens":1},"content":"PRIVATE-CONFLICT"}}`,
+		`{"type":"assistant","sessionId":"session-conflict","requestId":"req-2","timestamp":"2026-07-23T01:00:01Z","message":{"id":"msg-2","usage":{"input_tokens":3,"output_tokens":1}}}`,
 	}, "\n")+"\n")
-	_, err := filesystem.NewClaudeUsageSourceForTest(
+	result, err := filesystem.NewClaudeUsageSourceForTest(
 		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
 	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
-	if err == nil || strings.Contains(err.Error(), "PRIVATE-CONFLICT") {
+	if err != nil {
 		t.Fatalf("Load() error = %v", err)
+	}
+	if len(result.Samples) != 2 || result.ConflictingDuplicates != 1 {
+		t.Fatalf("result = %+v, want two samples and one conflicting duplicate", result)
+	}
+	if result.Samples[0].Counters.InputTokens == nil || *result.Samples[0].Counters.InputTokens != 1 {
+		t.Fatalf("first-seen sample was overwritten: %+v", result.Samples[0])
+	}
+	if result.Samples[1].Counters.InputTokens == nil || *result.Samples[1].Counters.InputTokens != 3 {
+		t.Fatalf("second identity sample = %+v", result.Samples[1])
+	}
+	for _, sample := range result.Samples {
+		if strings.Contains(sample.RecordID, "PRIVATE-CONFLICT") {
+			t.Fatalf("conflict body leaked into identity: %+v", sample)
+		}
 	}
 }
 

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -257,12 +257,12 @@ func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) 
 		if err := c.replayHookSpoolRecord(ctx, record); err != nil {
 			result.Failed++
 			slog.Debug("hook spool replay failed", "path", claimedPath, "command", record.Command, "client", record.Client, "error", err)
-			// Observed unreplayable classes that still hit this path and
-			// eventually dead-letter after the retry cap (validators stay
-			// strict; do not relax them):
-			//  1. "invalid Kimi usage record metadata" — unreplayable input
-			//  2. "conflicting duplicate Claude assistant usage" — unreplayable
-			//     against current identity rules (not last-write-wins)
+			// Observed last_error classes that still hit this path and
+			// eventually dead-letter after the retry cap:
+			//  1. "invalid Kimi usage record metadata" — still fail-closed
+			//     for broken turn records (non-turn scopes are skipped)
+			//  2. "conflicting duplicate Claude assistant usage" — historical
+			//     last_error; Load now keeps first-seen and continues
 			if requeueErr := requeueHookSpoolRecord(claimedPath, err.Error()); requeueErr != nil {
 				slog.Debug("failed hook spool requeue failed", "path", claimedPath, "error", requeueErr)
 			}


### PR DESCRIPTION
Closes #2051

Leaves parent #2049 open.

A conflicting duplicate assistant sample (same requestID+messageID, different counters) no longer aborts the whole Claude usage load. First-seen is kept, the conflict is counted on ClaudeUsageLoadResult.ConflictingDuplicates, and the rest of the batch continues. Terminal result conflicts stay fail-closed. No CLI or public JSON contract changes.