### PR TITLE
fix: emit hook-state-residue once on the large-store doctor path

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -307,7 +307,8 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		// reported via directory entry counts and byte sizes only (pending /
 		// stale inflight / dead-letter).
 		report.Checks = append(report.Checks, inspectHookSpoolFilesystemMetadata())
-		report.Checks = append(report.Checks, inspectHookStateResidueMetadata(time.Now().UTC()))
+		// hook-state-residue is owned by appendFilesystemHostDoctorChecks on
+		// this path; appending it here would print and --fix it twice.
 		// Host package identity (installed plugin/manifest version, native
 		// grok/kimi activation state) reads only host manifests, host plugin
 		// caches, and host CLI probes, so it stays available in the bounded

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -597,6 +597,16 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 	if cost.Status != "skip" || report.OperatorCost == nil || report.OperatorCost.ResidentBytes != 2<<30 {
 		t.Fatalf("operator cost = %#v report=%+v", cost, report.OperatorCost)
 	}
+	assertDoctorCheckNamesUnique(t, report)
+	residueFixes := 0
+	for _, fix := range report.Fixes {
+		if fix.Name == "hook-state-residue" {
+			residueFixes++
+		}
+	}
+	if residueFixes > 1 {
+		t.Fatalf("hook-state-residue fix ran %d times, want at most 1", residueFixes)
+	}
 }
 
 func TestRootCLI_DoctorJSONIncludesOperatorCost(t *testing.T) {
@@ -714,6 +724,7 @@ func TestRootCLI_DoctorLargeStoreReportsHookSpoolMetadataWithoutPayloadReads(t *
 	if strings.Contains(spool.Message, secretPayload) || strings.Contains(spool.Hint, secretPayload) {
 		t.Fatalf("large-store doctor leaked spool payload body: %#v", spool)
 	}
+	assertDoctorCheckNamesUnique(t, report)
 }
 
 func TestRootCLI_DoctorCommand_ClaudeHookCancellationDiagnostics(t *testing.T) {
@@ -2246,6 +2257,26 @@ func setTracearyPathToCurrentExecutable(t *testing.T) {
 		}
 	}
 	t.Setenv("PATH", dir)
+}
+
+func assertDoctorCheckNamesUnique(t *testing.T, report doctorReport) {
+	t.Helper()
+	seen := make(map[string]int, len(report.Checks))
+	for _, check := range report.Checks {
+		if check.Name == "" {
+			t.Fatal("doctor check has empty name")
+		}
+		seen[check.Name]++
+	}
+	var dupes []string
+	for name, count := range seen {
+		if count > 1 {
+			dupes = append(dupes, name)
+		}
+	}
+	if len(dupes) > 0 {
+		t.Fatalf("duplicate doctor check names %v", dupes)
+	}
 }
 
 func decodeDoctorReport(t *testing.T, data []byte) doctorReport {


### PR DESCRIPTION
Closes #2054

Leaves parent #2049 open.

The bounded large-store doctor path appended inspectHookStateResidueMetadata and then called appendFilesystemHostDoctorChecks, which appended the same check again. That doubled the WARN and ran --fix twice. The extra append is removed. Shipped doctor JSON tests assert check names are unique.

No CLI flags or JSON contract additions.