### PR TITLE
fix: stop treating empty cancellation diagnostics as forever-unreadable

### DIFF
--- a/presentation/cli/hook_diagnostics.go
+++ b/presentation/cli/hook_diagnostics.go
@@ -127,8 +127,8 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsWithLookup(ctx context
 				"読めない diagnostic file を確認してください。読める diagnostic が無いことは、Claude が Traceary 起動前に hook を cancel していない証明にはなりません",
 			),
 			Message: localizef(
-				"found unreadable Claude hook cancellation diagnostic file(s): %s",
-				"読めない Claude hook cancellation diagnostic file があります: %s",
+				"found unreadable nonempty Claude hook cancellation diagnostic file(s): %s",
+				"読めない nonempty の Claude hook cancellation diagnostic file があります: %s",
 				strings.Join(scan.Unreadable, ", "),
 			),
 		}
@@ -204,8 +204,8 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsWithLookup(ctx context
 			"この marker は Traceary が Claude SessionEnd まで到達したものの正常完了していないことを示します。file と最近の `traceary list --agent claude` を確認し、stale と判断できたら marker を削除してください。Claude が Traceary 起動前に cancel した場合、marker は書けません。",
 		),
 		Message: localizef(
-			"found %d actionable Claude SessionEnd hook cancellation diagnostic(s), %d resolved, %d unknown-store; latest phase=%s host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
-			"対応が必要な Claude SessionEnd hook cancellation diagnostic が %d 件、解決済みが %d 件、ストア不明が %d 件あります。latest phase=%s host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
+			"found %d unresolved Claude SessionEnd hook cancellation diagnostic(s), %d resolved, %d unknown-store; latest phase=%s host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
+			"未解決の Claude SessionEnd hook cancellation diagnostic が %d 件、解決済みが %d 件、ストア不明が %d 件あります。latest phase=%s host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
 			len(classification.Actionable),
 			len(classification.Resolved),
 			len(classification.Unknown),
@@ -512,7 +512,18 @@ func formatUnreadableHookDiagnosticsSuffix(paths []string) string {
 	if len(paths) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("; unreadable=%s", strings.Join(paths, ","))
+	return fmt.Sprintf("; unreadable_nonempty=%s", strings.Join(paths, ","))
+}
+
+func hookDiagnosticEntrySize(entry os.DirEntry) int64 {
+	if entry == nil {
+		return -1
+	}
+	info, err := entry.Info()
+	if err != nil {
+		return -1
+	}
+	return info.Size()
 }
 
 func scanHookCancellationDiagnostics(client, hostEvent string, workspace types.Workspace) (hookCancellationDiagnosticScan, error) {
@@ -539,7 +550,15 @@ func scanHookCancellationDiagnostics(client, hostEvent string, workspace types.W
 		path := filepath.Join(diagnosticsDir, entry.Name())
 		data, err := os.ReadFile(path)
 		if err != nil {
+			if hookDiagnosticEntrySize(entry) == 0 {
+				continue
+			}
 			scan.Unreadable = append(scan.Unreadable, path)
+			continue
+		}
+		if len(data) == 0 {
+			// Crash-while-write 0-byte markers never become readable.
+			// Aged ones are residue GC; none count as "needs attention".
 			continue
 		}
 		var record hookCancellationDiagnostic

--- a/presentation/cli/hook_diagnostics_test.go
+++ b/presentation/cli/hook_diagnostics_test.go
@@ -291,6 +291,7 @@ func writeHookCancellationDiagnosticForTest(t *testing.T, path string, record ho
 }
 
 func TestScanHookCancellationDiagnosticsSkipsEmptyMarkers(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)
 	now := time.Now().UTC()

--- a/presentation/cli/hook_diagnostics_test.go
+++ b/presentation/cli/hook_diagnostics_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -286,5 +287,50 @@ func writeHookCancellationDiagnosticForTest(t *testing.T, path string, record ho
 	encoded = append(encoded, '\n')
 	if err := os.WriteFile(path, encoded, 0o600); err != nil {
 		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func TestScanHookCancellationDiagnosticsSkipsEmptyMarkers(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Now().UTC()
+	diagDir := filepath.Join(stateDir, "diagnostics")
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	emptyAged := filepath.Join(diagDir, "claude-SessionEnd-empty-aged.json")
+	emptyFresh := filepath.Join(diagDir, "claude-SessionEnd-empty-fresh.json")
+	garbage := filepath.Join(diagDir, "claude-SessionEnd-garbage.json")
+	for _, path := range []string{emptyAged, emptyFresh} {
+		if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(garbage, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agedAt := now.Add(-hookStateResidueRetention - time.Hour)
+	if err := os.Chtimes(emptyAged, agedAt, agedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	scan, err := scanHookCancellationDiagnostics("claude", "SessionEnd", "")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(scan.Records) != 0 {
+		t.Fatalf("records=%d, want 0", len(scan.Records))
+	}
+	if len(scan.Unreadable) != 1 || scan.Unreadable[0] != garbage {
+		t.Fatalf("unreadable=%v, want only nonempty garbage", scan.Unreadable)
+	}
+
+	root := &RootCLI{}
+	check := root.inspectClaudeHookCancellationDiagnosticsWithLookup(context.Background(), "", "", nil)
+	if strings.Contains(check.Message, emptyAged) || strings.Contains(check.Message, emptyFresh) {
+		t.Fatalf("empty markers must not be needs-attention: %q", check.Message)
+	}
+	if !strings.Contains(check.Message, "unreadable nonempty") || !strings.Contains(check.Message, garbage) {
+		t.Fatalf("nonempty unreadable must remain reported: %q", check.Message)
 	}
 }

--- a/presentation/cli/hook_state_gc.go
+++ b/presentation/cli/hook_state_gc.go
@@ -58,8 +58,8 @@ func inspectHookStateResidueMetadata(now time.Time) doctorCheck {
 		Name:   hookStateResidueCheckName,
 		Status: status,
 		Message: localizef(
-			"hook state residue: per_pid=%d stale_pid=%d diagnostics=%d ended=%d",
-			"hook state 残渣: per_pid=%d stale_pid=%d diagnostics=%d ended=%d",
+			"hook state residue: per_pid=%d stale_pid=%d aged_diagnostics=%d aged_ended=%d",
+			"hook state 残渣: per_pid=%d stale_pid=%d aged_diagnostics=%d aged_ended=%d",
 			stats.PerPID, stats.StalePerPID, stats.Diagnostics, stats.Ended,
 		),
 		Hint: Localize(

--- a/presentation/cli/hook_state_gc_test.go
+++ b/presentation/cli/hook_state_gc_test.go
@@ -95,6 +95,7 @@ func TestGCHookStateResiduesRemovesStalePIDAndAgedMarkers(t *testing.T) {
 }
 
 func TestGCHookStateResiduesRemovesEmptyAgedDiagnostic(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)
 	now := time.Now().UTC()

--- a/presentation/cli/hook_state_gc_test.go
+++ b/presentation/cli/hook_state_gc_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -90,6 +91,43 @@ func TestGCHookStateResiduesRemovesStalePIDAndAgedMarkers(t *testing.T) {
 	}
 	if _, err := os.Stat(agedEnded); !os.IsNotExist(err) {
 		t.Fatal("aged ended marker must be removed")
+	}
+}
+
+func TestGCHookStateResiduesRemovesEmptyAgedDiagnostic(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Now().UTC()
+	diagDir := filepath.Join(stateDir, "diagnostics")
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	emptyAged := filepath.Join(diagDir, "claude-SessionEnd-empty.json")
+	if err := os.WriteFile(emptyAged, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agedAt := now.Add(-hookStateResidueRetention - time.Hour)
+	if err := os.Chtimes(emptyAged, agedAt, agedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	check := inspectHookStateResidueMetadata(now)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q, want warn", check.Status)
+	}
+	if !strings.Contains(check.Message, "aged_diagnostics=1") || !strings.Contains(check.Message, "aged_ended=0") {
+		t.Fatalf("message=%q, want aged population labels", check.Message)
+	}
+
+	result, err := gcHookStateResidues(now, hookStateGCDoctorBudget, false)
+	if err != nil {
+		t.Fatalf("gc: %v", err)
+	}
+	if result.Removed != 1 {
+		t.Fatalf("removed=%d, want 1", result.Removed)
+	}
+	if _, err := os.Stat(emptyAged); !os.IsNotExist(err) {
+		t.Fatal("empty aged diagnostic must be GC-eligible residue")
 	}
 }
 


### PR DESCRIPTION
0-byte crash markers past residue retention are GC-eligible and no longer count as needs-attention. Nonempty unreadable files stay reported. Messages label aged vs unresolved populations.

Closes #2056
Leaves parent #2049 open