### PR TITLE
fix: drain doctor --fix hook-state and memory-extract backlogs under a 45s wall

### DIFF
--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -38,6 +38,9 @@ const (
 	hookMemoryExtractDrainBatchLimit = 3
 	// hookMemoryExtractDoctorFixLimit is the larger batch used by doctor --fix.
 	hookMemoryExtractDoctorFixLimit = 50
+	// hookMemoryExtractDoctorWall bounds one doctor --fix drain. The hook
+	// path keeps hookMemoryExtractDrainBatchLimit and does not loop.
+	hookMemoryExtractDoctorWall = 45 * time.Second
 )
 
 type hookMemoryExtractRequest struct {
@@ -709,21 +712,72 @@ func countHookMemoryExtractSidecars(now time.Time) (locks, tmps int) {
 }
 
 func memoryExtractQueueFix(c *RootCLI, dryRun bool) (string, error) {
-	pending, _, err := scanHookMemoryExtractJobs()
-	if err != nil {
-		return "", err
-	}
-	locks, tmps := countHookMemoryExtractSidecars(time.Now().UTC())
+	now := hookMemoryExtractNow()
+	drainable := countHookMemoryExtractDrainable(now)
 	if dryRun {
 		return localizef(
-			"would drain/GC up to %d pending memory extraction job(s) and sweep %d orphan lock(s) and %d aged temp file(s)",
-			"未処理 memory extraction job 最大 %d 件を drain/GC し、orphan lock %d 件と古い temp %d 件を sweep します",
-			min(len(pending), hookMemoryExtractDoctorFixLimit), locks, tmps,
+			"would drain/GC memory extraction queue under a 45s wall (batch %d): drainable=%d",
+			"45 秒の壁時計内で memory extraction queue を drain/GC します（batch %d）: drainable=%d",
+			hookMemoryExtractDoctorFixLimit, drainable,
 		), nil
 	}
-	launched, removed := c.drainHookMemoryExtractQueue(time.Now().UTC(), hookMemoryExtractDoctorFixLimit)
-	return localizef("drained memory extraction queue: launched=%d removed=%d", "memory extraction queue を drain しました: launched=%d removed=%d", launched, removed), nil
+	launched, removed := c.drainHookMemoryExtractQueueUntil(now, hookMemoryExtractNow().Add(hookMemoryExtractDoctorWall), hookMemoryExtractDoctorFixLimit, hookMemoryExtractNow)
+	remaining := countHookMemoryExtractDrainable(now)
+	if remaining > 0 {
+		return localizef(
+			"drained memory extraction queue: launched=%d removed=%d remaining=%d; run `traceary doctor --fix` again to continue",
+			"memory extraction queue を drain しました: launched=%d removed=%d remaining=%d。続きは `traceary doctor --fix` を再実行してください",
+			launched, removed, remaining,
+		), nil
+	}
+	return localizef(
+		"drained memory extraction queue: launched=%d removed=%d remaining=0",
+		"memory extraction queue を drain しました: launched=%d removed=%d remaining=0",
+		launched, removed,
+	), nil
 }
+
+func (c *RootCLI) drainHookMemoryExtractQueueUntil(now, deadline time.Time, batchLimit int, clock func() time.Time) (launched, removed int) {
+	if clock == nil {
+		clock = hookMemoryExtractNow
+	}
+	for {
+		if !clock().Before(deadline) {
+			return launched, removed
+		}
+		batchLaunched, batchRemoved := c.drainHookMemoryExtractQueue(now, batchLimit)
+		launched += batchLaunched
+		removed += batchRemoved
+		if batchLaunched+batchRemoved == 0 {
+			return launched, removed
+		}
+	}
+}
+
+func countHookMemoryExtractDrainable(now time.Time) int {
+	jobs, _, err := scanHookMemoryExtractJobs()
+	n := 0
+	if err == nil {
+		for _, job := range jobs {
+			if hookMemoryExtractJobReadyForGC(job, now) || !hookMemoryExtractJobIsTerminal(job) {
+				n++
+			}
+		}
+	}
+	locks, tmps := countHookMemoryExtractSidecars(now)
+	return n + locks + tmps
+}
+
+func hookMemoryExtractNow() time.Time {
+	if hookMemoryExtractClock != nil {
+		return hookMemoryExtractClock()
+	}
+	return time.Now().UTC()
+}
+
+// hookMemoryExtractClock is the wall clock used by doctor --fix loops.
+// Tests replace it; production leaves it nil so time.Now.UTC is used.
+var hookMemoryExtractClock func() time.Time
 
 func (c *RootCLI) inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck {
 	const name = "hook-memory-extract"
@@ -745,8 +799,8 @@ func (c *RootCLI) inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck
 				locks, tmps,
 			),
 			Hint: Localize(
-				"completed jobs left flock sidecars or crash temps. Run `traceary doctor --fix` to sweep a bounded batch.",
-				"完了済み job の flock sidecar か crash temp が残っています。bounded batch で掃除するには `traceary doctor --fix` を実行してください。",
+				"completed jobs left flock sidecars or crash temps. `traceary doctor --fix` sweeps under a 45s wall; remaining files need another run.",
+				"完了済み job の flock sidecar か crash temp が残っています。`traceary doctor --fix` は 45 秒の壁時計内で sweep します。残れば再実行してください。",
 			),
 			FixCommand:       "traceary doctor --fix",
 			AutoFixAvailable: true,
@@ -781,8 +835,8 @@ func (c *RootCLI) inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck
 			len(jobs), failed, terminal, len(unreadable), oldestAge.Round(time.Second),
 		),
 		Hint: Localize(
-			"later hooks drain a bounded oldest-first batch across sessions (not only the same session key). Terminal jobs (attempts exhausted) are GC'd after retention. Run `traceary doctor --fix` to force a larger drain, or inspect debug logs if failures remain.",
-			"後続 hook は同一 session に限らず oldest-first の bounded batch で queue 全体を drain します。terminal job（試行上限到達）は retention 後に GC されます。大きめに drain するには `traceary doctor --fix` を使い、失敗が残る場合は debug log を確認してください。",
+			"later hooks drain a bounded oldest-first batch across sessions (not only the same session key). Terminal jobs (attempts exhausted) are GC'd after retention. `traceary doctor --fix` drains under a 45s wall; remaining jobs need another run. Inspect debug logs if failures remain.",
+			"後続 hook は同一 session に限らず oldest-first の bounded batch で queue 全体を drain します。terminal job（試行上限到達）は retention 後に GC されます。`traceary doctor --fix` は 45 秒の壁時計内で drain し、残れば再実行してください。失敗が残る場合は debug log を確認してください。",
 		),
 		FixCommand:       "traceary doctor --fix",
 		AutoFixAvailable: true,

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -548,13 +548,16 @@ func hookMemoryExtractJobReadyForGC(job hookMemoryExtractJob, now time.Time) boo
 // includes both GC'd jobs and swept sidecar files, so the whole pass stays
 // bounded by limit regardless of directory size.
 func (c *RootCLI) drainHookMemoryExtractQueue(now time.Time, limit int, skipPaths ...string) (launched, removed int) {
-	launched, removed, _ = c.drainHookMemoryExtractQueueRecorded(now, limit, skipPaths...)
+	launched, removed, _ = c.drainHookMemoryExtractQueueRecorded(now, limit, limit, skipPaths...)
 	return launched, removed
 }
 
