### PR TITLE
fix: requeue transient hook spool dead letters from doctor --fix

### DIFF
--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -45,10 +45,11 @@ const (
 	hookSpoolDeadDirName      = "dead"
 	// Dead-letter is append-only unless the operator asks doctor --fix to
 	// prune files older than the retention window (#2007).
-	hookSpoolDeadWarnCount  = 100
-	hookSpoolDeadWarnBytes  = 10 * 1024 * 1024
-	hookSpoolDeadRetention  = 14 * 24 * time.Hour
-	hookSpoolDeadPruneLimit = 200
+	hookSpoolDeadWarnCount    = 100
+	hookSpoolDeadWarnBytes    = 10 * 1024 * 1024
+	hookSpoolDeadRetention    = 14 * 24 * time.Hour
+	hookSpoolDeadPruneLimit   = 200
+	hookSpoolDeadRequeueLimit = 200
 	// Claimed paths are pending/*.json.claim-<rand> so listHookSpoolRecordPaths
 	// (suffix .json only) cannot pick them up while another process owns them.
 	hookSpoolClaimMarker = ".claim-"
@@ -108,6 +109,29 @@ type hookSpoolRecord struct {
 // has exhausted hookSpoolRetryLimit and must leave the replayable queue.
 func shouldDeadLetter(attempt int) bool {
 	return attempt >= hookSpoolRetryLimit
+}
+
+// hookSpoolDeadLetterRequeueable reports whether a dead-letter last_error is
+// safe to move back to pending. The set is conservative: store-timeout /
+// lock / ping classes, plus the two load errors that #2050 and #2051 made
+// replayable. Matching is case-insensitive and looks at last_error only.
+func hookSpoolDeadLetterRequeueable(lastError string) bool {
+	msg := strings.ToLower(strings.TrimSpace(lastError))
+	if msg == "" {
+		return false
+	}
+	for _, marker := range []string{
+		"context deadline exceeded",
+		"database is locked",
+		"failed to ping sqlite db",
+		"invalid kimi usage record metadata",
+		"conflicting duplicate claude assistant usage",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // explicitHookPayloadReader tells readHookPayload that the bytes came from a
@@ -927,6 +951,71 @@ func hookSpoolDeadOverThreshold(stats hookSpoolFilesystemStats) bool {
 	return stats.DeadCount >= hookSpoolDeadWarnCount || stats.DeadBytes >= hookSpoolDeadWarnBytes
 }
 
+func requeueHookSpoolDeadLetters(ctx context.Context, now time.Time, dryRun bool) (requeued, skipped, remaining int, err error) {
+	dir, err := hookSpoolDir()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	deadDir := filepath.Join(dir, hookSpoolDeadDirName)
+	entries, err := os.ReadDir(deadDir)
+	if os.IsNotExist(err) {
+		return 0, 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, 0, xerrors.Errorf("failed to read hook spool dead-letter directory: %w", err)
+	}
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return requeued, skipped, remaining, xerrors.Errorf("hook spool dead-letter requeue cancelled: %w", err)
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(deadDir, entry.Name())
+		data, readErr := readHookSpoolFile(path)
+		if readErr != nil {
+			skipped++
+			remaining++
+			continue
+		}
+		record, ok := parseHookSpoolRecordForRequeue(data)
+		if !ok || !hookSpoolDeadLetterRequeueable(record.LastError) {
+			skipped++
+			remaining++
+			continue
+		}
+		if requeued >= hookSpoolDeadRequeueLimit {
+			remaining++
+			continue
+		}
+		if dryRun {
+			requeued++
+			continue
+		}
+		record.AttemptCount = 0
+		record.LastError = ""
+		record.Path = ""
+		if writeErr := writeHookSpoolRecordAtomic(path, record); writeErr != nil {
+			return requeued, skipped, remaining, writeErr
+		}
+		random := make([]byte, 8)
+		if _, randErr := rand.Read(random); randErr != nil {
+			return requeued, skipped, remaining, xerrors.Errorf("failed to generate hook spool requeue ID: %w", randErr)
+		}
+		name := fmt.Sprintf(
+			"zz-retry-%s-%s.json",
+			now.UTC().Format("20060102T150405.000000000Z"),
+			hex.EncodeToString(random),
+		)
+		dest := filepath.Join(dir, name)
+		if renameErr := os.Rename(path, dest); renameErr != nil {
+			return requeued, skipped, remaining, xerrors.Errorf("failed to requeue hook spool dead-letter: %w", renameErr)
+		}
+		requeued++
+	}
+	return requeued, skipped, remaining, nil
+}
+
 func pruneHookSpoolDeadLetters(now time.Time, dryRun bool) (pruned, remaining int, err error) {
 	dir, err := hookSpoolDir()
 	if err != nil {
@@ -1010,8 +1099,8 @@ func inspectHookSpoolFilesystemMetadata() doctorCheck {
 			formatByteSize(stats.DeadBytes),
 		),
 		Hint: Localize(
-			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations or `traceary doctor --fix`. Dead-letter records stay under spool/dead/ until `traceary doctor --fix` prunes files older than 14 days.",
-			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook または `traceary doctor --fix` で drain されます。dead-letter は spool/dead/ に残り、`traceary doctor --fix` が 14 日より古いファイルを prune します。",
+			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations or `traceary doctor --fix`. Dead-letter records stay under spool/dead/ until `traceary doctor --fix` requeues transient classes or prunes files older than 14 days.",
+			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook または `traceary doctor --fix` で drain されます。dead-letter は spool/dead/ に残り、`traceary doctor --fix` が transient を再キューするか 14 日より古いファイルを prune します。",
 		),
 	}
 }
@@ -1108,27 +1197,35 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		if err != nil {
 			return doctorFixResult{}, err
 		}
+		requeued, skippedNontransient, _, err := requeueHookSpoolDeadLetters(ctx, now, dryRun)
+		if err != nil {
+			return doctorFixResult{}, err
+		}
 		pruned, deadRemaining, err := pruneHookSpoolDeadLetters(now, dryRun)
 		if err != nil {
 			return doctorFixResult{}, err
 		}
 		if dryRun {
 			return doctorFixResult{Action: localizef(
-				"would drain up to %d pending hook spool record(s) and prune %d aged dead-letter file(s)",
-				"未処理 hook spool record 最大 %d 件を drain し、古い dead-letter %d 件を prune します",
-				min(pending, 200),
+				"would requeue %d transient dead-letter(s), skip %d non-transient, drain up to %d pending hook spool record(s), and prune %d aged dead-letter file(s)",
+				"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、未処理 hook spool record 最大 %d 件を drain し、古い dead-letter %d 件を prune します",
+				requeued,
+				skippedNontransient,
+				min(pending+requeued, 200),
 				pruned,
 			)}, nil
 		}
-		limit := min(pending, 200)
+		limit := min(pending+requeued, 200)
 		result := c.drainHookSpoolRecordsDetailed(ctx, limit)
 		if result.Err != nil {
 			return doctorFixResult{}, result.Err
 		}
 		return doctorFixResult{
 			Action: localizef(
-				"drained hook spool: replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d",
-				"hook spool を drain しました: replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d",
+				"drained hook spool: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d",
+				"hook spool を drain しました: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d",
+				requeued,
+				skippedNontransient,
 				result.Replayed,
 				result.Failed,
 				result.Unreadable,
@@ -1137,12 +1234,14 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 				deadRemaining,
 			),
 			Metrics: map[string]int{
-				"replayed":       result.Replayed,
-				"failed":         result.Failed,
-				"remaining":      result.Remaining,
-				"unreadable":     result.Unreadable,
-				"pruned_dead":    pruned,
-				"dead_remaining": deadRemaining,
+				"requeued":             requeued,
+				"skipped_nontransient": skippedNontransient,
+				"replayed":             result.Replayed,
+				"failed":               result.Failed,
+				"remaining":            result.Remaining,
+				"unreadable":           result.Unreadable,
+				"pruned_dead":          pruned,
+				"dead_remaining":       deadRemaining,
 			},
 		}, nil
 	}
@@ -1164,8 +1263,8 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		Status:  status,
 		Message: message,
 		Hint: Localize(
-			"records are drained automatically on later hook invocations (bounded batch). After 3 failed attempts a record is retained under spool/dead/ and excluded from drain. Run `traceary doctor --fix` to drain pending records and prune dead-letter files older than 14 days. Doctor never deletes dead-letter files without --fix.",
-			"record は後続 hook 呼び出し時に bounded batch で自動 drain されます。3 回失敗すると spool/dead/ に保持され drain 対象外になります。`traceary doctor --fix` で未処理を drain し、14 日より古い dead-letter を prune します。--fix なしでは dead-letter を削除しません。",
+			"records are drained automatically on later hook invocations (bounded batch). After 3 failed attempts a record is retained under spool/dead/. Run `traceary doctor --fix` to requeue transient dead letters, drain pending records, and prune dead-letter files older than 14 days. Doctor never deletes dead-letter files without --fix.",
+			"record は後続 hook 呼び出し時に bounded batch で自動 drain されます。3 回失敗すると spool/dead/ に保持されます。`traceary doctor --fix` で transient dead-letter を再キューし、未処理を drain し、14 日より古い dead-letter を prune します。--fix なしでは dead-letter を削除しません。",
 		),
 	}
 	if status == doctorStatusWarn {

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -992,12 +992,8 @@ func requeueHookSpoolDeadLetters(ctx context.Context, now time.Time, dryRun bool
 			requeued++
 			continue
 		}
-		record.AttemptCount = 0
-		record.LastError = ""
-		record.Path = ""
-		if writeErr := writeHookSpoolRecordAtomic(path, record); writeErr != nil {
-			return requeued, skipped, remaining, writeErr
-		}
+		// Rename first so a crash cannot leave a dead file with last_error
+		// cleared (that would make the record unreplayable until prune).
 		random := make([]byte, 8)
 		if _, randErr := rand.Read(random); randErr != nil {
 			return requeued, skipped, remaining, xerrors.Errorf("failed to generate hook spool requeue ID: %w", randErr)
@@ -1010,6 +1006,12 @@ func requeueHookSpoolDeadLetters(ctx context.Context, now time.Time, dryRun bool
 		dest := filepath.Join(dir, name)
 		if renameErr := os.Rename(path, dest); renameErr != nil {
 			return requeued, skipped, remaining, xerrors.Errorf("failed to requeue hook spool dead-letter: %w", renameErr)
+		}
+		record.AttemptCount = 0
+		record.LastError = ""
+		record.Path = ""
+		if writeErr := writeHookSpoolRecordAtomic(dest, record); writeErr != nil {
+			return requeued, skipped, remaining, writeErr
 		}
 		requeued++
 	}
@@ -1062,7 +1064,7 @@ func pruneHookSpoolDeadLetters(now time.Time, dryRun bool) (pruned, remaining in
 
 // inspectHookSpoolFilesystemMetadata builds a doctor check from directory
 // metadata only (entry counts + byte sizes). Safe on the large-store early
-// path: no SQLite open and no payload reads.
+// path: no SQLite open. Fix reads last_error envelope fields only.
 func inspectHookSpoolFilesystemMetadata() doctorCheck {
 	const name = "hook-spool"
 	stats, err := inspectHookSpoolFilesystemStats(time.Now().UTC())
@@ -1085,7 +1087,7 @@ func inspectHookSpoolFilesystemMetadata() doctorCheck {
 	if pendingTotal > 0 || hookSpoolDeadOverThreshold(stats) {
 		status = doctorStatusWarn
 	}
-	return doctorCheck{
+	check := doctorCheck{
 		Name:   name,
 		Status: status,
 		Message: localizef(
@@ -1099,10 +1101,58 @@ func inspectHookSpoolFilesystemMetadata() doctorCheck {
 			formatByteSize(stats.DeadBytes),
 		),
 		Hint: Localize(
-			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations or `traceary doctor --fix`. Dead-letter records stay under spool/dead/ until `traceary doctor --fix` requeues transient classes or prunes files older than 14 days.",
-			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook または `traceary doctor --fix` で drain されます。dead-letter は spool/dead/ に残り、`traceary doctor --fix` が transient を再キューするか 14 日より古いファイルを prune します。",
+			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations. `traceary doctor --fix` requeues transient dead letters and prunes files older than 14 days without opening SQLite.",
+			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook で drain されます。`traceary doctor --fix` は SQLite を開かず transient dead-letter を再キューし、14 日より古いファイルを prune します。",
 		),
 	}
+	if status == doctorStatusWarn {
+		check.FixCommand = "traceary doctor --fix"
+		check.AutoFixAvailable = true
+		check.StructuredFixFunc = func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
+			return fixHookSpoolDeadLettersFilesystem(ctx, time.Now().UTC(), dryRun)
+		}
+		check.FixFunc = func(ctx context.Context, dryRun bool) (string, error) {
+			result, err := fixHookSpoolDeadLettersFilesystem(ctx, time.Now().UTC(), dryRun)
+			return result.Action, err
+		}
+	}
+	return check
+}
+
+func fixHookSpoolDeadLettersFilesystem(ctx context.Context, now time.Time, dryRun bool) (doctorFixResult, error) {
+	requeued, skippedNontransient, _, err := requeueHookSpoolDeadLetters(ctx, now, dryRun)
+	if err != nil {
+		return doctorFixResult{}, err
+	}
+	pruned, deadRemaining, err := pruneHookSpoolDeadLetters(now, dryRun)
+	if err != nil {
+		return doctorFixResult{}, err
+	}
+	if dryRun {
+		return doctorFixResult{Action: localizef(
+			"would requeue %d transient dead-letter(s), skip %d non-transient, and prune %d aged dead-letter file(s)",
+			"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、古い dead-letter %d 件を prune します",
+			requeued,
+			skippedNontransient,
+			pruned,
+		)}, nil
+	}
+	return doctorFixResult{
+		Action: localizef(
+			"requeued=%d skipped_nontransient=%d pruned_dead=%d dead_remaining=%d",
+			"requeued=%d skipped_nontransient=%d pruned_dead=%d dead_remaining=%d",
+			requeued,
+			skippedNontransient,
+			pruned,
+			deadRemaining,
+		),
+		Metrics: map[string]int{
+			"requeued":             requeued,
+			"skipped_nontransient": skippedNontransient,
+			"pruned_dead":          pruned,
+			"dead_remaining":       deadRemaining,
+		},
+	}, nil
 }
 
 func scanHookSpoolRecords(clients []string) ([]hookSpoolRecord, []string, error) {

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1559,6 +1559,9 @@ func TestInspectHookSpoolFilesystemMetadata_CountsWithoutReadingPayloads(t *test
 	if check.Status != doctorStatusWarn {
 		t.Fatalf("status=%q, want warn", check.Status)
 	}
+	if !check.AutoFixAvailable || check.StructuredFixFunc == nil {
+		t.Fatal("large-store hook-spool check must expose filesystem requeue/prune")
+	}
 	if !strings.Contains(check.Message, "pending=1") || !strings.Contains(check.Message, "dead=1") {
 		t.Fatalf("message=%q, want pending and dead counts", check.Message)
 	}
@@ -1698,6 +1701,54 @@ func TestRequeueHookSpoolDeadLetters_MovesTransientAndKeepsPoison(t *testing.T) 
 	}
 	if pendingJSON != 2 {
 		t.Fatalf("pending JSON count=%d, want 2", pendingJSON)
+	}
+}
+
+func TestInspectHookSpoolFilesystemMetadata_FixRequeuesWithoutDrain(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	deadDir := filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	record := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "audit",
+		Client:        "claude",
+		Payload:       `{"sentinel":"PRIVATE-BODY"}`,
+		CreatedAt:     time.Now().UTC(),
+		AttemptCount:  hookSpoolRetryLimit,
+		LastError:     "failed to ping SQLite DB: context deadline exceeded",
+	}
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deadDir, "deadline.json"), append(encoded, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := persistHookSpoolRecord(hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{}`,
+		CreatedAt:     time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	check := inspectHookSpoolFilesystemMetadata()
+	if !check.AutoFixAvailable || check.StructuredFixFunc == nil {
+		t.Fatal("expected filesystem auto-fix")
+	}
+	result, err := check.StructuredFixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Metrics["requeued"] != 1 || strings.Contains(result.Action, "PRIVATE-BODY") {
+		t.Fatalf("result=%+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(deadDir, "deadline.json")); !os.IsNotExist(err) {
+		t.Fatalf("dead letter must be requeued, stat err=%v", err)
 	}
 }
 

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1011,7 +1011,16 @@ func TestInspectHookSpoolDiagnostics_FixReportsUnreadableRemaining(t *testing.T)
 			t.Fatalf("message=%q, missing %q", message, expected)
 		}
 	}
-	wantMetrics := map[string]int{"replayed": 1, "failed": 0, "remaining": 1, "unreadable": 1, "pruned_dead": 0, "dead_remaining": 0}
+	wantMetrics := map[string]int{
+		"requeued":             0,
+		"skipped_nontransient": 0,
+		"replayed":             1,
+		"failed":               0,
+		"remaining":            1,
+		"unreadable":           1,
+		"pruned_dead":          0,
+		"dead_remaining":       0,
+	}
 	if !reflect.DeepEqual(result.Metrics, wantMetrics) {
 		t.Fatalf("metrics=%v, want %v", result.Metrics, wantMetrics)
 	}

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1594,6 +1594,104 @@ func TestInspectHookSpoolDiagnostics_ReportsPendingAndTerminalCounts(t *testing.
 	}
 }
 
+func TestHookSpoolDeadLetterRequeueable(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"failed to ping SQLite DB: context deadline exceeded":                true,
+		"Kimi usage session index scan cancelled: context deadline exceeded": true,
+		"failed to insert hook delivery ledger row: database is locked":      true,
+		"invalid Kimi usage record metadata":                                 true,
+		"conflicting duplicate Claude assistant usage":                       true,
+		"invalid Claude usage JSON event":                                    false,
+		"":                                                                   false,
+	}
+	for lastError, want := range cases {
+		if got := hookSpoolDeadLetterRequeueable(lastError); got != want {
+			t.Fatalf("hookSpoolDeadLetterRequeueable(%q) = %t, want %t", lastError, got, want)
+		}
+	}
+}
+
+func TestRequeueHookSpoolDeadLetters_MovesTransientAndKeepsPoison(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	deadDir := filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeDead := func(name, lastError string) {
+		t.Helper()
+		record := hookSpoolRecord{
+			SchemaVersion: hookSpoolSchemaVersion,
+			Command:       "usage",
+			Client:        "kimi",
+			Payload:       `{"sentinel":"PRIVATE-BODY"}`,
+			CreatedAt:     time.Now().UTC(),
+			AttemptCount:  hookSpoolRetryLimit,
+			LastError:     lastError,
+		}
+		encoded, err := json.Marshal(record)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(deadDir, name), append(encoded, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeDead("deadline.json", "failed to ping SQLite DB: context deadline exceeded")
+	writeDead("kimi.json", "invalid Kimi usage record metadata")
+	writeDead("poison.json", "invalid Claude usage JSON event")
+
+	requeued, skipped, remaining, err := requeueHookSpoolDeadLetters(context.Background(), time.Now().UTC(), true)
+	if err != nil {
+		t.Fatalf("dry-run requeue: %v", err)
+	}
+	if requeued != 2 || skipped != 1 {
+		t.Fatalf("dry-run requeued=%d skipped=%d remaining=%d", requeued, skipped, remaining)
+	}
+	if entries, err := os.ReadDir(deadDir); err != nil || len(entries) != 3 {
+		t.Fatalf("dry-run must leave dead files, entries=%v err=%v", entries, err)
+	}
+
+	requeued, skipped, remaining, err = requeueHookSpoolDeadLetters(context.Background(), time.Now().UTC(), false)
+	if err != nil {
+		t.Fatalf("requeue: %v", err)
+	}
+	if requeued != 2 || skipped != 1 || remaining != 1 {
+		t.Fatalf("requeued=%d skipped=%d remaining=%d, want 2, 1, 1", requeued, skipped, remaining)
+	}
+	if _, err := os.Stat(filepath.Join(deadDir, "poison.json")); err != nil {
+		t.Fatalf("poison must stay in dead: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(deadDir, "deadline.json")); !os.IsNotExist(err) {
+		t.Fatalf("deadline dead-letter must leave dead, stat err=%v", err)
+	}
+	pending, err := os.ReadDir(filepath.Join(stateDir, "spool"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingJSON := 0
+	for _, entry := range pending {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			pendingJSON++
+			body, readErr := os.ReadFile(filepath.Join(stateDir, "spool", entry.Name()))
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			var record hookSpoolRecord
+			if err := json.Unmarshal(body, &record); err != nil {
+				t.Fatal(err)
+			}
+			if record.AttemptCount != 0 || record.LastError != "" {
+				t.Fatalf("requeued record = %+v, want reset attempt and last_error", record)
+			}
+		}
+	}
+	if pendingJSON != 2 {
+		t.Fatalf("pending JSON count=%d, want 2", pendingJSON)
+	}
+}
+
 func TestPruneHookSpoolDeadLetters_RemovesAgedFilesOnlyOnFix(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)


### PR DESCRIPTION
Closes #2053

Leaves parent #2049 open.

doctor --fix now moves conservative last_error classes from spool/dead back to pending (attempt_count reset) before the existing drain and 14-day prune. Classifier covers deadline exceeded, database is locked, SQLite ping failures, and the Kimi/Claude load errors that #2050 and #2051 made replayable. Output includes requeued and skipped_nontransient. No new flags.