### PR TITLE
fix: skip uncached dbstat on search-projection status

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **`store search-projection status` が dbstat を歩かない (#2059)** — 物理バイトは `store capacity` の sidecar cache（`physical_evidence.status=cached`）か、即座の `unavailable`。lifecycle 欄は control snapshot のまま。大きい store でも数秒で答えるのが目標。
 - **parked な search-projection が毎コマンド WARN しない (#2058)** — skip WARN は store あたり 24 時間に 1 回。`doctor` と `store search-projection status` は毎回 parked 理由を出す。復旧文言は `start` のあと `resume --until-complete`。
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **`store search-projection status` no longer walks dbstat (#2059)** — physical bytes come from the `store capacity` sidecar cache (`physical_evidence.status=cached`) or are immediately `unavailable`. Lifecycle fields stay on the control snapshot. Target is low-second answers on large stores.
 - **Parked search-projection catch-up no longer warns on every command (#2058)** — the skip WARN is rate-limited to once per 24h per store. `doctor` and `store search-projection status` still always show the parked reason. Recovery text names `start` then `resume --until-complete`.
 
 ### Removed

--- a/docs/search-projection-rebuild.ja.md
+++ b/docs/search-projection-rebuild.ja.md
@@ -111,9 +111,10 @@ b-tree 割当であり、ソーステキストではありません。デフォ�
 `0`（超過）、`-1`（測定不能）を記録します。
 
 `-1` は**不明**を意味します。「予算以下」を意味することは決してありません。
-split の `dbstat` が期限切れでもファミリ合計（`physical_bytes`）が取れるときは、
-`store search-projection status` がその合計に対する粗い `0` / `1` を出します
-（persist はしません）。cutover も同じ fallback なので、complete 世代には
+新しい `store capacity` の dbstat cache があるとき、`store search-projection status`
+はその cache したファミリ合計（`physical_bytes`、`physical_evidence.status=cached`）
+に対する粗い `0` / `1` を出します（persist はしません）。status 自身は dbstat を歩きません。
+cache miss は即座に `unavailable` です。cutover は完了時に測定するので、complete 世代には
 persist された判定が残ります。合計も取れないときだけ `-1` のまま、
 `physical_evidence.reason` が理由を出します
 （[#1835](https://github.com/duck8823/traceary/issues/1835)）。

--- a/docs/search-projection-rebuild.md
+++ b/docs/search-projection-rebuild.md
@@ -152,12 +152,14 @@ guaranteed in advance: when a generation completes, the family is re-measured an
 `index_family_within_budget` records `1` (within), `0` (over) or `-1` (not
 measurable).
 
-`-1` means **unknown**. It never means "within budget". When the split `dbstat`
-walk times out but the family **total** (`physical_bytes`) is available,
-`store search-projection status` publishes a coarse `0`/`1` against that total
-and does not persist it. Cutover uses the same fallback so a complete generation
-still records a persisted verdict. If the total is also unavailable the field
-stays `-1` and `physical_evidence.reason` names why
+`-1` means **unknown**. It never means "within budget". When a fresh
+`store capacity` dbstat cache is present, `store search-projection status`
+publishes a coarse `0`/`1` against the cached family **total**
+(`physical_bytes`, `physical_evidence.status=cached`) and does not persist it.
+Status does not walk dbstat itself; a cache miss is immediately `unavailable`.
+Cutover still measures at completion so a complete generation records a
+persisted verdict. If the total is also unavailable the field stays `-1` and
+`physical_evidence.reason` names why
 ([#1835](https://github.com/duck8823/traceary/issues/1835)).
 
 A generation recorded over budget stays that way. Nothing corrects it in place —

--- a/infrastructure/sqlite/dbstat_cache.go
+++ b/infrastructure/sqlite/dbstat_cache.go
@@ -62,10 +62,24 @@ func storeDBStatCache(dbPath string, objects []apptypes.CapacityObject) {
 func searchProjectionFamilyBytesFromObjects(objects []apptypes.CapacityObject) int64 {
 	var total int64
 	for _, object := range objects {
-		name := object.Name
-		if strings.HasPrefix(name, "search_projection_") || strings.HasPrefix(name, "literal_search_") {
+		if searchProjectionFamilyObjectName(object.Name) {
 			total += object.Bytes
 		}
 	}
 	return total
+}
+
+// searchProjectionFamilyObjectName mirrors select_search_projection_family_total.sql
+// membership (name or tbl_name GLOB search_projection_* / literal_search_*).
+// Capacity cache rows have no tbl_name, so SQLite index/autoindex names that
+// belong to those tables must be included by their own name.
+func searchProjectionFamilyObjectName(name string) bool {
+	return searchProjectionFamilyNameOrIndex(name, "search_projection_") ||
+		searchProjectionFamilyNameOrIndex(name, "literal_search_")
+}
+
+func searchProjectionFamilyNameOrIndex(name, prefix string) bool {
+	return strings.HasPrefix(name, prefix) ||
+		strings.HasPrefix(name, "idx_"+prefix) ||
+		strings.HasPrefix(name, "sqlite_autoindex_"+prefix)
 }

--- a/infrastructure/sqlite/search_projection_budget_verdict_internal_test.go
+++ b/infrastructure/sqlite/search_projection_budget_verdict_internal_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
 )
 
 func TestSearchProjectionStatusBudgetVerdictUsesFamilyTotalWhenPersistedUnknown(t *testing.T) {
@@ -25,12 +27,13 @@ func TestSearchProjectionStatusBudgetVerdictUsesFamilyTotalWhenPersistedUnknown(
 	if _, err := db.Exec(`UPDATE search_projection_state SET index_family_byte_limit=1 WHERE singleton=1`); err != nil {
 		t.Fatal(err)
 	}
+	seedProjectionFamilyDBStatCache(t, store.Path(), 4096)
 	status, err := store.SearchProjectionStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.PhysicalEvidence.Status != "complete" {
-		t.Fatalf("physical_evidence=%+v, want complete so a coarse verdict exists", status.PhysicalEvidence)
+	if status.PhysicalEvidence.Status != "cached" {
+		t.Fatalf("physical_evidence=%+v, want cached family total", status.PhysicalEvidence)
 	}
 	if status.PhysicalBytes <= 1 {
 		t.Fatalf("physical_bytes=%d, want above the forced 1-byte limit", status.PhysicalBytes)
@@ -66,4 +69,37 @@ func TestSearchProjectionStatusUnknownBudgetVerdictNamesReason(t *testing.T) {
 	if strings.TrimSpace(status.PhysicalEvidence.Reason) == "" {
 		t.Fatal("timeout/unavailable path returned -1 with no reason")
 	}
+}
+
+func TestSearchProjectionStatusSkipsUncachedDBStat(t *testing.T) {
+	store, _ := newCapacityTestStore(t, []struct{ id, body, created string }{
+		{"e1", "status must not walk dbstat", "2026-06-01T12:00:00Z"},
+	})
+	now := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	if _, err := store.Start(context.Background(), capacityBudget(64<<20), now); err != nil {
+		t.Fatal(err)
+	}
+	status, err := store.SearchProjectionStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.PhysicalEvidence.Status != "unavailable" {
+		t.Fatalf("physical_evidence=%+v, want unavailable without a cache", status.PhysicalEvidence)
+	}
+	if !strings.Contains(status.PhysicalEvidence.Reason, "cache miss") {
+		t.Fatalf("reason=%q, want cache miss", status.PhysicalEvidence.Reason)
+	}
+	if status.State == "" {
+		t.Fatal("lifecycle state must still be populated without dbstat")
+	}
+}
+
+func seedProjectionFamilyDBStatCache(t *testing.T, path string, familyBytes int64) {
+	t.Helper()
+	storeDBStatCache(path, []apptypes.CapacityObject{{
+		Name:  "search_projection_recent_documents",
+		Kind:  "table",
+		Pages: 1,
+		Bytes: familyBytes,
+	}})
 }

--- a/infrastructure/sqlite/search_projection_budget_verdict_internal_test.go
+++ b/infrastructure/sqlite/search_projection_budget_verdict_internal_test.go
@@ -94,6 +94,55 @@ func TestSearchProjectionStatusSkipsUncachedDBStat(t *testing.T) {
 	}
 }
 
+func TestSearchProjectionFamilyBytesFromObjectsIncludesIndexes(t *testing.T) {
+	objects := []apptypes.CapacityObject{
+		{Name: "search_projection_recent_documents", Kind: "table", Bytes: 100},
+		{Name: "idx_search_projection_recent_eviction", Kind: "index", Bytes: 50},
+		{Name: "idx_search_projection_exclusions_event", Kind: "index", Bytes: 25},
+		{Name: "sqlite_autoindex_search_projection_source_sequence_1", Kind: "index", Bytes: 10},
+		{Name: "idx_literal_search_fingerprint_candidate", Kind: "index", Bytes: 5},
+		{Name: "sqlite_autoindex_literal_search_fingerprints_1", Kind: "index", Bytes: 7},
+		{Name: "events", Kind: "table", Bytes: 999},
+		{Name: "idx_events_created", Kind: "index", Bytes: 888},
+		{Name: "sqlite_autoindex_event_search_documents_1", Kind: "index", Bytes: 777},
+	}
+	got := searchProjectionFamilyBytesFromObjects(objects)
+	const want = 100 + 50 + 25 + 10 + 5 + 7
+	if got != want {
+		t.Fatalf("family bytes=%d, want %d (indexes must count; unrelated objects must not)", got, want)
+	}
+}
+
+func TestSearchProjectionStatusCachedFamilyTotalIncludesIndexes(t *testing.T) {
+	store, db := newCapacityTestStore(t, []struct{ id, body, created string }{
+		{"e1", "index allocations belong to the family total", "2026-06-01T12:00:00Z"},
+	})
+	now := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	if _, err := store.Start(context.Background(), capacityBudget(64<<20), now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE search_projection_state SET index_family_byte_limit=100 WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+	storeDBStatCache(store.Path(), []apptypes.CapacityObject{
+		{Name: "search_projection_recent_documents", Kind: "table", Pages: 1, Bytes: 1},
+		{Name: "idx_search_projection_recent_eviction", Kind: "index", Pages: 1, Bytes: 4096},
+	})
+	status, err := store.SearchProjectionStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.PhysicalEvidence.Status != "cached" {
+		t.Fatalf("physical_evidence=%+v, want cached", status.PhysicalEvidence)
+	}
+	if status.PhysicalBytes != 4097 {
+		t.Fatalf("physical_bytes=%d, want table+index=4097", status.PhysicalBytes)
+	}
+	if status.IndexFamilyWithinBudget != 0 {
+		t.Fatalf("index_family_within_budget=%d, want 0 once index bytes exceed the 100-byte limit", status.IndexFamilyWithinBudget)
+	}
+}
+
 func seedProjectionFamilyDBStatCache(t *testing.T, path string, familyBytes int64) {
 	t.Helper()
 	storeDBStatCache(path, []apptypes.CapacityObject{{

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -1430,25 +1430,20 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 			s.PhysicalBytes = searchProjectionFamilyBytesFromObjects(cached.Objects)
 			s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "cached", Method: "dbstat", Reason: "dbstat cache hit for unchanged store file"}
 		} else {
-			budgetCtx, cancel := context.WithTimeout(ctx, dbstatInspectBudget)
-			scanErr := db.QueryRowContext(budgetCtx, selectSearchProjectionFamilyTotalSQL).Scan(&s.PhysicalBytes)
-			deadlineExceeded := errors.Is(budgetCtx.Err(), context.DeadlineExceeded)
-			cancel()
-			if scanErr == nil {
-				s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "complete", Method: "dbstat"}
-			} else if deadlineExceeded {
-				s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "bounded", Method: "dbstat", Reason: "dbstat wall budget exceeded"}
-				e = nil
-			} else {
-				s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "unavailable", Method: "pragma", Reason: "dbstat unavailable"}
-				e = nil
+			// Status never walks dbstat (#2059). store capacity refreshes the
+			// sidecar cache; a miss is immediately unavailable so parked
+			// lifecycle inspection stays in the low-second range.
+			s.PhysicalEvidence = apptypes.CapacityEvidence{
+				Status: "unavailable",
+				Method: "dbstat",
+				Reason: "dbstat cache miss; run traceary store capacity to refresh",
 			}
 		}
 	}
 	applySearchProjectionBudgetVerdict(&s)
 	s.InspectionMilliseconds = time.Since(started).Milliseconds()
 	s.ApplyParkedNotice(apptypes.DefaultSearchProjectionBudget().ConfigHash())
-	return s, e
+	return s, nil
 }
 
 // searchProjectionFamilyTotalUnavailableForTest skips the family-total dbstat
@@ -1464,7 +1459,7 @@ func applySearchProjectionBudgetVerdict(s *apptypes.SearchProjectionStatus) {
 		return
 	}
 	s.IndexFamilyWithinBudget = -1
-	if s.IndexFamilyByteLimit > 0 && s.PhysicalEvidence.Status == "complete" {
+	if s.IndexFamilyByteLimit > 0 && (s.PhysicalEvidence.Status == "complete" || s.PhysicalEvidence.Status == "cached") {
 		if s.PhysicalBytes <= s.IndexFamilyByteLimit {
 			s.IndexFamilyWithinBudget = 1
 		} else {


### PR DESCRIPTION
search-projection status serves physical bytes from the store-capacity cache or reports unavailable immediately. No live dbstat walk. Lifecycle fields stay on the control snapshot.

Closes #2059
Leaves parent #2049 open