### PR TITLE
docs: route session skills and help off session latest

### DIFF
--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -361,10 +361,10 @@ func validateSessionHistorySkillContract(rel, body string) error {
 		{
 			section: "Discovery",
 			body:    discovery,
-			concept: "workspace-recent reads via context and list/search",
+			concept: "workspace-recent session ids via list/search metadata",
 			variants: [][]string{
-				{"traceary context", "list"},
-				{"context", "list", "search"},
+				{"list", "search"},
+				{"traceary list"},
 			},
 		},
 		{

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -361,10 +361,10 @@ func validateSessionHistorySkillContract(rel, body string) error {
 		{
 			section: "Discovery",
 			body:    discovery,
-			concept: "session latest and session latest --active entry points",
+			concept: "workspace-recent reads via context and list/search",
 			variants: [][]string{
-				{"session latest", "session latest --active"},
-				{"traceary session latest", "traceary session latest --active"},
+				{"traceary context", "list"},
+				{"context", "list", "search"},
 			},
 		},
 		{
@@ -402,6 +402,9 @@ func validateSessionHistorySkillContract(rel, body string) error {
 	}
 	if err := validateSessionHistoryDiscoveryFields(rel, discovery); err != nil {
 		return err
+	}
+	if strings.Contains(strings.ToLower(body), "session latest") {
+		return xerrors.Errorf("%s must not instruct session latest", rel)
 	}
 	if strings.Contains(strings.ToLower(body), "mcp server") || strings.Contains(body, "list_events") || strings.Contains(body, "manage_memory") {
 		return xerrors.Errorf("%s must use the CLI read path, not MCP tool names", rel)
@@ -484,6 +487,15 @@ func validateSessionRefineSkillContract(rel, body string) error {
 	}
 	if !strings.Contains(body, "How it went") {
 		return xerrors.Errorf("%s must mention optional How it went", rel)
+	}
+	if strings.Contains(strings.ToLower(body), "session latest") {
+		return xerrors.Errorf("%s must not instruct session latest", rel)
+	}
+	if !strings.Contains(body, "[Traceary] Session") {
+		return xerrors.Errorf("%s must take the session id from the hook [Traceary] Session line", rel)
+	}
+	if !strings.Contains(body, "traceary context") {
+		return xerrors.Errorf("%s must fall back to traceary context when the hook line is absent", rel)
 	}
 	return nil
 }

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -114,7 +114,7 @@ func TestValidateSessionHistorySkillContract_AcceptsEquivalentContractWording(t 
 ### 1. Discovery
 Use traceary list with --workspace and a limit of 5.
 traceary list --workspace x --limit 5 --json --fields id,ts,kind,session
-Use session latest or session latest --active when the question is about a session.
+Use traceary context and list or search when the question is about recent work.
 
 ### 2. Inspection
 Example: traceary context.
@@ -130,6 +130,75 @@ For a single event, run traceary show <event-id>.
 	}
 }
 
+func TestValidateSessionHistorySkillContract_RejectsSessionLatest(t *testing.T) {
+	t.Parallel()
+
+	body := `
+### 1. Discovery
+Use traceary list with --workspace and a limit of 5.
+traceary list --workspace x --limit 5 --json --fields id,ts,kind,session
+Use traceary context and list or search when the question is about recent work.
+Use session latest if you still want the last session.
+
+### 2. Inspection
+Example: traceary context.
+traceary context has no event-id filter and narrows only with workspace, session_id, and limit.
+
+### 3. Detail
+For a single event, run traceary show <event-id>.
+
+## Preferred tools
+`
+	err := validateSessionHistorySkillContract("skill", body)
+	if err == nil {
+		t.Fatal("validateSessionHistorySkillContract() error = nil, want session latest rejection")
+	}
+	if !strings.Contains(err.Error(), "session latest") {
+		t.Fatalf("error = %v, want session latest prohibition", err)
+	}
+}
+
+func TestValidateSessionRefineSkillContract_RequiresHookSessionAndContext(t *testing.T) {
+	t.Parallel()
+
+	body := `
+Motivation
+The change
+How it went
+session refine
+covers-to
+Merge
+[Traceary] Session <id>
+traceary context
+`
+	if err := validateSessionRefineSkillContract("skill", body); err != nil {
+		t.Fatalf("validateSessionRefineSkillContract() error = %v, want nil", err)
+	}
+}
+
+func TestValidateSessionRefineSkillContract_RejectsSessionLatest(t *testing.T) {
+	t.Parallel()
+
+	body := `
+Motivation
+The change
+How it went
+session refine
+covers-to
+Merge
+[Traceary] Session <id>
+traceary context
+session latest
+`
+	err := validateSessionRefineSkillContract("skill", body)
+	if err == nil {
+		t.Fatal("validateSessionRefineSkillContract() error = nil, want session latest rejection")
+	}
+	if !strings.Contains(err.Error(), "session latest") {
+		t.Fatalf("error = %v, want session latest prohibition", err)
+	}
+}
+
 func TestValidateSessionHistorySkillContract_RejectsMissingContextScope(t *testing.T) {
 	t.Parallel()
 
@@ -137,7 +206,7 @@ func TestValidateSessionHistorySkillContract_RejectsMissingContextScope(t *testi
 ### 1. Discovery
 Use traceary list with --workspace and a limit of 5.
 traceary list --workspace x --limit 5 --json --fields id,ts,kind,session
-Use session latest or session latest --active when the question is about a session.
+Use traceary context and list or search when the question is about recent work.
 
 ### 2. Inspection
 Example: traceary context.
@@ -163,7 +232,7 @@ func TestValidateSessionHistoryDiscoveryFields_RejectsBareListWithoutFields(t *t
 	body := `
 ### 1. Discovery
 traceary list --workspace x --limit 5
-Use session latest or session latest --active.
+Use traceary context and list or search.
 
 ### 2. Inspection
 Example: traceary context.
@@ -189,7 +258,7 @@ func TestValidateSessionHistoryDiscoveryFields_RejectsMessageWithoutMetadataOnly
 	body := `
 ### 1. Discovery
 traceary list --workspace x --limit 5 --json --fields id,ts,kind,message
-Use session latest or session latest --active.
+Use traceary context and list or search.
 
 ### 2. Inspection
 Example: traceary context.
@@ -215,7 +284,7 @@ func TestValidateSessionHistoryDiscoveryFields_RejectsFieldsWithoutID(t *testing
 	body := `
 ### 1. Discovery
 traceary list --workspace x --limit 5 --json --fields ts,kind,session
-Use session latest or session latest --active.
+Use traceary context and list or search.
 
 ### 2. Inspection
 Example: traceary context.

--- a/docs/integrations/skills.ja.md
+++ b/docs/integrations/skills.ja.md
@@ -8,7 +8,7 @@ skill は **Traceary CLI** 経由（MCP ではない）で案内し、shell 呼�
 
 | Skill | Job | 主な CLI |
 | --- | --- | --- |
-| `traceary-session-history` | 過去 session / event / audit の参照 | `list`, `search`, `context`, `show`, `report`, `session latest`, `session latest --active` |
+| `traceary-session-history` | 過去 session / event / audit の参照 | `list`, `search`, `context`, `show`, `report` |
 | `traceary-session-refine` | session refinement を書き、後から body を discard できるようにする | `session refine` |
 | `traceary-memory-review` | memory inbox の curate。任意で inline の session recap | `memory inbox list` / `accept` / `reject`（+ 対話 `review`） |
 | `traceary-memory-remember` | 明示的な user ask のときだけ durable memory を propose | `memory store propose`（`memory store remember` は使わない） |

--- a/docs/integrations/skills.md
+++ b/docs/integrations/skills.md
@@ -9,7 +9,7 @@ observable.
 
 | Skill | Job | Primary CLI |
 | --- | --- | --- |
-| `traceary-session-history` | Read prior sessions, events, and audits | `list`, `search`, `context`, `show`, `report`, `session latest`, `session latest --active` |
+| `traceary-session-history` | Read prior sessions, events, and audits | `list`, `search`, `context`, `show`, `report` |
 | `traceary-session-refine` | Write a session refinement so bodies can later be discarded | `session refine` |
 | `traceary-memory-review` | Curate the memory inbox; optional inline session recap | `memory inbox list` / `accept` / `reject` (+ interactive `review`) |
 | `traceary-memory-remember` | Propose durable memory only on an explicit user ask | `memory store propose` (never `memory store remember`) |

--- a/integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md
@@ -52,10 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-When the question is about the most recent or still-open work, start with
-`traceary context` (workspace-recent events) and the same small `list` /
-`search` Discovery query. Take the session id from that output. Do not
-resolve the session from a session-listing command.
+When the question is about the most recent or still-open work, run the same
+small `list` / `search` Discovery query and take the session id from those
+metadata rows. Use a bounded `traceary context` only in Inspection, after
+Discovery. Do not resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -96,7 +96,6 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Traceary session history
@@ -52,9 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-Use `traceary session latest` first when the task is specifically about the most
-recent session; use `traceary session latest --active` only when it asks about an open
-session.
+When the question is about the most recent or still-open work, start with
+`traceary context` (workspace-recent events) and the same small `list` /
+`search` Discovery query. Take the session id from that output. Do not
+resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -95,8 +96,7 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary session latest`: most recent session metadata for the current workspace
-- `traceary session latest --active`: only when the question is specifically about an open session
+- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/antigravity-plugin/skills/traceary-session-refine/SKILL.md
+++ b/integrations/antigravity-plugin/skills/traceary-session-refine/SKILL.md
@@ -28,9 +28,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 ## Workflow
 
 1. **Identify the session**. Prefer the session id from the hook nudge
-   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
-   and take the session id from workspace-recent events. Do not resolve the
-   session from a session-listing command.
+   (`[Traceary] Session <id> …`). If that line is absent, run a bounded
+   `traceary context --limit 1` (or the session-history Discovery `list`
+   query) and take the session id. Do not resolve the session from a
+   session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/antigravity-plugin/skills/traceary-session-refine/SKILL.md
+++ b/integrations/antigravity-plugin/skills/traceary-session-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-refine
 description: Use when Traceary asks for a session refinement (consolidation threshold), or when the user asks to summarize/refine the current session so event bodies can later be discarded. Trigger phrases — "session refine", "refine this session", "session summary", "write a refinement", "セッション要約", "refinement を書いて". Do not use for durable L3 memory facts (that is traceary-memory-remember) or inbox review.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session refine
@@ -27,14 +27,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 
 ## Workflow
 
-1. **Identify the session**. Prefer the session named in the consolidation ask.
-   Otherwise:
-
-   ```sh
-   traceary session latest --active
-   # or
-   traceary session latest
-   ```
+1. **Identify the session**. Prefer the session id from the hook nudge
+   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
+   and take the session id from workspace-recent events. Do not resolve the
+   session from a session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
@@ -52,10 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-When the question is about the most recent or still-open work, start with
-`traceary context` (workspace-recent events) and the same small `list` /
-`search` Discovery query. Take the session id from that output. Do not
-resolve the session from a session-listing command.
+When the question is about the most recent or still-open work, run the same
+small `list` / `search` Discovery query and take the session id from those
+metadata rows. Use a bounded `traceary context` only in Inspection, after
+Discovery. Do not resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -96,7 +96,6 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Traceary session history
@@ -52,9 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-Use `traceary session latest` first when the task is specifically about the most
-recent session; use `traceary session latest --active` only when it asks about an open
-session.
+When the question is about the most recent or still-open work, start with
+`traceary context` (workspace-recent events) and the same small `list` /
+`search` Discovery query. Take the session id from that output. Do not
+resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -95,8 +96,7 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary session latest`: most recent session metadata for the current workspace
-- `traceary session latest --active`: only when the question is specifically about an open session
+- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/claude-plugin/skills/traceary-session-refine/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-session-refine/SKILL.md
@@ -28,9 +28,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 ## Workflow
 
 1. **Identify the session**. Prefer the session id from the hook nudge
-   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
-   and take the session id from workspace-recent events. Do not resolve the
-   session from a session-listing command.
+   (`[Traceary] Session <id> …`). If that line is absent, run a bounded
+   `traceary context --limit 1` (or the session-history Discovery `list`
+   query) and take the session id. Do not resolve the session from a
+   session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/claude-plugin/skills/traceary-session-refine/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-session-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-refine
 description: Use when Traceary asks for a session refinement (consolidation threshold), or when the user asks to summarize/refine the current session so event bodies can later be discarded. Trigger phrases — "session refine", "refine this session", "session summary", "write a refinement", "セッション要約", "refinement を書いて". Do not use for durable L3 memory facts (that is traceary-memory-remember) or inbox review.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session refine
@@ -27,14 +27,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 
 ## Workflow
 
-1. **Identify the session**. Prefer the session named in the consolidation ask.
-   Otherwise:
-
-   ```sh
-   traceary session latest --active
-   # or
-   traceary session latest
-   ```
+1. **Identify the session**. Prefer the session id from the hook nudge
+   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
+   and take the session id from workspace-recent events. Do not resolve the
+   session from a session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/gemini-extension/skills/traceary-session-history/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-session-history/SKILL.md
@@ -52,10 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-When the question is about the most recent or still-open work, start with
-`traceary context` (workspace-recent events) and the same small `list` /
-`search` Discovery query. Take the session id from that output. Do not
-resolve the session from a session-listing command.
+When the question is about the most recent or still-open work, run the same
+small `list` / `search` Discovery query and take the session id from those
+metadata rows. Use a bounded `traceary context` only in Inspection, after
+Discovery. Do not resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -96,7 +96,6 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/gemini-extension/skills/traceary-session-history/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-session-history/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Traceary session history
@@ -52,9 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-Use `traceary session latest` first when the task is specifically about the most
-recent session; use `traceary session latest --active` only when it asks about an open
-session.
+When the question is about the most recent or still-open work, start with
+`traceary context` (workspace-recent events) and the same small `list` /
+`search` Discovery query. Take the session id from that output. Do not
+resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -95,8 +96,7 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary session latest`: most recent session metadata for the current workspace
-- `traceary session latest --active`: only when the question is specifically about an open session
+- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/gemini-extension/skills/traceary-session-refine/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-session-refine/SKILL.md
@@ -28,9 +28,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 ## Workflow
 
 1. **Identify the session**. Prefer the session id from the hook nudge
-   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
-   and take the session id from workspace-recent events. Do not resolve the
-   session from a session-listing command.
+   (`[Traceary] Session <id> …`). If that line is absent, run a bounded
+   `traceary context --limit 1` (or the session-history Discovery `list`
+   query) and take the session id. Do not resolve the session from a
+   session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/gemini-extension/skills/traceary-session-refine/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-session-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-refine
 description: Use when Traceary asks for a session refinement (consolidation threshold), or when the user asks to summarize/refine the current session so event bodies can later be discarded. Trigger phrases — "session refine", "refine this session", "session summary", "write a refinement", "セッション要約", "refinement を書いて". Do not use for durable L3 memory facts (that is traceary-memory-remember) or inbox review.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session refine
@@ -27,14 +27,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 
 ## Workflow
 
-1. **Identify the session**. Prefer the session named in the consolidation ask.
-   Otherwise:
-
-   ```sh
-   traceary session latest --active
-   # or
-   traceary session latest
-   ```
+1. **Identify the session**. Prefer the session id from the hook nudge
+   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
+   and take the session id from workspace-recent events. Do not resolve the
+   session from a session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
@@ -52,10 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-When the question is about the most recent or still-open work, start with
-`traceary context` (workspace-recent events) and the same small `list` /
-`search` Discovery query. Take the session id from that output. Do not
-resolve the session from a session-listing command.
+When the question is about the most recent or still-open work, run the same
+small `list` / `search` Discovery query and take the session id from those
+metadata rows. Use a bounded `traceary context` only in Inspection, after
+Discovery. Do not resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -96,7 +96,6 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Traceary session history
@@ -52,9 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-Use `traceary session latest` first when the task is specifically about the most
-recent session; use `traceary session latest --active` only when it asks about an open
-session.
+When the question is about the most recent or still-open work, start with
+`traceary context` (workspace-recent events) and the same small `list` /
+`search` Discovery query. Take the session id from that output. Do not
+resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -95,8 +96,7 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary session latest`: most recent session metadata for the current workspace
-- `traceary session latest --active`: only when the question is specifically about an open session
+- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/grok-plugin/skills/traceary-session-refine/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-session-refine/SKILL.md
@@ -28,9 +28,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 ## Workflow
 
 1. **Identify the session**. Prefer the session id from the hook nudge
-   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
-   and take the session id from workspace-recent events. Do not resolve the
-   session from a session-listing command.
+   (`[Traceary] Session <id> …`). If that line is absent, run a bounded
+   `traceary context --limit 1` (or the session-history Discovery `list`
+   query) and take the session id. Do not resolve the session from a
+   session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/grok-plugin/skills/traceary-session-refine/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-session-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-refine
 description: Use when Traceary asks for a session refinement (consolidation threshold), or when the user asks to summarize/refine the current session so event bodies can later be discarded. Trigger phrases — "session refine", "refine this session", "session summary", "write a refinement", "セッション要約", "refinement を書いて". Do not use for durable L3 memory facts (that is traceary-memory-remember) or inbox review.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session refine
@@ -27,14 +27,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 
 ## Workflow
 
-1. **Identify the session**. Prefer the session named in the consolidation ask.
-   Otherwise:
-
-   ```sh
-   traceary session latest --active
-   # or
-   traceary session latest
-   ```
+1. **Identify the session**. Prefer the session id from the hook nudge
+   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
+   and take the session id from workspace-recent events. Do not resolve the
+   session from a session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
@@ -52,10 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-When the question is about the most recent or still-open work, start with
-`traceary context` (workspace-recent events) and the same small `list` /
-`search` Discovery query. Take the session id from that output. Do not
-resolve the session from a session-listing command.
+When the question is about the most recent or still-open work, run the same
+small `list` / `search` Discovery query and take the session id from those
+metadata rows. Use a bounded `traceary context` only in Inspection, after
+Discovery. Do not resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -96,7 +96,6 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Traceary session history
@@ -52,9 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-Use `traceary session latest` first when the task is specifically about the most
-recent session; use `traceary session latest --active` only when it asks about an open
-session.
+When the question is about the most recent or still-open work, start with
+`traceary context` (workspace-recent events) and the same small `list` /
+`search` Discovery query. Take the session id from that output. Do not
+resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -95,8 +96,7 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary session latest`: most recent session metadata for the current workspace
-- `traceary session latest --active`: only when the question is specifically about an open session
+- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/integrations/kimi-plugin/skills/traceary-session-refine/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-session-refine/SKILL.md
@@ -28,9 +28,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 ## Workflow
 
 1. **Identify the session**. Prefer the session id from the hook nudge
-   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
-   and take the session id from workspace-recent events. Do not resolve the
-   session from a session-listing command.
+   (`[Traceary] Session <id> …`). If that line is absent, run a bounded
+   `traceary context --limit 1` (or the session-history Discovery `list`
+   query) and take the session id. Do not resolve the session from a
+   session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/integrations/kimi-plugin/skills/traceary-session-refine/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-session-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-refine
 description: Use when Traceary asks for a session refinement (consolidation threshold), or when the user asks to summarize/refine the current session so event bodies can later be discarded. Trigger phrases — "session refine", "refine this session", "session summary", "write a refinement", "セッション要約", "refinement を書いて". Do not use for durable L3 memory facts (that is traceary-memory-remember) or inbox review.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session refine
@@ -27,14 +27,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 
 ## Workflow
 
-1. **Identify the session**. Prefer the session named in the consolidation ask.
-   Otherwise:
-
-   ```sh
-   traceary session latest --active
-   # or
-   traceary session latest
-   ```
+1. **Identify the session**. Prefer the session id from the hook nudge
+   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
+   and take the session id from workspace-recent events. Do not resolve the
+   session from a session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/plugins/traceary/commands/help.md
+++ b/plugins/traceary/commands/help.md
@@ -25,7 +25,7 @@ traceary --help
 ```
 
 If the question is about history or recall, prefer the Traceary CLI read path
-(`traceary list` / `search` / `context` / `show` / `session latest` / `session latest --active`) or
+(`traceary list` / `search` / `context` / `show` / `report`) or
 the `traceary-session-history` skill instead of direct SQLite access.
 
 ## Skills

--- a/plugins/traceary/skills/traceary-session-history/SKILL.md
+++ b/plugins/traceary/skills/traceary-session-history/SKILL.md
@@ -52,10 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-When the question is about the most recent or still-open work, start with
-`traceary context` (workspace-recent events) and the same small `list` /
-`search` Discovery query. Take the session id from that output. Do not
-resolve the session from a session-listing command.
+When the question is about the most recent or still-open work, run the same
+small `list` / `search` Discovery query and take the session id from those
+metadata rows. Use a bounded `traceary context` only in Inspection, after
+Discovery. Do not resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -96,7 +96,6 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/plugins/traceary/skills/traceary-session-history/SKILL.md
+++ b/plugins/traceary/skills/traceary-session-history/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Traceary session history
@@ -52,9 +52,10 @@ traceary search "<query>" \
 Both `list` and `search` accept `--session-id` when a session is already known.
 Omit unknown filters rather than guessing them.
 
-Use `traceary session latest` first when the task is specifically about the most
-recent session; use `traceary session latest --active` only when it asks about an open
-session.
+When the question is about the most recent or still-open work, start with
+`traceary context` (workspace-recent events) and the same small `list` /
+`search` Discovery query. Take the session id from that output. Do not
+resolve the session from a session-listing command.
 
 ### 2. Inspection — bounded context for selected candidates
 
@@ -95,8 +96,7 @@ the first history query.
 
 ## Preferred tools
 
-- `traceary session latest`: most recent session metadata for the current workspace
-- `traceary session latest --active`: only when the question is specifically about an open session
+- `traceary context`: workspace-recent events and a session id when the question is about recent or open work
 - `traceary list --json --fields id,ts,kind,session`: Discovery for recent metadata (always include `id`; never `message` at this stage)
 - `traceary search "<query>" --json --fields id,ts,kind,session`: Discovery for a narrow literal query (same field rule)
 - `traceary context`: bounded surrounding context narrowed only by workspace, session-id, and limit; it cannot target an event id

--- a/plugins/traceary/skills/traceary-session-refine/SKILL.md
+++ b/plugins/traceary/skills/traceary-session-refine/SKILL.md
@@ -28,9 +28,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 ## Workflow
 
 1. **Identify the session**. Prefer the session id from the hook nudge
-   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
-   and take the session id from workspace-recent events. Do not resolve the
-   session from a session-listing command.
+   (`[Traceary] Session <id> …`). If that line is absent, run a bounded
+   `traceary context --limit 1` (or the session-history Discovery `list`
+   query) and take the session id. Do not resolve the session from a
+   session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/plugins/traceary/skills/traceary-session-refine/SKILL.md
+++ b/plugins/traceary/skills/traceary-session-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-session-refine
 description: Use when Traceary asks for a session refinement (consolidation threshold), or when the user asks to summarize/refine the current session so event bodies can later be discarded. Trigger phrases — "session refine", "refine this session", "session summary", "write a refinement", "セッション要約", "refinement を書いて". Do not use for durable L3 memory facts (that is traceary-memory-remember) or inbox review.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session refine
@@ -27,14 +27,10 @@ saying why is not — that is what the mechanical fallback already produces for 
 
 ## Workflow
 
-1. **Identify the session**. Prefer the session named in the consolidation ask.
-   Otherwise:
-
-   ```sh
-   traceary session latest --active
-   # or
-   traceary session latest
-   ```
+1. **Identify the session**. Prefer the session id from the hook nudge
+   (`[Traceary] Session <id> …`). If that line is absent, run `traceary context`
+   and take the session id from workspace-recent events. Do not resolve the
+   session from a session-listing command.
 
 2. **Discover coverage and prior summary**. Use staged reads from
    `traceary-session-history` (list → context → show) to learn the latest event

--- a/presentation/cli/hook_consolidation.go
+++ b/presentation/cli/hook_consolidation.go
@@ -144,7 +144,7 @@ func (c *RootCLI) requestConsolidationIfDue(
 func formatConsolidationReason(sessionID types.SessionID, result usecase.ConsolidationPressureResult) string {
 	var b strings.Builder
 	fmt.Fprintf(&b,
-		"Session %s has unrefined material at or above the consolidation threshold (%d bytes). "+
+		"[Traceary] Session %s has unrefined material at or above the consolidation threshold (%d bytes). "+
 			"Write a session refinement with `traceary session refine` covering this session's events so far. "+
 			"State why the work was undertaken and what changed; if useful, include how it went, including approaches tried and rejected.",
 		sessionID.String(),

--- a/presentation/cli/hook_consolidation_reason_test.go
+++ b/presentation/cli/hook_consolidation_reason_test.go
@@ -20,7 +20,7 @@ func TestFormatConsolidationReason(t *testing.T) {
 			result: usecase.ConsolidationPressureResult{
 				PressureBytes: 66560,
 			},
-			want: "Session sess-1 has unrefined material at or above the consolidation threshold (66560 bytes). Write a session refinement with `traceary session refine` covering this session's events so far. State why the work was undertaken and what changed; if useful, include how it went, including approaches tried and rejected.",
+			want: "[Traceary] Session sess-1 has unrefined material at or above the consolidation threshold (66560 bytes). Write a session refinement with `traceary session refine` covering this session's events so far. State why the work was undertaken and what changed; if useful, include how it went, including approaches tried and rejected.",
 		},
 		{
 			name: "with previous summary",
@@ -29,7 +29,7 @@ func TestFormatConsolidationReason(t *testing.T) {
 				PreviousSummary:  types.Some("previous summary"),
 				PreviousCoversTo: types.Some(types.EventID("evt-1")),
 			},
-			want: "Session sess-1 has unrefined material at or above the consolidation threshold (66560 bytes). Write a session refinement with `traceary session refine` covering this session's events so far. State why the work was undertaken and what changed; if useful, include how it went, including approaches tried and rejected. Merge with the previous summary (covers_to=evt-1): previous summary",
+			want: "[Traceary] Session sess-1 has unrefined material at or above the consolidation threshold (66560 bytes). Write a session refinement with `traceary session refine` covering this session's events so far. State why the work was undertaken and what changed; if useful, include how it went, including approaches tried and rejected. Merge with the previous summary (covers_to=evt-1): previous summary",
 		},
 	}
 


### PR DESCRIPTION
Session-history uses context/list/search for recent work. Session-refine takes the id from the hook [Traceary] Session line, else context. Help and skills docs drop the retired entries. Consolidation nudge uses the same prefix. Six host copies stay byte-identical.

Closes #2066
Leaves parent #2049 open