### PR TITLE
fix: stamp and backfill epoch-zero headless_stream usage times

### DIFF
--- a/application/usecase/gemini_usage_capture.go
+++ b/application/usecase/gemini_usage_capture.go
@@ -186,8 +186,9 @@ func geminiUsageObservation(
 	if err != nil {
 		return nil, xerrors.Errorf("invalid Gemini usage source: %w", err)
 	}
+	observedAt := stampHeadlessUsageObservedAt(sample.ObservedAt)
 	descriptor, err := model.NewUsageObservationDescriptor(
-		id, sessionID, source, types.UsageScopeRun, types.UsageAccountingAdditive, sample.ObservedAt.UTC(),
+		id, sessionID, source, types.UsageScopeRun, types.UsageAccountingAdditive, observedAt,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("invalid Gemini usage descriptor: %w", err)
@@ -201,7 +202,7 @@ func geminiUsageObservation(
 		terminal = types.UsageTerminalUnknown
 	}
 	observation, err := model.NewFinalizedUsageObservation(
-		descriptor, counters, types.UnavailableUsageCost(), terminal, sample.ObservedAt.UTC(),
+		descriptor, counters, types.UnavailableUsageCost(), terminal, observedAt,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("invalid Gemini usage observation: %w", err)

--- a/application/usecase/gemini_usage_capture.go
+++ b/application/usecase/gemini_usage_capture.go
@@ -63,7 +63,7 @@ func (u *geminiUsageCaptureUsecase) CaptureHeadless(
 	}
 	result := GeminiUsageCaptureResult{}
 	for _, sample := range loaded.Samples {
-		observation, err := geminiUsageObservation(input.SessionID, sample)
+		observation, err := geminiUsageObservation(ctx, u.repository, input.SessionID, sample)
 		if err != nil {
 			return result, xerrors.Errorf("failed to map Gemini usage sample: %w", err)
 		}
@@ -165,6 +165,8 @@ func (u *geminiUsageCaptureUsecase) recordUnavailable(
 }
 
 func geminiUsageObservation(
+	ctx context.Context,
+	repo application.GeminiUsageRepository,
 	sessionID types.SessionID,
 	sample application.GeminiUsageSample,
 ) (*model.UsageObservation, error) {
@@ -186,7 +188,10 @@ func geminiUsageObservation(
 	if err != nil {
 		return nil, xerrors.Errorf("invalid Gemini usage source: %w", err)
 	}
-	observedAt := stampHeadlessUsageObservedAt(sample.ObservedAt)
+	observedAt, err := resolveUnavailableObservationTime(ctx, repo, id, sample.ObservedAt)
+	if err != nil {
+		return nil, err
+	}
 	descriptor, err := model.NewUsageObservationDescriptor(
 		id, sessionID, source, types.UsageScopeRun, types.UsageAccountingAdditive, observedAt,
 	)

--- a/application/usecase/google_usage_capture_test.go
+++ b/application/usecase/google_usage_capture_test.go
@@ -69,6 +69,28 @@ func (s *googleUsageRepositoryStub) FindSnapshotHead(
 	return types.None[*model.UsageObservation](), nil
 }
 
+func TestGeminiUsageCapture_StampsZeroObservedAtWithWallClock(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGeminiUsageCaptureUsecase(repository)
+	loaded := application.GeminiUsageLoadResult{
+		BoundaryObserved: true,
+		Samples: []application.GeminiUsageSample{
+			geminiUsageSampleFixture("record-zero", "model-a", time.Time{}, 14, 6, 4, 20),
+		},
+	}
+	result, err := capture.CaptureHeadless(
+		context.Background(),
+		usecase.GeminiUsageCaptureInput{SessionID: "session-1", DeliveryID: "session_run"},
+		loaded,
+	)
+	if err != nil || result.Applied != 1 {
+		t.Fatalf("CaptureHeadless() = (%+v, %v)", result, err)
+	}
+	for _, observation := range repository.observations {
+		assertUnavailableObservationNotEpoch(t, observation)
+	}
+}
+
 func TestGeminiUsageCapture_RecordsModelRunsWithoutAggregateDuplicate(t *testing.T) {
 	repository := newGoogleUsageRepositoryStub()
 	capture := usecase.NewGeminiUsageCaptureUsecase(repository)

--- a/application/usecase/google_usage_capture_test.go
+++ b/application/usecase/google_usage_capture_test.go
@@ -78,16 +78,25 @@ func TestGeminiUsageCapture_StampsZeroObservedAtWithWallClock(t *testing.T) {
 			geminiUsageSampleFixture("record-zero", "model-a", time.Time{}, 14, 6, 4, 20),
 		},
 	}
-	result, err := capture.CaptureHeadless(
-		context.Background(),
-		usecase.GeminiUsageCaptureInput{SessionID: "session-1", DeliveryID: "session_run"},
-		loaded,
-	)
+	input := usecase.GeminiUsageCaptureInput{SessionID: "session-1", DeliveryID: "session_run"}
+	result, err := capture.CaptureHeadless(context.Background(), input, loaded)
 	if err != nil || result.Applied != 1 {
 		t.Fatalf("CaptureHeadless() = (%+v, %v)", result, err)
 	}
+	var firstObserved time.Time
 	for _, observation := range repository.observations {
 		assertUnavailableObservationNotEpoch(t, observation)
+		firstObserved = observation.Descriptor().ObservedAt()
+	}
+	time.Sleep(2 * time.Millisecond)
+	replayed, err := capture.CaptureHeadless(context.Background(), input, loaded)
+	if err != nil || replayed.AlreadyApplied != 1 {
+		t.Fatalf("replay = (%+v, %v)", replayed, err)
+	}
+	for _, observation := range repository.observations {
+		if !observation.Descriptor().ObservedAt().Equal(firstObserved) {
+			t.Fatalf("replay observed_at = %s, want %s", observation.Descriptor().ObservedAt(), firstObserved)
+		}
 	}
 }
 

--- a/application/usecase/grok_usage_capture.go
+++ b/application/usecase/grok_usage_capture.go
@@ -273,8 +273,9 @@ func grokUsageObservation(
 	if err != nil {
 		return nil, xerrors.Errorf("invalid Grok usage source: %w", err)
 	}
+	observedAt := stampHeadlessUsageObservedAt(sample.ObservedAt)
 	descriptor, err := model.NewUsageObservationDescriptor(
-		id, sessionID, source, types.UsageScopeRun, types.UsageAccountingAdditive, sample.ObservedAt.UTC(),
+		id, sessionID, source, types.UsageScopeRun, types.UsageAccountingAdditive, observedAt,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("invalid Grok usage descriptor: %w", err)
@@ -288,7 +289,7 @@ func grokUsageObservation(
 		terminal = types.UsageTerminalUnknown
 	}
 	observation, err := model.NewFinalizedUsageObservation(
-		descriptor, counters, types.UnavailableUsageCost(), terminal, sample.ObservedAt.UTC(),
+		descriptor, counters, types.UnavailableUsageCost(), terminal, observedAt,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("invalid Grok usage observation: %w", err)

--- a/application/usecase/grok_usage_capture.go
+++ b/application/usecase/grok_usage_capture.go
@@ -61,7 +61,7 @@ func (u *grokUsageCaptureUsecase) CaptureHeadless(
 	}
 	result := GrokUsageCaptureResult{}
 	if len(loaded.Samples) == 1 {
-		observation, err := grokUsageObservation(input.SessionID, loaded.Samples[0])
+		observation, err := grokUsageObservation(ctx, u.repository, input.SessionID, loaded.Samples[0])
 		if err != nil {
 			return result, xerrors.Errorf("failed to map Grok usage sample: %w", err)
 		}
@@ -252,6 +252,8 @@ func (u *grokUsageCaptureUsecase) recordUnavailable(
 }
 
 func grokUsageObservation(
+	ctx context.Context,
+	repo application.GrokUsageRepository,
 	sessionID types.SessionID,
 	sample application.GrokUsageSample,
 ) (*model.UsageObservation, error) {
@@ -273,7 +275,10 @@ func grokUsageObservation(
 	if err != nil {
 		return nil, xerrors.Errorf("invalid Grok usage source: %w", err)
 	}
-	observedAt := stampHeadlessUsageObservedAt(sample.ObservedAt)
+	observedAt, err := resolveUnavailableObservationTime(ctx, repo, id, sample.ObservedAt)
+	if err != nil {
+		return nil, err
+	}
 	descriptor, err := model.NewUsageObservationDescriptor(
 		id, sessionID, source, types.UsageScopeRun, types.UsageAccountingAdditive, observedAt,
 	)

--- a/application/usecase/grok_usage_capture_test.go
+++ b/application/usecase/grok_usage_capture_test.go
@@ -32,6 +32,7 @@ func TestGrokUsageCapture_RecordsVerifiedRunExactlyOnce(t *testing.T) {
 			observation.Counters().Availability() != types.UsageAvailabilityPartial {
 			t.Fatalf("observation = %+v", observation)
 		}
+		assertUnavailableObservationNotEpoch(t, observation)
 		if value, known := observation.Counters().ReasoningOutput().Value(); !known || value != 20 {
 			t.Fatalf("reasoning = (%d, %t)", value, known)
 		}

--- a/application/usecase/usage_unavailable_time.go
+++ b/application/usecase/usage_unavailable_time.go
@@ -35,13 +35,3 @@ func resolveUnavailableObservationTime(
 	}
 	return time.Now().UTC(), nil
 }
-
-// stampHeadlessUsageObservedAt keeps a provider timestamp when it is a real
-// instant and otherwise uses the wall clock. Unix epoch must not land in the
-// ledger: period reports treat it as outside every real interval.
-func stampHeadlessUsageObservedAt(sampleTime time.Time) time.Time {
-	if sampleTime.Unix() > 0 {
-		return sampleTime.UTC()
-	}
-	return time.Now().UTC()
-}

--- a/application/usecase/usage_unavailable_time.go
+++ b/application/usecase/usage_unavailable_time.go
@@ -35,3 +35,13 @@ func resolveUnavailableObservationTime(
 	}
 	return time.Now().UTC(), nil
 }
+
+// stampHeadlessUsageObservedAt keeps a provider timestamp when it is a real
+// instant and otherwise uses the wall clock. Unix epoch must not land in the
+// ledger: period reports treat it as outside every real interval.
+func stampHeadlessUsageObservedAt(sampleTime time.Time) time.Time {
+	if sampleTime.Unix() > 0 {
+		return sampleTime.UTC()
+	}
+	return time.Now().UTC()
+}

--- a/infrastructure/sqlite/usage_epoch_repair.go
+++ b/infrastructure/sqlite/usage_epoch_repair.go
@@ -15,7 +15,7 @@ const epochZeroHookUsageRepairBatchSize = 1000
 const epochZeroHookUsageObservedAt = "1970-01-01T00:00:00.000000000Z"
 
 const epochZeroHookUsageSourceFilter = `
-    source_name IN ('stop_hook', 'session_end_hook', 'after_agent_hook')`
+    source_name IN ('stop_hook', 'session_end_hook', 'after_agent_hook', 'headless_stream')`
 
 const selectEpochZeroHookUsageBatch = `
 SELECT observation.observation_id,
@@ -83,7 +83,7 @@ type EpochZeroHookUsageRepairResult struct {
 }
 
 // RepairEpochZeroHookUsageObservations backfills a bounded batch of
-// stop-hook-family rows whose observed_at is Unix epoch.
+// stop-hook-family and headless_stream rows whose observed_at is Unix epoch.
 func RepairEpochZeroHookUsageObservations(ctx context.Context, db *sql.DB, batchSize int) (EpochZeroHookUsageRepairResult, error) {
 	if batchSize <= 0 {
 		batchSize = epochZeroHookUsageRepairBatchSize

--- a/infrastructure/sqlite/usage_epoch_repair_test.go
+++ b/infrastructure/sqlite/usage_epoch_repair_test.go
@@ -79,8 +79,8 @@ func TestRepairEpochZeroHookUsage_BackfillsFromSessionBoundary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepairEpochZeroHookUsageObservations() error = %v", err)
 	}
-	if result.Repaired != 4 || result.Skipped != 1 || result.MorePending {
-		t.Fatalf("repair result = %+v, want repaired=4 skipped=1", result)
+	if result.Repaired != 5 || result.Skipped != 1 || result.MorePending {
+		t.Fatalf("repair result = %+v, want repaired=5 skipped=1", result)
 	}
 
 	want := sessionTime.UTC().Format(time.RFC3339Nano)
@@ -89,11 +89,11 @@ func TestRepairEpochZeroHookUsage_BackfillsFromSessionBoundary(t *testing.T) {
 		"antigravity:stop_hook:repaired",
 		"kimi:session_end_hook:repaired",
 		"gemini:after_agent_hook:repaired",
+		"grok:headless_stream:leave",
 	} {
 		assertUsageTimes(t, conn, id, want, want)
 	}
 	epoch := time.Unix(0, 0).UTC().Format(time.RFC3339Nano)
-	assertUsageTimes(t, conn, "grok:headless_stream:leave", epoch, epoch)
 	assertUsageTimes(t, conn, "grok:stop_hook:orphan", epoch, epoch)
 
 	rerun, err := sqlite.RepairEpochZeroHookUsageObservations(ctx, conn, 10)


### PR DESCRIPTION
Closes #2052

Leaves parent #2049 open.

Grok and Gemini headless_stream samples with a zero ObservedAt no longer persist Unix epoch. First write uses wall time when the sample timestamp is missing or epoch, matching the stop-hook stamp policy. The existing epoch-zero repair pass now includes source_name=headless_stream so the two live leftover rows restamp from the session boundary. No CLI or public JSON contract changes.