-func (c *RootCLI) drainHookMemoryExtractQueueRecorded(now time.Time, limit int, skipPaths ...string) (launched, removed int, launchedPaths []string) {
+func (c *RootCLI) drainHookMemoryExtractQueueRecorded(now time.Time, limit, launchBudget int, skipPaths ...string) (launched, removed int, launchedPaths []string) {
 	if limit <= 0 {
 		return 0, 0, nil
+	}
+	if launchBudget < 0 {
+		launchBudget = 0
 	}
 	skip := make(map[string]struct{}, len(skipPaths))
 	for _, p := range skipPaths {
@@ -588,6 +591,9 @@ func (c *RootCLI) drainHookMemoryExtractQueueRecorded(now time.Time, limit int, 
 			}
 			if hookMemoryExtractJobIsTerminal(job) {
 				// Still within retention; leave visible for doctor.
+				continue
+			}
+			if launched >= launchBudget {
 				continue
 			}
 			if err := c.launchHookMemoryExtractWorker(job.Path); err != nil {
@@ -727,8 +733,8 @@ func memoryExtractQueueFix(c *RootCLI, dryRun bool) (string, error) {
 			hookMemoryExtractDoctorFixLimit, drainable,
 		), nil
 	}
-	launched, removed := c.drainHookMemoryExtractQueueUntil(now, hookMemoryExtractNow().Add(hookMemoryExtractDoctorWall), hookMemoryExtractDoctorFixLimit, hookMemoryExtractNow)
-	remaining := countHookMemoryExtractDrainable(now)
+	launched, removed, launchedPaths := c.drainHookMemoryExtractQueueUntil(now, hookMemoryExtractNow().Add(hookMemoryExtractDoctorWall), hookMemoryExtractDoctorFixLimit, hookMemoryExtractNow)
+	remaining := countHookMemoryExtractDrainableExcept(now, launchedPaths)
 	if remaining > 0 {
 		return localizef(
 			"drained memory extraction queue: launched=%d removed=%d remaining=%d; run `traceary doctor --fix` again to continue",
@@ -743,30 +749,45 @@ func memoryExtractQueueFix(c *RootCLI, dryRun bool) (string, error) {
 	), nil
 }
 
-func (c *RootCLI) drainHookMemoryExtractQueueUntil(now, deadline time.Time, batchLimit int, clock func() time.Time) (launched, removed int) {
+func (c *RootCLI) drainHookMemoryExtractQueueUntil(now, deadline time.Time, batchLimit int, clock func() time.Time) (launched, removed int, launchedPaths []string) {
 	if clock == nil {
 		clock = hookMemoryExtractNow
 	}
 	var skip []string
 	for {
 		if !clock().Before(deadline) {
-			return launched, removed
+			return launched, removed, launchedPaths
 		}
-		batchLaunched, batchRemoved, launchedPaths := c.drainHookMemoryExtractQueueRecorded(now, batchLimit, skip...)
-		skip = append(skip, launchedPaths...)
+		remainingLaunch := batchLimit - launched
+		batchLaunched, batchRemoved, batchPaths := c.drainHookMemoryExtractQueueRecorded(now, batchLimit, remainingLaunch, skip...)
+		skip = append(skip, batchPaths...)
+		launchedPaths = append(launchedPaths, batchPaths...)
 		launched += batchLaunched
 		removed += batchRemoved
 		if batchLaunched+batchRemoved == 0 {
-			return launched, removed
+			return launched, removed, launchedPaths
 		}
 	}
 }
 
 func countHookMemoryExtractDrainable(now time.Time) int {
+	return countHookMemoryExtractDrainableExcept(now, nil)
+}
+
+func countHookMemoryExtractDrainableExcept(now time.Time, excludePaths []string) int {
+	exclude := make(map[string]struct{}, len(excludePaths))
+	for _, p := range excludePaths {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			exclude[trimmed] = struct{}{}
+		}
+	}
 	jobs, _, err := scanHookMemoryExtractJobs()
 	n := 0
 	if err == nil {
 		for _, job := range jobs {
+			if _, skip := exclude[job.Path]; skip {
+				continue
+			}
 			if hookMemoryExtractJobReadyForGC(job, now) || !hookMemoryExtractJobIsTerminal(job) {
 				n++
 			}

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -548,8 +548,13 @@ func hookMemoryExtractJobReadyForGC(job hookMemoryExtractJob, now time.Time) boo
 // includes both GC'd jobs and swept sidecar files, so the whole pass stays
 // bounded by limit regardless of directory size.
 func (c *RootCLI) drainHookMemoryExtractQueue(now time.Time, limit int, skipPaths ...string) (launched, removed int) {
+	launched, removed, _ = c.drainHookMemoryExtractQueueRecorded(now, limit, skipPaths...)
+	return launched, removed
+}
+
+func (c *RootCLI) drainHookMemoryExtractQueueRecorded(now time.Time, limit int, skipPaths ...string) (launched, removed int, launchedPaths []string) {
 	if limit <= 0 {
-		return 0, 0
+		return 0, 0, nil
 	}
 	skip := make(map[string]struct{}, len(skipPaths))
 	for _, p := range skipPaths {
@@ -590,12 +595,13 @@ func (c *RootCLI) drainHookMemoryExtractQueue(now time.Time, limit int, skipPath
 				continue
 			}
 			launched++
+			launchedPaths = append(launchedPaths, job.Path)
 		}
 	}
 	if remaining := limit - (launched + removed); remaining > 0 {
 		removed += sweepHookMemoryExtractSidecars(now, remaining)
 	}
-	return launched, removed
+	return launched, removed, launchedPaths
 }
 
 // sweepHookMemoryExtractSidecars removes files derived from jobs rather than
@@ -741,11 +747,13 @@ func (c *RootCLI) drainHookMemoryExtractQueueUntil(now, deadline time.Time, batc
 	if clock == nil {
 		clock = hookMemoryExtractNow
 	}
+	var skip []string
 	for {
 		if !clock().Before(deadline) {
 			return launched, removed
 		}
-		batchLaunched, batchRemoved := c.drainHookMemoryExtractQueue(now, batchLimit)
+		batchLaunched, batchRemoved, launchedPaths := c.drainHookMemoryExtractQueueRecorded(now, batchLimit, skip...)
+		skip = append(skip, launchedPaths...)
 		launched += batchLaunched
 		removed += batchRemoved
 		if batchLaunched+batchRemoved == 0 {

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -725,12 +725,16 @@ func countHookMemoryExtractSidecars(now time.Time) (locks, tmps int) {
 
 func memoryExtractQueueFix(c *RootCLI, dryRun bool) (string, error) {
 	now := hookMemoryExtractNow()
-	drainable := countHookMemoryExtractDrainable(now)
+	pending, _, err := scanHookMemoryExtractJobs()
+	if err != nil {
+		return "", err
+	}
+	locks, tmps := countHookMemoryExtractSidecars(now)
 	if dryRun {
 		return localizef(
-			"would drain/GC memory extraction queue under a 45s wall (batch %d): drainable=%d",
-			"45 秒の壁時計内で memory extraction queue を drain/GC します（batch %d）: drainable=%d",
-			hookMemoryExtractDoctorFixLimit, drainable,
+			"would drain/GC memory extraction queue under a 45s wall (batch %d): %d pending job(s), %d orphan lock(s), %d aged temp file(s)",
+			"45 秒の壁時計内で memory extraction queue を drain/GC します（batch %d）: 未処理 job %d 件、orphan lock %d 件、古い temp %d 件",
+			hookMemoryExtractDoctorFixLimit, len(pending), locks, tmps,
 		), nil
 	}
 	launched, removed, launchedPaths := c.drainHookMemoryExtractQueueUntil(now, hookMemoryExtractNow().Add(hookMemoryExtractDoctorWall), hookMemoryExtractDoctorFixLimit, hookMemoryExtractNow)

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -774,10 +774,6 @@ func (c *RootCLI) drainHookMemoryExtractQueueUntil(now, deadline time.Time, batc
 	}
 }
 
-func countHookMemoryExtractDrainable(now time.Time) int {
-	return countHookMemoryExtractDrainableExcept(now, nil)
-}
-
 func countHookMemoryExtractDrainableExcept(now time.Time, excludePaths []string) int {
 	exclude := make(map[string]struct{}, len(excludePaths))
 	for _, p := range excludePaths {

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -428,7 +428,7 @@ func TestDrainHookMemoryExtractQueueUntilDrainsMultipleBatchesBeforeDeadline(t *
 
 	root := &RootCLI{}
 	deadline := now.Add(time.Hour)
-	launched, removed := root.drainHookMemoryExtractQueueUntil(now, deadline, 5, func() time.Time { return now })
+	launched, removed, _ := root.drainHookMemoryExtractQueueUntil(now, deadline, 5, func() time.Time { return now })
 	if launched != 0 || removed != orphanCount {
 		t.Fatalf("launched=%d removed=%d, want 0/%d", launched, removed, orphanCount)
 	}
@@ -463,7 +463,7 @@ func TestDrainHookMemoryExtractQueueUntilStopsWhenDeadlineHasPassed(t *testing.T
 
 	root := &RootCLI{}
 	deadline := now.Add(-time.Second)
-	launched, removed := root.drainHookMemoryExtractQueueUntil(now, deadline, 5, func() time.Time { return now })
+	launched, removed, _ := root.drainHookMemoryExtractQueueUntil(now, deadline, 5, func() time.Time { return now })
 	if launched != 0 || removed != 0 {
 		t.Fatalf("launched=%d removed=%d, want 0/0", launched, removed)
 	}
@@ -501,14 +501,15 @@ func TestDrainHookMemoryExtractQueueUntilDoesNotRelaunchPendingJobs(t *testing.T
 		return nil
 	}))
 	deadline := now.Add(time.Hour)
-	launched, removed := root.drainHookMemoryExtractQueueUntil(now, deadline, 5, func() time.Time { return now })
-	if launched != jobCount || removed != 0 {
-		t.Fatalf("launched=%d removed=%d, want %d/0", launched, removed, jobCount)
+	const batch = 5
+	launched, removed, _ := root.drainHookMemoryExtractQueueUntil(now, deadline, batch, func() time.Time { return now })
+	if launched != batch || removed != 0 {
+		t.Fatalf("launched=%d removed=%d, want %d/0 (one doctor launch budget)", launched, removed, batch)
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if len(launchedPaths) != jobCount {
-		t.Fatalf("launcher called %d times, want %d (must not relaunch pending jobs)", len(launchedPaths), jobCount)
+	if len(launchedPaths) != batch {
+		t.Fatalf("launcher called %d times, want %d (must not relaunch or exceed launch budget)", len(launchedPaths), batch)
 	}
 	seen := make(map[string]int, len(launchedPaths))
 	for _, path := range launchedPaths {
@@ -553,6 +554,9 @@ func TestInspectHookMemoryExtractDiagnostics_FixFuncDrains(t *testing.T) {
 	}
 	if !strings.Contains(msg, "launched=1") {
 		t.Fatalf("apply msg = %q", msg)
+	}
+	if !strings.Contains(msg, "remaining=0") {
+		t.Fatalf("apply msg = %q, want remaining=0 (in-flight launches are not leftover)", msg)
 	}
 	if launched != 1 {
 		t.Fatalf("launched = %d", launched)

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -406,6 +406,76 @@ func TestDrainHookMemoryExtractQueue_SidecarSweepIsBounded(t *testing.T) {
 	}
 }
 
+func TestDrainHookMemoryExtractQueueUntilDrainsMultipleBatchesBeforeDeadline(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	queueDir := filepath.Join(stateDir, "memory-extract")
+	if err := os.MkdirAll(queueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	aged := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	const orphanCount = 12
+	for i := 0; i < orphanCount; i++ {
+		lockPath := filepath.Join(queueDir, fmt.Sprintf("orphan-%02d.json.lock", i))
+		if err := os.WriteFile(lockPath, []byte{}, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.Chtimes(lockPath, aged, aged); err != nil {
+			t.Fatalf("Chtimes: %v", err)
+		}
+	}
+
+	root := &RootCLI{}
+	deadline := now.Add(time.Hour)
+	launched, removed := root.drainHookMemoryExtractQueueUntil(now, deadline, 5, func() time.Time { return now })
+	if launched != 0 || removed != orphanCount {
+		t.Fatalf("launched=%d removed=%d, want 0/%d", launched, removed, orphanCount)
+	}
+	entries, err := os.ReadDir(queueDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("remaining entries=%d, want 0", len(entries))
+	}
+}
+
+func TestDrainHookMemoryExtractQueueUntilStopsWhenDeadlineHasPassed(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	queueDir := filepath.Join(stateDir, "memory-extract")
+	if err := os.MkdirAll(queueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	aged := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	const orphanCount = 12
+	for i := 0; i < orphanCount; i++ {
+		lockPath := filepath.Join(queueDir, fmt.Sprintf("orphan-%02d.json.lock", i))
+		if err := os.WriteFile(lockPath, []byte{}, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.Chtimes(lockPath, aged, aged); err != nil {
+			t.Fatalf("Chtimes: %v", err)
+		}
+	}
+
+	root := &RootCLI{}
+	deadline := now.Add(-time.Second)
+	launched, removed := root.drainHookMemoryExtractQueueUntil(now, deadline, 5, func() time.Time { return now })
+	if launched != 0 || removed != 0 {
+		t.Fatalf("launched=%d removed=%d, want 0/0", launched, removed)
+	}
+	entries, err := os.ReadDir(queueDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != orphanCount {
+		t.Fatalf("remaining entries=%d, want %d", len(entries), orphanCount)
+	}
+}
+
 func TestInspectHookMemoryExtractDiagnostics_FixFuncDrains(t *testing.T) {
 	t.Setenv(hookStateDirEnvKey, t.TempDir())
 	now := time.Now().UTC()

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -476,6 +476,49 @@ func TestDrainHookMemoryExtractQueueUntilStopsWhenDeadlineHasPassed(t *testing.T
 	}
 }
 
+func TestDrainHookMemoryExtractQueueUntilDoesNotRelaunchPendingJobs(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	const jobCount = 12
+	for i := 0; i < jobCount; i++ {
+		request := hookMemoryExtractRequest{
+			SessionID:      types.SessionID(fmt.Sprintf("pending-%02d", i)),
+			Workspace:      types.Workspace("traceary"),
+			DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+			SourceBoundary: "session_end",
+		}
+		if _, err := enqueueHookMemoryExtract(request, now.Add(-time.Hour)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	var mu sync.Mutex
+	launchedPaths := []string{}
+	root := NewRootCLI(WithHookMemoryExtractLauncher(func(jobPath string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		launchedPaths = append(launchedPaths, jobPath)
+		return nil
+	}))
+	deadline := now.Add(time.Hour)
+	launched, removed := root.drainHookMemoryExtractQueueUntil(now, deadline, 5, func() time.Time { return now })
+	if launched != jobCount || removed != 0 {
+		t.Fatalf("launched=%d removed=%d, want %d/0", launched, removed, jobCount)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(launchedPaths) != jobCount {
+		t.Fatalf("launcher called %d times, want %d (must not relaunch pending jobs)", len(launchedPaths), jobCount)
+	}
+	seen := make(map[string]int, len(launchedPaths))
+	for _, path := range launchedPaths {
+		seen[path]++
+		if seen[path] > 1 {
+			t.Fatalf("relaunched %q", path)
+		}
+	}
+}
+
 func TestInspectHookMemoryExtractDiagnostics_FixFuncDrains(t *testing.T) {
 	t.Setenv(hookStateDirEnvKey, t.TempDir())
 	now := time.Now().UTC()

--- a/presentation/cli/hook_state_gc.go
+++ b/presentation/cli/hook_state_gc.go
@@ -16,7 +16,13 @@ const (
 	hookStateResidueRetention = 14 * 24 * time.Hour
 	hookStateGCHookBudget     = 20
 	hookStateGCDoctorBudget   = 200
-	hookStateResidueCheckName = "hook-state-residue"
+	// hookStateGCDoctorWall bounds one doctor --fix drain. The hook
+	// invocation path keeps hookStateGCHookBudget and does not loop.
+	hookStateGCDoctorWall = 45 * time.Second
+	// hookStateGCDoctorReservedPerKind keeps diagnostics and ended
+	// markers from starving behind a large per-PID backlog in one batch.
+	hookStateGCDoctorReservedPerKind = 20
+	hookStateResidueCheckName        = "hook-state-residue"
 )
 
 var hookPerPIDStateName = regexp.MustCompile(`^(claude|codex|antigravity|grok|kimi|gemini)-(\d+)(-repo)?$`)
@@ -57,35 +63,27 @@ func inspectHookStateResidueMetadata(now time.Time) doctorCheck {
 			stats.PerPID, stats.StalePerPID, stats.Diagnostics, stats.Ended,
 		),
 		Hint: Localize(
-			"killed host processes leave per-PID state files; SessionEnd diagnostics and ended markers accumulate. Later hooks prune a bounded batch. Run `traceary doctor --fix` to catch up. Does not touch spool/ or spool/dead/.",
-			"異常終了した host は per-PID state を残します。SessionEnd diagnostics と ended marker も蓄積します。後続 hook が bounded batch で掃除し、`traceary doctor --fix` で一括できます。spool/ と spool/dead/ は対象外です。",
+			"killed host processes leave per-PID state files; SessionEnd diagnostics and ended markers accumulate. Later hooks prune a bounded batch. `traceary doctor --fix` drains under a 45s wall; remaining files need another run. Does not touch spool/ or spool/dead/.",
+			"異常終了した host は per-PID state を残します。SessionEnd diagnostics と ended marker も蓄積します。後続 hook が bounded batch で掃除し、`traceary doctor --fix` は 45 秒の壁時計内で続けます。残れば再実行してください。spool/ と spool/dead/ は対象外です。",
 		),
 	}
 	if status == doctorStatusWarn {
 		check.FixCommand = "traceary doctor --fix"
 		check.AutoFixAvailable = true
 		check.FixFunc = func(_ context.Context, dryRun bool) (string, error) {
-			result, err := gcHookStateResidues(now, hookStateGCDoctorBudget, dryRun)
+			result, err := gcHookStateResiduesUntil(now, hookStateGCNow().Add(hookStateGCDoctorWall), hookStateGCDoctorBudget, hookStateGCDoctorReservedPerKind, dryRun, hookStateGCNow)
 			if err != nil {
 				return "", err
 			}
-			return localizef(
-				"pruned hook state residue: removed=%d remaining_stale=%d",
-				"hook state 残渣を prune しました: removed=%d remaining_stale=%d",
-				result.Removed, result.Remaining,
-			), nil
+			return formatHookStateGCFixMessage(result), nil
 		}
 		check.StructuredFixFunc = func(_ context.Context, dryRun bool) (doctorFixResult, error) {
-			result, err := gcHookStateResidues(now, hookStateGCDoctorBudget, dryRun)
+			result, err := gcHookStateResiduesUntil(now, hookStateGCNow().Add(hookStateGCDoctorWall), hookStateGCDoctorBudget, hookStateGCDoctorReservedPerKind, dryRun, hookStateGCNow)
 			if err != nil {
 				return doctorFixResult{}, err
 			}
 			return doctorFixResult{
-				Action: localizef(
-					"pruned hook state residue: removed=%d remaining_stale=%d",
-					"hook state 残渣を prune しました: removed=%d remaining_stale=%d",
-					result.Removed, result.Remaining,
-				),
+				Action:  formatHookStateGCFixMessage(result),
 				Metrics: map[string]int{"removed": result.Removed, "remaining": result.Remaining},
 			}, nil
 		}
@@ -211,6 +209,10 @@ func listAgedFiles(dir string, now time.Time, retention time.Duration, kind hook
 }
 
 func gcHookStateResidues(now time.Time, budget int, dryRun bool) (hookStateGCResult, error) {
+	return gcHookStateResiduesWithReserve(now, budget, 0, dryRun)
+}
+
+func gcHookStateResiduesWithReserve(now time.Time, budget, reservedPerKind int, dryRun bool) (hookStateGCResult, error) {
 	if budget < 1 {
 		budget = hookStateGCHookBudget
 	}
@@ -218,15 +220,15 @@ func gcHookStateResidues(now time.Time, budget int, dryRun bool) (hookStateGCRes
 	if err != nil {
 		return hookStateGCResult{}, err
 	}
-	var result hookStateGCResult
+	stale := 0
 	for _, candidate := range candidates {
-		if !candidate.stale {
-			continue
+		if candidate.stale {
+			stale++
 		}
-		if result.Removed >= budget {
-			result.Remaining++
-			continue
-		}
+	}
+	selected := prioritizeHookStateResidueCandidates(candidates, budget, reservedPerKind)
+	var result hookStateGCResult
+	for _, candidate := range selected {
 		if dryRun {
 			result.Removed++
 			continue
@@ -236,8 +238,133 @@ func gcHookStateResidues(now time.Time, budget int, dryRun bool) (hookStateGCRes
 		}
 		result.Removed++
 	}
+	result.Remaining = stale - result.Removed
+	if result.Remaining < 0 {
+		result.Remaining = 0
+	}
 	return result, nil
 }
+
+// prioritizeHookStateResidueCandidates reserves a quota for diagnostics and
+// ended markers, then fills the rest of the budget from leftover stale
+// candidates in listing order (typically per-PID files). reservedPerKind==0
+// preserves the original listing order used by the hook path.
+func prioritizeHookStateResidueCandidates(candidates []hookResidueCandidate, budget, reservedPerKind int) []hookResidueCandidate {
+	if budget < 1 {
+		return nil
+	}
+	if reservedPerKind < 0 {
+		reservedPerKind = 0
+	}
+	var reserved, leftover []hookResidueCandidate
+	reservedDiag := 0
+	reservedEnded := 0
+	for _, candidate := range candidates {
+		if !candidate.stale {
+			continue
+		}
+		switch {
+		case candidate.kind == hookResidueDiagnostics && reservedDiag < reservedPerKind:
+			reserved = append(reserved, candidate)
+			reservedDiag++
+		case candidate.kind == hookResidueEnded && reservedEnded < reservedPerKind:
+			reserved = append(reserved, candidate)
+			reservedEnded++
+		default:
+			leftover = append(leftover, candidate)
+		}
+	}
+	out := reserved
+	if len(out) > budget {
+		return out[:budget]
+	}
+	for _, candidate := range leftover {
+		if len(out) >= budget {
+			break
+		}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func gcHookStateResiduesUntil(now, deadline time.Time, batchBudget, reservedPerKind int, dryRun bool, clock func() time.Time) (hookStateGCResult, error) {
+	if clock == nil {
+		clock = hookStateGCNow
+	}
+	var total hookStateGCResult
+	for {
+		if !clock().Before(deadline) {
+			remaining, err := countStaleHookStateResidues(now)
+			if err != nil {
+				return total, err
+			}
+			if dryRun {
+				total.Remaining = remaining - total.Removed
+			} else {
+				total.Remaining = remaining
+			}
+			if total.Remaining < 0 {
+				total.Remaining = 0
+			}
+			return total, nil
+		}
+		result, err := gcHookStateResiduesWithReserve(now, batchBudget, reservedPerKind, dryRun)
+		if err != nil {
+			return total, err
+		}
+		if dryRun {
+			// dry-run cannot delete, so looping the same listing would
+			// recount the same files until the deadline. Report one
+			// listing's batch and the leftover stale set.
+			return result, nil
+		}
+		total.Removed += result.Removed
+		if result.Removed == 0 || result.Remaining == 0 {
+			total.Remaining = result.Remaining
+			return total, nil
+		}
+	}
+}
+
+func countStaleHookStateResidues(now time.Time) (int, error) {
+	candidates, err := listHookStateResidueCandidates(now)
+	if err != nil {
+		return 0, err
+	}
+	stale := 0
+	for _, candidate := range candidates {
+		if candidate.stale {
+			stale++
+		}
+	}
+	return stale, nil
+}
+
+func formatHookStateGCFixMessage(result hookStateGCResult) string {
+	if result.Remaining > 0 {
+		return localizef(
+			"pruned hook state residue: removed=%d remaining_stale=%d; run `traceary doctor --fix` again to continue",
+			"hook state 残渣を prune しました: removed=%d remaining_stale=%d。続きは `traceary doctor --fix` を再実行してください",
+			result.Removed, result.Remaining,
+		)
+	}
+	return localizef(
+		"pruned hook state residue: removed=%d remaining_stale=%d",
+		"hook state 残渣を prune しました: removed=%d remaining_stale=%d",
+		result.Removed, result.Remaining,
+	)
+}
+
+func hookStateGCNow() time.Time {
+	if hookStateGCClock != nil {
+		return hookStateGCClock()
+	}
+	return time.Now()
+}
+
+// hookStateGCClock is the wall clock used by doctor --fix loops. Tests
+// replace it; production leaves it nil so time.Now is used.
+var hookStateGCClock func() time.Time
 
 func maybeGCHookStateResidues() {
 	_, _ = gcHookStateResidues(time.Now().UTC(), hookStateGCHookBudget, false)

--- a/presentation/cli/hook_state_gc_test.go
+++ b/presentation/cli/hook_state_gc_test.go
@@ -92,3 +92,92 @@ func TestGCHookStateResiduesRemovesStalePIDAndAgedMarkers(t *testing.T) {
 		t.Fatal("aged ended marker must be removed")
 	}
 }
+
+func TestGCHookStateResiduesUntilDrainsMultipleBatchesBeforeDeadline(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Now().UTC()
+	writeStaleHookPIDFiles(t, stateDir, now, 5)
+
+	deadline := now.Add(time.Hour)
+	result, err := gcHookStateResiduesUntil(now, deadline, 2, 0, false, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("until: %v", err)
+	}
+	if result.Removed != 5 || result.Remaining != 0 {
+		t.Fatalf("removed=%d remaining=%d, want 5/0", result.Removed, result.Remaining)
+	}
+}
+
+func TestGCHookStateResiduesUntilStopsWhenDeadlineHasPassed(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Now().UTC()
+	writeStaleHookPIDFiles(t, stateDir, now, 5)
+
+	deadline := now.Add(-time.Second)
+	result, err := gcHookStateResiduesUntil(now, deadline, 2, 0, false, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("until: %v", err)
+	}
+	if result.Removed != 0 || result.Remaining != 5 {
+		t.Fatalf("removed=%d remaining=%d, want 0/5", result.Removed, result.Remaining)
+	}
+}
+
+func TestPrioritizeHookStateResidueCandidatesReservesDiagnostics(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Now().UTC()
+	pids := writeStaleHookPIDFiles(t, stateDir, now, 3)
+
+	diagDir := filepath.Join(stateDir, "diagnostics")
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agedDiag := filepath.Join(diagDir, "old.json")
+	if err := os.WriteFile(agedDiag, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agedAt := now.Add(-hookStateResidueRetention - time.Hour)
+	if err := os.Chtimes(agedDiag, agedAt, agedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := gcHookStateResiduesWithReserve(now, 2, 1, false)
+	if err != nil {
+		t.Fatalf("gc: %v", err)
+	}
+	if result.Removed != 2 || result.Remaining != 2 {
+		t.Fatalf("removed=%d remaining=%d, want 2/2", result.Removed, result.Remaining)
+	}
+	if _, err := os.Stat(agedDiag); !os.IsNotExist(err) {
+		t.Fatal("reserved diagnostic must be removed in the first batch")
+	}
+	removedPID := 0
+	for _, path := range pids {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			removedPID++
+		}
+	}
+	if removedPID != 1 {
+		t.Fatalf("removed PID files=%d, want 1", removedPID)
+	}
+}
+
+func writeStaleHookPIDFiles(t *testing.T, stateDir string, now time.Time, n int) []string {
+	t.Helper()
+	old := now.Add(-hookStatePIDAgeFloor - time.Hour)
+	paths := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		path := filepath.Join(stateDir, "codex-99999"+strconv.Itoa(i))
+		if err := os.WriteFile(path, []byte("sess"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}


### PR DESCRIPTION
doctor --fix loops hook-state (200) and memory-extract (50) batches under a 45s wall. Diagnostics/ended get reserved quota 20 so PID backlog cannot starve them. Hook budgets stay 20/3. Remaining>0 asks for another --fix.

Closes #2055
Leaves parent #2049 open