### PR TITLE
fix: rate-limit parked search-projection skip warnings

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Fixed
+- **parked な search-projection が毎コマンド WARN しない (#2058)** — skip WARN は store あたり 24 時間に 1 回。`doctor` と `store search-projection status` は毎回 parked 理由を出す。復旧文言は `start` のあと `resume --until-complete`。
+
 ### Removed
 - **`traceary sessions` を削除 (#2061)** — `--snapshot` / `--snapshot --json` を含む。呼び出しは unknown command（非ゼロ、`DEPRECATED` なし）。`list` / `search` / `context` / `report` / `session handoff` を使います。hook の workspace 正規化向け List は残します。
 - **`traceary session latest` と `traceary session list` を削除 (#2057)** — どちらも unknown subcommand（非ゼロ、`DEPRECATED` なし）。hook の `[Traceary] Session <id>`、`list` / `search` / `context`、`report` を使います。handoff / hooks / context 向けの内部 Active/Latest/List クエリは残します。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Fixed
+- **Parked search-projection catch-up no longer warns on every command (#2058)** — the skip WARN is rate-limited to once per 24h per store. `doctor` and `store search-projection status` still always show the parked reason. Recovery text names `start` then `resume --until-complete`.
+
 ### Removed
 - **`traceary sessions` (#2061)** — including `--snapshot` / `--snapshot --json`. Invocations fail as an unknown command (non-zero, no `DEPRECATED` notice). Use `list` / `search` / `context` / `report` / `session handoff`. Internal session List stays for hook workspace canonicalization.
 - **`traceary session latest` and `traceary session list` (#2057)** — both fail as unknown subcommands (non-zero, no `DEPRECATED` notice). Use hook `[Traceary] Session <id>`, `list` / `search` / `context`, and `report`. Internal Active/Latest/List queries stay for handoff, hooks, and context.

--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -71,6 +71,11 @@ const (
 	SearchProjectionOriginAutomatic = "automatic"
 	SearchProjectionOriginOperator  = "operator"
 	SearchProjectionStartCommand    = "traceary store search-projection start"
+	// SearchProjectionRecoveryCommand is the practical parked-generation
+	// remedy: start replaces the generation (no row work), then resume
+	// --until-complete walks batches. Repeated resume continues from the
+	// last durable checkpoint.
+	SearchProjectionRecoveryCommand = "traceary store search-projection start then resume --until-complete"
 	// SearchProjectionFailureCleanupNoProgress is recorded when automatic
 	// catch-up spends N consecutive cleanup attempts without committing a row.
 	SearchProjectionFailureCleanupNoProgress = "cleanup_no_progress"
@@ -443,7 +448,7 @@ func (s *SearchProjectionStatus) ApplyParkedNotice(defaultConfigHash string) {
 			class = "(unclassified)"
 		}
 		s.ParkedReason = "parked after generation failure " + class
-		s.RecoveryCommand = SearchProjectionStartCommand
+		s.RecoveryCommand = SearchProjectionRecoveryCommand
 	case (s.State == "rebuilding" || (s.State == "drifted" && s.Phase == "cleanup")) &&
 		s.ConfigHash != "" && s.ConfigHash != defaultConfigHash:
 		if s.Origin == SearchProjectionOriginAutomatic {
@@ -451,7 +456,7 @@ func (s *SearchProjectionStatus) ApplyParkedNotice(defaultConfigHash string) {
 			return
 		}
 		s.ParkedReason = "budget does not match generation configuration"
-		s.RecoveryCommand = SearchProjectionStartCommand
+		s.RecoveryCommand = SearchProjectionRecoveryCommand
 	}
 }
 

--- a/application/types/search_projection_origin_test.go
+++ b/application/types/search_projection_origin_test.go
@@ -43,7 +43,7 @@ func TestSearchProjectionStatusApplyParkedNotice(t *testing.T) {
 				State:           "failed",
 				FailureClass:    "decoded_bytes",
 				ParkedReason:    "parked after generation failure decoded_bytes",
-				RecoveryCommand: SearchProjectionStartCommand,
+				RecoveryCommand: SearchProjectionRecoveryCommand,
 			},
 		},
 		{
@@ -60,7 +60,7 @@ func TestSearchProjectionStatusApplyParkedNotice(t *testing.T) {
 				Origin:          SearchProjectionOriginOperator,
 				ConfigHash:      "v4:1:1:1:1:1",
 				ParkedReason:    "budget does not match generation configuration",
-				RecoveryCommand: SearchProjectionStartCommand,
+				RecoveryCommand: SearchProjectionRecoveryCommand,
 			},
 		},
 		{

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -470,7 +470,7 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 		out.Action = "skipped"
 		out.GenerationID = status.GenerationID
 		out.SkippedReason = "budget does not match generation configuration; run '" +
-			apptypes.SearchProjectionStartCommand + "' to replace the generation"
+			apptypes.SearchProjectionRecoveryCommand + "' to replace the generation"
 		return out, nil
 	}
 	// A failed generation is parked, not retried. Every failure class this store
@@ -487,7 +487,7 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 		// this state. Resume rejects a failed generation, and abort leaves the
 		// row failed with class abandoned. Only an explicit start replaces it.
 		out.SkippedReason = "parked after generation failure " + failureClassOrUnknown(status.FailureClass) +
-			"; run 'traceary store search-projection start' to replace the generation"
+			"; run '" + apptypes.SearchProjectionRecoveryCommand + "' to replace the generation"
 		return out, nil
 	}
 	switch {
@@ -530,7 +530,7 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 		if parked {
 			out.Action = "skipped"
 			out.SkippedReason = "parked after generation failure " + apptypes.SearchProjectionFailureCleanupNoProgress +
-				"; run 'traceary store search-projection start' to replace the generation"
+				"; run '" + apptypes.SearchProjectionRecoveryCommand + "' to replace the generation"
 			return u.refreshCatchUpPosition(ctx, out), nil
 		}
 		return out, resumeErr

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -491,7 +491,7 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string, allowOffli
 	// Path(), so skip when SetPath raced against the migrate snapshot.
 	if snapshot == d.Path() {
 		projectionCatchUp, projectionCatchUpErr := catchUpSearchProjection(ctx, d)
-		logSearchProjectionCatchUp(projectionCatchUp, projectionCatchUpErr)
+		logSearchProjectionCatchUp(snapshot, projectionCatchUp, projectionCatchUpErr)
 	}
 	usageRepairResult, usageRepairErr := catchUpEpochZeroHookUsage(ctx, db, epochZeroHookUsageRepairBatchSize)
 	logEpochZeroHookUsageRepair(usageRepairResult, usageRepairErr)

--- a/infrastructure/sqlite/search_projection_capacity_internal_test.go
+++ b/infrastructure/sqlite/search_projection_capacity_internal_test.go
@@ -1282,7 +1282,7 @@ func TestSearchProjectionOperatorTuningNotHijacked(t *testing.T) {
 	if !strings.Contains(result.SkippedReason, "budget does not match") {
 		t.Fatalf("reason=%q, want budget mismatch", result.SkippedReason)
 	}
-	if !strings.Contains(result.SkippedReason, apptypes.SearchProjectionStartCommand) {
+	if !strings.Contains(result.SkippedReason, apptypes.SearchProjectionRecoveryCommand) {
 		t.Fatalf("reason=%q, want recovery command", result.SkippedReason)
 	}
 	status, err := store.SearchProjectionStatus(ctx)
@@ -1292,7 +1292,7 @@ func TestSearchProjectionOperatorTuningNotHijacked(t *testing.T) {
 	if status.Origin != apptypes.SearchProjectionOriginOperator {
 		t.Fatalf("origin=%q, want operator", status.Origin)
 	}
-	if status.ParkedReason == "" || status.RecoveryCommand != apptypes.SearchProjectionStartCommand {
+	if status.ParkedReason == "" || status.RecoveryCommand != apptypes.SearchProjectionRecoveryCommand {
 		t.Fatalf("status parked_reason=%q recovery=%q", status.ParkedReason, status.RecoveryCommand)
 	}
 }

--- a/infrastructure/sqlite/search_projection_catchup.go
+++ b/infrastructure/sqlite/search_projection_catchup.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log/slog"
+	"os"
+	"strings"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -12,6 +14,10 @@ import (
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 )
+
+const searchProjectionParkWarnInterval = 24 * time.Hour
+
+var searchProjectionParkWarnNow = time.Now
 
 // defaultSearchProjectionCatchUpBudget is the automatic generation budget used
 // on every store open. One Resume per open keeps the unit of work bounded;
@@ -133,8 +139,37 @@ func (d *Database) SearchProjectionHasSourceWork(ctx context.Context) (bool, err
 	return requiresInventory != 0, nil
 }
 
+func searchProjectionParkWarnStatePath(storePath string) string {
+	return storePath + ".projection-park-warn"
+}
+
+func shouldEmitSearchProjectionParkWarn(storePath string, now time.Time) bool {
+	if storePath == "" {
+		return true
+	}
+	raw, err := os.ReadFile(searchProjectionParkWarnStatePath(storePath))
+	if err != nil {
+		return true
+	}
+	last, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(raw)))
+	if err != nil {
+		return true
+	}
+	return !last.After(now) && now.Sub(last) >= searchProjectionParkWarnInterval
+}
+
+func recordSearchProjectionParkWarn(storePath string, now time.Time) {
+	if storePath == "" {
+		return
+	}
+	_ = os.WriteFile(searchProjectionParkWarnStatePath(storePath), []byte(now.UTC().Format(time.RFC3339Nano)+"\n"), 0o600)
+}
+
 // logSearchProjectionCatchUp emits structured progress without failing Initialize.
-func logSearchProjectionCatchUp(result apptypes.SearchProjectionCatchUpResult, err error) {
+// storePath rate-limits parked/skipped WARNs to once per 24h per store so hooks
+// and every CLI open do not nag. doctor and search-projection status stay
+// always-on through their own JSON. An empty path (unit tests) always emits.
+func logSearchProjectionCatchUp(storePath string, result apptypes.SearchProjectionCatchUpResult, err error) {
 	if err != nil {
 		var noProgress *apptypes.SearchProjectionNoProgressError
 		if errors.As(err, &noProgress) && noProgress.Code == apptypes.SearchProjectionNoProgressSingleRowLockDurationCap {
@@ -209,6 +244,10 @@ func logSearchProjectionCatchUp(result apptypes.SearchProjectionCatchUpResult, e
 		return
 	}
 	if result.Action == "skipped" {
+		now := searchProjectionParkWarnNow()
+		if !shouldEmitSearchProjectionParkWarn(storePath, now) {
+			return
+		}
 		slog.Warn("search projection catch-up skipped; the generation will not advance on its own until the reason is addressed",
 			"action", result.Action,
 			"state", result.State,
@@ -216,6 +255,7 @@ func logSearchProjectionCatchUp(result apptypes.SearchProjectionCatchUpResult, e
 			"generation_id", result.GenerationID,
 			"reason", result.SkippedReason,
 		)
+		recordSearchProjectionParkWarn(storePath, now)
 		return
 	}
 	attrs := []any{

--- a/infrastructure/sqlite/search_projection_catchup_log_internal_test.go
+++ b/infrastructure/sqlite/search_projection_catchup_log_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/xerrors"
@@ -68,7 +69,7 @@ func TestLogSearchProjectionCatchUp_SingleRowLockCapSeparatesFromTheTransientMes
 				Reason: "single row exceeded lock cap",
 			})
 
-			logSearchProjectionCatchUp(result, err)
+			logSearchProjectionCatchUp("", result, err)
 
 			if diff := cmp.Diff(1, len(handler.records)); diff != "" {
 				t.Fatalf("unexpected record count (-want +got):\n%s", diff)
@@ -125,7 +126,7 @@ func TestLogSearchProjectionCatchUp_DiskFullSeparatesFromTheTransientMessage(t *
 	}
 	err := xerrors.Errorf("search projection catch-up: %w", forceSQLiteFull(t))
 
-	logSearchProjectionCatchUp(result, err)
+	logSearchProjectionCatchUp("", result, err)
 
 	if diff := cmp.Diff(1, len(handler.records)); diff != "" {
 		t.Fatalf("unexpected record count (-want +got):\n%s", diff)
@@ -157,7 +158,7 @@ func TestLogSearchProjectionCatchUp_OtherErrorsKeepTheGenericLine(t *testing.T) 
 	slog.SetDefault(slog.New(handler))
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	logSearchProjectionCatchUp(apptypes.SearchProjectionCatchUpResult{Action: "resume", State: "rebuilding"}, xerrors.New("wall time exceeded"))
+	logSearchProjectionCatchUp("", apptypes.SearchProjectionCatchUpResult{Action: "resume", State: "rebuilding"}, xerrors.New("wall time exceeded"))
 
 	if diff := cmp.Diff(1, len(handler.records)); diff != "" {
 		t.Fatalf("unexpected record count (-want +got):\n%s", diff)
@@ -261,7 +262,7 @@ func TestLogSearchProjectionCatchUp_LogsSkipsButNotQuietStates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf.Reset()
-			logSearchProjectionCatchUp(tt.result, nil)
+			logSearchProjectionCatchUp("", tt.result, nil)
 			got := buf.String()
 			if tt.wantLog {
 				if got == "" {
@@ -284,5 +285,48 @@ func TestLogSearchProjectionCatchUp_LogsSkipsButNotQuietStates(t *testing.T) {
 				t.Fatalf("quiet state logged unexpectedly (-want +got):\n%s\nlog=%q", diff, got)
 			}
 		})
+	}
+}
+
+func TestLogSearchProjectionCatchUp_RateLimitsSkippedWarnPerStore(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "traceary.db")
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	searchProjectionParkWarnNow = func() time.Time { return now }
+	t.Cleanup(func() { searchProjectionParkWarnNow = time.Now })
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	skipped := apptypes.SearchProjectionCatchUpResult{
+		Action:        "skipped",
+		State:         "failed",
+		Phase:         "complete",
+		GenerationID:  "gen-parked",
+		SkippedReason: "parked after generation failure cleanup_no_progress; run '" + apptypes.SearchProjectionRecoveryCommand + "' to replace the generation",
+	}
+
+	logSearchProjectionCatchUp(storePath, skipped, nil)
+	first := buf.String()
+	if !strings.Contains(first, "search projection catch-up skipped") {
+		t.Fatalf("first emit missing warn: %s", first)
+	}
+	if !strings.Contains(first, "resume --until-complete") {
+		t.Fatalf("first emit missing practical recovery: %s", first)
+	}
+
+	buf.Reset()
+	logSearchProjectionCatchUp(storePath, skipped, nil)
+	if got := buf.String(); got != "" {
+		t.Fatalf("second emit inside 24h = %q, want silence", got)
+	}
+
+	now = now.Add(searchProjectionParkWarnInterval)
+	searchProjectionParkWarnNow = func() time.Time { return now }
+	buf.Reset()
+	logSearchProjectionCatchUp(storePath, skipped, nil)
+	if !strings.Contains(buf.String(), "search projection catch-up skipped") {
+		t.Fatalf("emit after 24h missing warn: %s", buf.String())
 	}
 }

--- a/infrastructure/sqlite/search_projection_cleanup_internal_test.go
+++ b/infrastructure/sqlite/search_projection_cleanup_internal_test.go
@@ -216,7 +216,7 @@ func TestLogSearchProjectionCatchUp_RepeatIncompleteIsDebug(t *testing.T) {
 	slog.SetDefault(slog.New(handler))
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	logSearchProjectionCatchUp(apptypes.SearchProjectionCatchUpResult{
+	logSearchProjectionCatchUp("", apptypes.SearchProjectionCatchUpResult{
 		Action: "resume", State: "rebuilding", Phase: "cleanup",
 	}, context.DeadlineExceeded)
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -350,6 +350,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			Message: localizef("initialized SQLite store: %s", "SQLite ストアを初期化しました: %s", resolvedDBPath),
 		})
 		report.Checks = append(report.Checks, c.inspectSearchProjectionBudget(ctx))
+		report.Checks = append(report.Checks, c.inspectSearchProjectionParked(ctx))
 		report.Checks = append(report.Checks, c.inspectStaleActiveSessions(ctx))
 		report.Checks = append(report.Checks, c.inspectArchiveRetention(ctx, resolvedDBPath))
 		report.Checks = append(report.Checks, c.inspectFileRetentionCapacity(ctx, resolvedDBPath, input.archiveRoot, input.backupRoot)...)

--- a/presentation/cli/doctor_report.go
+++ b/presentation/cli/doctor_report.go
@@ -137,7 +137,7 @@ func buildDoctorSections(checks []doctorCheck) []doctorSection {
 
 func doctorSectionNameForCheck(name string) string {
 	switch {
-	case name == "db-path" || name == "db-write" || name == "search-projection-budget" || name == "stale-active-sessions" || name == "archive-retention" || strings.HasSuffix(name, "-capacity-retention") || name == "audit-reliability" || name == "content-event-reliability" || name == "sensitive-access-audit" || name == "retry-loops" || name == "body-codec":
+	case name == "db-path" || name == "db-write" || name == "search-projection-budget" || name == "search-projection-parked" || name == "stale-active-sessions" || name == "archive-retention" || strings.HasSuffix(name, "-capacity-retention") || name == "audit-reliability" || name == "content-event-reliability" || name == "sensitive-access-audit" || name == "retry-loops" || name == "body-codec":
 		return "Database"
 	case name == "config" || name == "project-dir" || name == "version" || name == "path":
 		return "Environment"

--- a/presentation/cli/doctor_search_projection.go
+++ b/presentation/cli/doctor_search_projection.go
@@ -42,15 +42,20 @@ func searchProjectionParkedDoctorCheck(status apptypes.SearchProjectionControlSt
 			Message: Localize("search projection is not parked", "search projection は parked ではありません"),
 		}
 	}
-	hint := notice.RecoveryCommand
-	if hint == "" {
-		hint = apptypes.SearchProjectionRecoveryCommand
+	// Automatic stale-hash generations are not operator-parked: the next
+	// store open replaces them (#1861). Do not advertise start/resume.
+	if notice.RecoveryCommand == "" {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusSkip,
+			Message: notice.ParkedReason,
+		}
 	}
 	return doctorCheck{
 		Name:    name,
 		Status:  doctorStatusWarn,
 		Message: notice.ParkedReason,
-		Hint:    hint,
+		Hint:    notice.RecoveryCommand,
 	}
 }
 

--- a/presentation/cli/doctor_search_projection.go
+++ b/presentation/cli/doctor_search_projection.go
@@ -6,6 +6,54 @@ import (
 	apptypes "github.com/duck8823/traceary/application/types"
 )
 
+func (c *RootCLI) inspectSearchProjectionParked(ctx context.Context) doctorCheck {
+	if c.searchProjection == nil {
+		return doctorCheck{
+			Name:    "search-projection-parked",
+			Status:  doctorStatusSkip,
+			Message: Localize("search projection usecase is not configured", "search projection usecase が設定されていません"),
+		}
+	}
+	status, err := c.searchProjection.ControlStatus(ctx)
+	return searchProjectionParkedDoctorCheck(status, err)
+}
+
+func searchProjectionParkedDoctorCheck(status apptypes.SearchProjectionControlStatus, err error) doctorCheck {
+	const name = "search-projection-parked"
+	if err != nil {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusWarn,
+			Message: localizef("failed to inspect search-projection parked state: %v", "search-projection の parked 状態を確認できません: %v", err),
+		}
+	}
+	notice := apptypes.SearchProjectionStatus{
+		State:        status.State,
+		Phase:        status.Phase,
+		ConfigHash:   status.ConfigHash,
+		FailureClass: status.FailureClass,
+		Origin:       status.Origin,
+	}
+	notice.ApplyParkedNotice(apptypes.DefaultSearchProjectionBudget().ConfigHash())
+	if notice.ParkedReason == "" {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusSkip,
+			Message: Localize("search projection is not parked", "search projection は parked ではありません"),
+		}
+	}
+	hint := notice.RecoveryCommand
+	if hint == "" {
+		hint = apptypes.SearchProjectionRecoveryCommand
+	}
+	return doctorCheck{
+		Name:    name,
+		Status:  doctorStatusWarn,
+		Message: notice.ParkedReason,
+		Hint:    hint,
+	}
+}
+
 func (c *RootCLI) inspectSearchProjectionBudget(ctx context.Context) doctorCheck {
 	if c.searchProjection == nil {
 		return doctorCheck{

--- a/presentation/cli/doctor_search_projection_test.go
+++ b/presentation/cli/doctor_search_projection_test.go
@@ -67,6 +67,16 @@ func TestSearchProjectionParkedDoctorCheck(t *testing.T) {
 			hint:   apptypes.SearchProjectionRecoveryCommand,
 		},
 		{
+			name: "automatic stale hash is not an operator park",
+			status: apptypes.SearchProjectionControlStatus{
+				State:      "rebuilding",
+				Phase:      "source",
+				Origin:     apptypes.SearchProjectionOriginAutomatic,
+				ConfigHash: "v4:1:1:1:1:1",
+			},
+			want: doctorStatusSkip,
+		},
+		{
 			name:   "complete generation is not parked",
 			status: apptypes.SearchProjectionControlStatus{State: "complete"},
 			want:   doctorStatusSkip,

--- a/presentation/cli/doctor_search_projection_test.go
+++ b/presentation/cli/doctor_search_projection_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
 	apptypes "github.com/duck8823/traceary/application/types"
@@ -46,6 +47,45 @@ func TestSearchProjectionBudgetDoctorCheck(t *testing.T) {
 			}
 			if tt.want == doctorStatusWarn && got.Hint == "" {
 				t.Fatal("over-budget warning must name the operator lever")
+			}
+		})
+	}
+}
+
+func TestSearchProjectionParkedDoctorCheck(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status apptypes.SearchProjectionControlStatus
+		want   string
+		hint   string
+	}{
+		{
+			name:   "failed generation always warns with full recovery",
+			status: apptypes.SearchProjectionControlStatus{State: "failed", FailureClass: "cleanup_no_progress"},
+			want:   doctorStatusWarn,
+			hint:   apptypes.SearchProjectionRecoveryCommand,
+		},
+		{
+			name:   "complete generation is not parked",
+			status: apptypes.SearchProjectionControlStatus{State: "complete"},
+			want:   doctorStatusSkip,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := searchProjectionParkedDoctorCheck(tt.status, nil)
+			if got.Name != "search-projection-parked" {
+				t.Fatalf("name=%q", got.Name)
+			}
+			if got.Status != tt.want {
+				t.Fatalf("status=%q, want %q", got.Status, tt.want)
+			}
+			if tt.hint != "" && got.Hint != tt.hint {
+				t.Fatalf("hint=%q, want %q", got.Hint, tt.hint)
+			}
+			if tt.want == doctorStatusWarn && !strings.Contains(got.Message, "cleanup_no_progress") {
+				t.Fatalf("message=%q, want parked class", got.Message)
 			}
 		})
 	}

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -75,6 +75,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "search-projection-parked",
+      "status": "skip",
+      "severity": "PASS",
+      "section": "Database",
+      "message": "search projection usecase is not configured",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "stale-active-sessions",
       "status": "pass",
       "severity": "PASS",
@@ -325,6 +335,16 @@
           "auto_fix_available": false
         },
         {
+          "name": "search-projection-parked",
+          "status": "skip",
+          "severity": "PASS",
+          "section": "Database",
+          "message": "search projection usecase is not configured",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
           "name": "stale-active-sessions",
           "status": "pass",
           "severity": "PASS",
@@ -507,7 +527,7 @@
     }
   ],
   "summary": {
-    "pass": 23,
+    "pass": 24,
     "warn": 1,
     "fail": 0
   },


### PR DESCRIPTION
Parked search-projection skip WARNs emit once per 24h per store. doctor and search-projection status always show the parked reason. Recovery text names start then resume --until-complete.

Closes #2058
Leaves parent #2049 open