### PR TITLE
fix: stamp and backfill 30-day TTL on extracted memory candidates

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **未レビューの extracted メモリ候補に 30 日 TTL を付ける (#2062)** — 提案時に `expires_at` を刻み、`memory decay --apply` で NULL を backfill する。decay の時計は `created_at`（`updated_at` ではない）。`remember-intent` / `manual` / `compact-summary` は対象外。dry-run 件数に `backfilled=` を出す。
 - **`store search-projection status` が dbstat を歩かない (#2059)** — 物理バイトは `store capacity` の sidecar cache（`physical_evidence.status=cached`）か、即座の `unavailable`。lifecycle 欄は control snapshot のまま。大きい store でも数秒で答えるのが目標。
 - **parked な search-projection が毎コマンド WARN しない (#2058)** — skip WARN は store あたり 24 時間に 1 回。`doctor` と `store search-projection status` は毎回 parked 理由を出す。復旧文言は `start` のあと `resume --until-complete`。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Unreviewed extracted memory candidates now carry a 30-day TTL (#2062)** — `expires_at` is stamped at propose time and backfilled on `memory decay --apply`. Decay clocks `created_at` (not `updated_at`). `remember-intent` / `manual` / `compact-summary` stay exempt. Dry-run counts include `backfilled=`.
 - **`store search-projection status` no longer walks dbstat (#2059)** — physical bytes come from the `store capacity` sidecar cache (`physical_evidence.status=cached`) or are immediately `unavailable`. Lifecycle fields stay on the control snapshot. Target is low-second answers on large stores.
 - **Parked search-projection catch-up no longer warns on every command (#2058)** — the skip WARN is rate-limited to once per 24h per store. `doctor` and `store search-projection status` still always show the parked reason. Recovery text names `start` then `resume --until-complete`.
 

--- a/application/types/memory_decay.go
+++ b/application/types/memory_decay.go
@@ -26,4 +26,5 @@ type MemoryDecayResult struct {
 	Applied        bool
 	OlderThan      time.Duration
 	Scanned        int
+	Backfilled     int
 }

--- a/application/usecase/memory_decay.go
+++ b/application/usecase/memory_decay.go
@@ -75,13 +75,11 @@ func (u *memoryUsecase) Decay(ctx context.Context, criteria apptypes.MemoryDecay
 		}
 	}
 	if criteria.Apply && result.Backfilled > 0 {
-		if _, ok := criteria.Workspace.Value(); !ok {
-			n, err := u.memoryRepo.BackfillCandidateTTLs(ctx, olderThan)
-			if err != nil {
-				return apptypes.MemoryDecayResult{}, xerrors.Errorf("failed to backfill candidate TTL stamps: %w", err)
-			}
-			result.Backfilled = n
+		n, err := u.memoryRepo.BackfillCandidateTTLs(ctx, domtypes.DefaultMemoryDecayOlderThan)
+		if err != nil {
+			return apptypes.MemoryDecayResult{}, xerrors.Errorf("failed to backfill candidate TTL stamps: %w", err)
 		}
+		result.Backfilled = n
 	}
 
 	// Expire pass (oldest created_at first — TTL is from creation, not last touch).
@@ -103,10 +101,17 @@ func (u *memoryUsecase) Decay(ctx context.Context, criteria apptypes.MemoryDecay
 			result.Skipped["source"]++
 			continue
 		}
-		cutoff := now.Add(-olderThan)
-		if !s.CreatedAt().UTC().Before(cutoff) {
-			result.Skipped["too_new"]++
-			continue
+		if expiresAt, ok := s.ExpiresAt().Value(); ok {
+			if now.UTC().Before(expiresAt.UTC()) {
+				result.Skipped["too_new"]++
+				continue
+			}
+		} else {
+			cutoff := now.Add(-olderThan)
+			if !s.CreatedAt().UTC().Before(cutoff) {
+				result.Skipped["too_new"]++
+				continue
+			}
 		}
 		eligible = append(eligible, s)
 	}

--- a/application/usecase/memory_decay.go
+++ b/application/usecase/memory_decay.go
@@ -66,12 +66,30 @@ func (u *memoryUsecase) Decay(ctx context.Context, criteria apptypes.MemoryDecay
 		Scanned:       len(summaries),
 	}
 
-	// Expire pass (oldest first).
+	for _, s := range summaries {
+		if s.Status() == domtypes.MemoryStatusCandidate &&
+			domtypes.CandidateTTLApplies(s.Source()) {
+			if _, ok := s.ExpiresAt().Value(); !ok {
+				result.Backfilled++
+			}
+		}
+	}
+	if criteria.Apply && result.Backfilled > 0 {
+		if _, ok := criteria.Workspace.Value(); !ok {
+			n, err := u.memoryRepo.BackfillCandidateTTLs(ctx, olderThan)
+			if err != nil {
+				return apptypes.MemoryDecayResult{}, xerrors.Errorf("failed to backfill candidate TTL stamps: %w", err)
+			}
+			result.Backfilled = n
+		}
+	}
+
+	// Expire pass (oldest created_at first — TTL is from creation, not last touch).
 	sort.SliceStable(summaries, func(i, j int) bool {
-		if summaries[i].UpdatedAt().Equal(summaries[j].UpdatedAt()) {
+		if summaries[i].CreatedAt().Equal(summaries[j].CreatedAt()) {
 			return summaries[i].MemoryID().String() < summaries[j].MemoryID().String()
 		}
-		return summaries[i].UpdatedAt().Before(summaries[j].UpdatedAt())
+		return summaries[i].CreatedAt().Before(summaries[j].CreatedAt())
 	})
 
 	eligible := make([]apptypes.MemorySummary, 0)
@@ -86,7 +104,7 @@ func (u *memoryUsecase) Decay(ctx context.Context, criteria apptypes.MemoryDecay
 			continue
 		}
 		cutoff := now.Add(-olderThan)
-		if !s.UpdatedAt().UTC().Before(cutoff) {
+		if !s.CreatedAt().UTC().Before(cutoff) {
 			result.Skipped["too_new"]++
 			continue
 		}

--- a/application/usecase/memory_decay.go
+++ b/application/usecase/memory_decay.go
@@ -101,17 +101,9 @@ func (u *memoryUsecase) Decay(ctx context.Context, criteria apptypes.MemoryDecay
 			result.Skipped["source"]++
 			continue
 		}
-		if expiresAt, ok := s.ExpiresAt().Value(); ok {
-			if now.UTC().Before(expiresAt.UTC()) {
-				result.Skipped["too_new"]++
-				continue
-			}
-		} else {
-			cutoff := now.Add(-olderThan)
-			if !s.CreatedAt().UTC().Before(cutoff) {
-				result.Skipped["too_new"]++
-				continue
-			}
+		if !policy.CandidateDue(s.CreatedAt(), s.ExpiresAt(), now) {
+			result.Skipped["too_new"]++
+			continue
 		}
 		eligible = append(eligible, s)
 	}

--- a/application/usecase/memory_decay_test.go
+++ b/application/usecase/memory_decay_test.go
@@ -216,6 +216,46 @@ func TestMemoryUsecase_Decay_HonorsScheduledStampAfterRestore(t *testing.T) {
 	}
 }
 
+func TestMemoryUsecase_Decay_ShorterOlderThanAppliesToOriginalStamp(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	id, err := domtypes.MemoryIDFrom("mem-decay-shorter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	summary, err := apptypes.MemorySummaryOf(
+		id,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("ws")),
+		"original stamp must honor a shorter older-than",
+		domtypes.MemoryStatusCandidate,
+		domtypes.ConfidenceLow,
+		domtypes.MemorySourceExtracted,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.Some(created.Add(domtypes.DefaultMemoryDecayOlderThan)),
+		created,
+		domtypes.None[time.Time](),
+		created,
+		created,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sut := usecase.NewMemoryUsecase(&decayRepoFake{}, &decayQueryFake{summaries: []apptypes.MemorySummary{summary}}, nil)
+	result, err := sut.Decay(context.Background(), apptypes.MemoryDecayCriteria{
+		OlderThan: 7 * 24 * time.Hour,
+		Limit:     10,
+		Apply:     false,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Decay() error = %v", err)
+	}
+	if len(result.ExpiredIDs) != 1 || result.ExpiredIDs[0] != "mem-decay-shorter" {
+		t.Fatalf("ExpiredIDs=%#v, want due under --older-than 7d", result.ExpiredIDs)
+	}
+}
+
 func TestMemoryUsecase_Restore_ExpiredToCandidate(t *testing.T) {
 	id, _ := domtypes.MemoryIDFrom("mem-restore-1")
 	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)

--- a/application/usecase/memory_decay_test.go
+++ b/application/usecase/memory_decay_test.go
@@ -50,6 +50,11 @@ func (r *decayRepoFake) SaveSupersession(context.Context, *model.Memory, *model.
 	return nil
 }
 
+func (r *decayRepoFake) BackfillCandidateTTLs(context.Context, time.Duration) (int, error) {
+	r.saves++
+	return 1, nil
+}
+
 type decayClock struct{ t time.Time }
 
 func (c decayClock) Now() time.Time { return c.t }
@@ -99,6 +104,75 @@ func TestMemoryUsecase_Decay_DryRunReportsEligibleWithoutWriting(t *testing.T) {
 	}
 	if repo.saves != 0 {
 		t.Fatalf("dry-run must not Save, saves=%d", repo.saves)
+	}
+	if result.Backfilled != 0 {
+		t.Fatalf("stamped extracted candidate Backfilled=%d, want 0", result.Backfilled)
+	}
+}
+
+func TestMemoryUsecase_Decay_UsesCreatedAtAndCountsUnstamped(t *testing.T) {
+	old := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	id, err := domtypes.MemoryIDFrom("mem-decay-unstamped")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := domtypes.WorkspaceScopeOf(domtypes.Workspace("ws"))
+	summary, err := apptypes.MemorySummaryOf(
+		id,
+		domtypes.MemoryTypeDecision,
+		scope,
+		"legacy extracted with null expires_at",
+		domtypes.MemoryStatusCandidate,
+		domtypes.ConfidenceLow,
+		domtypes.MemorySourceExtracted,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		old,
+		domtypes.None[time.Time](),
+		old,
+		now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := &decayQueryFake{summaries: []apptypes.MemorySummary{summary}}
+	repo := &decayRepoFake{}
+	sut := usecase.NewMemoryUsecase(repo, query, nil)
+
+	dry, err := sut.Decay(context.Background(), apptypes.MemoryDecayCriteria{
+		OlderThan: 30 * 24 * time.Hour,
+		Limit:     10,
+		Apply:     false,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Decay() dry-run error = %v", err)
+	}
+	if dry.Backfilled != 1 {
+		t.Fatalf("Backfilled=%d, want 1 unstamped extracted", dry.Backfilled)
+	}
+	if len(dry.ExpiredIDs) != 1 {
+		t.Fatalf("ExpiredIDs=%#v, want due from created_at despite fresh updated_at", dry.ExpiredIDs)
+	}
+	if repo.saves != 0 {
+		t.Fatalf("dry-run must not backfill, saves=%d", repo.saves)
+	}
+
+	applied, err := sut.Decay(context.Background(), apptypes.MemoryDecayCriteria{
+		OlderThan: 30 * 24 * time.Hour,
+		Limit:     10,
+		Apply:     true,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Decay() apply error = %v", err)
+	}
+	if applied.Backfilled != 1 {
+		t.Fatalf("apply Backfilled=%d, want SQL stamp count", applied.Backfilled)
+	}
+	if repo.saves < 1 {
+		t.Fatal("apply must call BackfillCandidateTTLs")
 	}
 }
 

--- a/application/usecase/memory_decay_test.go
+++ b/application/usecase/memory_decay_test.go
@@ -176,6 +176,46 @@ func TestMemoryUsecase_Decay_UsesCreatedAtAndCountsUnstamped(t *testing.T) {
 	}
 }
 
+func TestMemoryUsecase_Decay_HonorsScheduledStampAfterRestore(t *testing.T) {
+	old := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	id, err := domtypes.MemoryIDFrom("mem-decay-restored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	summary, err := apptypes.MemorySummaryOf(
+		id,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("ws")),
+		"restored extracted keeps a fresh TTL",
+		domtypes.MemoryStatusCandidate,
+		domtypes.ConfidenceLow,
+		domtypes.MemorySourceExtracted,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.Some(now.Add(domtypes.DefaultMemoryDecayOlderThan)),
+		old,
+		domtypes.None[time.Time](),
+		old,
+		now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sut := usecase.NewMemoryUsecase(&decayRepoFake{}, &decayQueryFake{summaries: []apptypes.MemorySummary{summary}}, nil)
+	result, err := sut.Decay(context.Background(), apptypes.MemoryDecayCriteria{
+		OlderThan: 24 * time.Hour,
+		Limit:     10,
+		Apply:     false,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Decay() error = %v", err)
+	}
+	if len(result.ExpiredIDs) != 0 {
+		t.Fatalf("ExpiredIDs=%#v, restored stamp must grant a fresh TTL", result.ExpiredIDs)
+	}
+}
+
 func TestMemoryUsecase_Restore_ExpiredToCandidate(t *testing.T) {
 	id, _ := domtypes.MemoryIDFrom("mem-restore-1")
 	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -37,6 +37,10 @@ func (s *memoryExtractionMemoryUsecaseStub) Save(_ context.Context, memory *mode
 	return s.proposeErr
 }
 
+func (s *memoryExtractionMemoryUsecaseStub) BackfillCandidateTTLs(context.Context, time.Duration) (int, error) {
+	return 0, nil
+}
+
 func (s *memoryExtractionMemoryUsecaseStub) SaveDistillation(context.Context, *model.Memory, []*model.Memory) error {
 	return nil
 }

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -1063,6 +1063,10 @@ func (r *candidateApplyMemoryRepository) SaveSupersession(context.Context, *mode
 	return nil
 }
 
+func (r *candidateApplyMemoryRepository) BackfillCandidateTTLs(context.Context, time.Duration) (int, error) {
+	return 0, nil
+}
+
 func (r *candidateApplyMemoryRepository) FindByID(_ context.Context, memoryID domtypes.MemoryID) (domtypes.Optional[*model.Memory], error) {
 	if r.findErr != nil {
 		return domtypes.None[*model.Memory](), r.findErr

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -71,6 +71,10 @@ func (s *memoryRepositoryStub) SaveSupersession(_ context.Context, superseded *m
 	return s.saveErr
 }
 
+func (s *memoryRepositoryStub) BackfillCandidateTTLs(context.Context, time.Duration) (int, error) {
+	return 0, nil
+}
+
 func (s *memoryRepositoryStub) FindByID(_ context.Context, memoryID domtypes.MemoryID) (domtypes.Optional[*model.Memory], error) {
 	if s.findErr != nil {
 		return domtypes.None[*model.Memory](), s.findErr

--- a/application/usecase/memory_usecase_import_test.go
+++ b/application/usecase/memory_usecase_import_test.go
@@ -345,6 +345,10 @@ func (s *stubImportMemoryUsecase) Save(_ context.Context, memory *model.Memory) 
 	return s.proposeErr
 }
 
+func (s *stubImportMemoryUsecase) BackfillCandidateTTLs(context.Context, time.Duration) (int, error) {
+	return 0, nil
+}
+
 func (s *stubImportMemoryUsecase) SaveDistillation(context.Context, *model.Memory, []*model.Memory) error {
 	return nil
 }

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -34,7 +34,7 @@ Durable memory には、type・scope・status・confidence・evidence ref・任�
 
 未レビューの auto-extracted 候補（`source=extracted` / `extracted-hidden`）は、提案時に `expires_at = created_at + 30 日` を刻みます。既存の `expires_at` NULL 行は `memory decay --apply`（および session-end hook / `doctor --fix` の同一経路）で backfill します。
 
-`memory decay`（既定は dry-run）は stamp 済みなら `now >= expires_at` で expire します。未 stamp は `created_at + --older-than` です。`updated_at` を触っても時計は巻き戻りません。restore は `now+30d` を刻み直すので、直後に再 expire しません。件数行の `backfilled=N` は、まだ stamp が無かった行数です。expire は非破壊（`status=expired`）で、`memory inbox restore` で戻せます。
+`memory decay`（既定は dry-run）は、いまの TTL grant が `--older-than`（session-end hook では `TRACEARY_MEMORY_DECAY_AFTER`）より古いとき expire します。grant の起点は未 stamp なら `created_at`、stamp 済みなら `expires_at − 30d` なので、短い operator window も効き、restore（`now+30d`）は直後に再 expire しません。`updated_at` を触っても時計は巻き戻りません。件数行の `backfilled=N` は、まだ stamp が無かった行数です。expire は非破壊（`status=expired`）で、`memory inbox restore` で戻せます。
 
 `remember-intent` / `manual` / `compact-summary` は対象外です。人の確認を待ちます。
 

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -34,7 +34,7 @@ Durable memory には、type・scope・status・confidence・evidence ref・任�
 
 未レビューの auto-extracted 候補（`source=extracted` / `extracted-hidden`）は、提案時に `expires_at = created_at + 30 日` を刻みます。既存の `expires_at` NULL 行は `memory decay --apply`（および session-end hook / `doctor --fix` の同一経路）で backfill します。
 
-`memory decay`（既定は dry-run）は `--older-than` を **`created_at` 基準** で判定します。`updated_at` を触っても時計は巻き戻りません。件数行の `backfilled=N` は、まだ stamp が無かった行数です。expire は非破壊（`status=expired`）で、`memory inbox restore` で戻せます。
+`memory decay`（既定は dry-run）は stamp 済みなら `now >= expires_at` で expire します。未 stamp は `created_at + --older-than` です。`updated_at` を触っても時計は巻き戻りません。restore は `now+30d` を刻み直すので、直後に再 expire しません。件数行の `backfilled=N` は、まだ stamp が無かった行数です。expire は非破壊（`status=expired`）で、`memory inbox restore` で戻せます。
 
 `remember-intent` / `manual` / `compact-summary` は対象外です。人の確認を待ちます。
 

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -30,11 +30,19 @@ Durable memory には、type・scope・status・confidence・evidence ref・任�
 
 既定の active-memory 系の取得では、active な accepted memory だけを対象にします。
 
+### Candidate TTL
+
+未レビューの auto-extracted 候補（`source=extracted` / `extracted-hidden`）は、提案時に `expires_at = created_at + 30 日` を刻みます。既存の `expires_at` NULL 行は `memory decay --apply`（および session-end hook / `doctor --fix` の同一経路）で backfill します。
+
+`memory decay`（既定は dry-run）は `--older-than` を **`created_at` 基準** で判定します。`updated_at` を触っても時計は巻き戻りません。件数行の `backfilled=N` は、まだ stamp が無かった行数です。expire は非破壊（`status=expired`）で、`memory inbox restore` で戻せます。
+
+`remember-intent` / `manual` / `compact-summary` は対象外です。人の確認を待ちます。
+
 durable memory を `type` + `scope` で分類する方針にし、別軸 `block` を入れなかった理由は [Memory blocks: 評価と決定](../architecture/memory-blocks.ja.md) を参照してください。
 
 ### コンテンツ validity window
 
-すべての durable memory は、lifecycle な `status` や `memory admin expire` で記録される `expires_at` とは別に、コンテンツの有効期間 `(valid_from, valid_to)` を持ちます。
+すべての durable memory は、lifecycle な `status` や `expires_at`（candidate 中は scheduled TTL、`memory decay` / `memory admin expire` 後は expire 時刻）とは別に、コンテンツの有効期間 `(valid_from, valid_to)` を持ちます。
 
 - `valid_from` — fact が真として主張され始める時刻（既定値は `created_at`）
 - `valid_to` — fact が真でなくなる時刻（`NULL` は open-ended）

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -34,7 +34,7 @@ Only active accepted memories are returned by the default "active memory" paths.
 
 Unreviewed auto-extracted candidates (`source=extracted` or `extracted-hidden`) carry a scheduled `expires_at` of `created_at + 30 days`. The stamp is written at propose time. Existing rows with `expires_at` NULL are backfilled by `memory decay --apply` (and the same path from session-end hooks / `doctor --fix`).
 
-`memory decay` (dry-run by default) expires those candidates once they are older than `--older-than` **from `created_at`**, not `updated_at`, so a later touch does not reset the clock. The count line reports `backfilled=N` for rows that still needed a stamp. Expiry is non-destructive (`status=expired`); restore with `memory inbox restore`.
+`memory decay` (dry-run by default) expires a stamped candidate when `now >= expires_at`. Unstamped rows use `created_at + --older-than`. A later `updated_at` does not reset the clock. Restore restamps `now+30d` so a restored row is not immediately due again. The count line reports `backfilled=N` for rows that still needed a stamp. Expiry is non-destructive (`status=expired`); restore with `memory inbox restore`.
 
 `remember-intent`, `manual`, and `compact-summary` candidates are exempt — they wait for a human look.
 

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -30,11 +30,19 @@ Every durable memory has a type, scope, status, confidence, evidence refs, and o
 
 Only active accepted memories are returned by the default "active memory" paths.
 
+### Candidate TTL
+
+Unreviewed auto-extracted candidates (`source=extracted` or `extracted-hidden`) carry a scheduled `expires_at` of `created_at + 30 days`. The stamp is written at propose time. Existing rows with `expires_at` NULL are backfilled by `memory decay --apply` (and the same path from session-end hooks / `doctor --fix`).
+
+`memory decay` (dry-run by default) expires those candidates once they are older than `--older-than` **from `created_at`**, not `updated_at`, so a later touch does not reset the clock. The count line reports `backfilled=N` for rows that still needed a stamp. Expiry is non-destructive (`status=expired`); restore with `memory inbox restore`.
+
+`remember-intent`, `manual`, and `compact-summary` candidates are exempt — they wait for a human look.
+
 See also [Memory blocks: evaluation and decision](../architecture/memory-blocks.md) for the reasoning behind keeping durable memory classified by `type` + `scope` instead of adding a separate `block` axis.
 
 ### Content validity window
 
-Every durable memory carries a content validity window `(valid_from, valid_to)` distinct from the lifecycle `status` and the `expires_at` operation timestamp written by `memory admin expire`:
+Every durable memory carries a content validity window `(valid_from, valid_to)` distinct from the lifecycle `status` and from `expires_at` (scheduled candidate TTL while `status=candidate`, or the expire-event timestamp after `memory decay` / `memory admin expire`):
 
 - `valid_from` — when the fact starts being asserted (defaults to `created_at`)
 - `valid_to` — when the fact stops being asserted (`NULL` means open-ended)

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -34,7 +34,7 @@ Only active accepted memories are returned by the default "active memory" paths.
 
 Unreviewed auto-extracted candidates (`source=extracted` or `extracted-hidden`) carry a scheduled `expires_at` of `created_at + 30 days`. The stamp is written at propose time. Existing rows with `expires_at` NULL are backfilled by `memory decay --apply` (and the same path from session-end hooks / `doctor --fix`).
 
-`memory decay` (dry-run by default) expires a stamped candidate when `now >= expires_at`. Unstamped rows use `created_at + --older-than`. A later `updated_at` does not reset the clock. Restore restamps `now+30d` so a restored row is not immediately due again. The count line reports `backfilled=N` for rows that still needed a stamp. Expiry is non-destructive (`status=expired`); restore with `memory inbox restore`.
+`memory decay` (dry-run by default) expires when the current TTL grant is older than `--older-than` (or `TRACEARY_MEMORY_DECAY_AFTER` on the session-end hook). The grant starts at `created_at` for unstamped rows, or at `expires_at − 30d` for stamped ones, so a shorter operator window still works and restore (`now+30d`) is not immediately due. A later `updated_at` does not reset the clock. The count line reports `backfilled=N` for rows that still needed a stamp. Expiry is non-destructive (`status=expired`); restore with `memory inbox restore`.
 
 `remember-intent`, `manual`, and `compact-summary` candidates are exempt — they wait for a human look.
 

--- a/domain/model/memory.go
+++ b/domain/model/memory.go
@@ -371,11 +371,11 @@ func (m *Memory) Expire(expiresAt time.Time) error {
 
 // EligibleForDecay reports whether this memory may be auto-expired under the
 // given policy at now. Only candidates with an allowed auto-source are
-// considered. A scheduled expires_at stamp is the clock when present
-// (so restore can grant a fresh TTL without rewriting created_at).
-// Unstamped rows fall back to created_at + olderThan. updated_at must
-// not reset the clock (#2062). Accepted, rejected, superseded, and
-// expired memories never decay.
+// considered. The clock is the current TTL grant (expires_at minus the
+// default window when stamped, otherwise created_at) plus policy.OlderThan,
+// so --older-than still shortens and restore still grants a fresh window.
+// updated_at must not reset the clock (#2062). Accepted, rejected,
+// superseded, and expired memories never decay.
 func (m *Memory) EligibleForDecay(policy types.MemoryDecayPolicy, now time.Time) bool {
 	if m.status != types.MemoryStatusCandidate {
 		return false
@@ -383,11 +383,7 @@ func (m *Memory) EligibleForDecay(policy types.MemoryDecayPolicy, now time.Time)
 	if !policy.AllowsSource(m.source) {
 		return false
 	}
-	if expiresAt, ok := m.expiresAt.Value(); ok {
-		return !now.UTC().Before(expiresAt.UTC())
-	}
-	cutoff := now.UTC().Add(-policy.OlderThan())
-	return m.createdAt.UTC().Before(cutoff)
+	return policy.CandidateDue(m.createdAt, m.expiresAt, now)
 }
 
 // MarkCandidateSupersededByDuplicate transitions a candidate to superseded

--- a/domain/model/memory.go
+++ b/domain/model/memory.go
@@ -14,8 +14,9 @@ import (
 //
 // validFrom / validTo describe the **content validity window** —
 // the period during which the fact is asserted to be true. They are
-// distinct from expiresAt (the lifecycle timestamp written when an
-// operator runs `memory expire`) and from createdAt / updatedAt
+// distinct from expiresAt (scheduled candidate TTL, or the lifecycle
+// timestamp written when decay / `memory expire` actually expires the
+// row) and from createdAt / updatedAt
 // (which describe when the row itself was recorded). See
 // docs/memory/README.md and docs/architecture/memory-blocks.md.
 type Memory struct {
@@ -63,7 +64,12 @@ func NewMemoryCandidateWithClock(
 	supersedes types.Optional[types.MemoryID],
 	clock types.Clock,
 ) (*Memory, error) {
-	return newMemory(memoryID, memoryType, scope, fact, types.MemoryStatusCandidate, types.ConfidenceLow, source, evidenceRefs, artifactRefs, supersedes, types.None[time.Time](), clock)
+	clock = clockOrSystem(clock)
+	expiresAt := types.None[time.Time]()
+	if types.CandidateTTLApplies(source) {
+		expiresAt = types.Some(clock.Now().Add(types.DefaultMemoryDecayOlderThan))
+	}
+	return newMemory(memoryID, memoryType, scope, fact, types.MemoryStatusCandidate, types.ConfidenceLow, source, evidenceRefs, artifactRefs, supersedes, expiresAt, clock)
 }
 
 // NewAcceptedMemory creates an accepted memory with the default
@@ -365,8 +371,9 @@ func (m *Memory) Expire(expiresAt time.Time) error {
 
 // EligibleForDecay reports whether this memory may be auto-expired under the
 // given policy at now. Only candidates with an allowed auto-source whose
-// updated_at is strictly older than the policy threshold are eligible.
-// Accepted, rejected, superseded, and expired memories never decay.
+// created_at is strictly older than the policy threshold are eligible.
+// updated_at must not reset the clock (#2062). Accepted, rejected,
+// superseded, and expired memories never decay.
 func (m *Memory) EligibleForDecay(policy types.MemoryDecayPolicy, now time.Time) bool {
 	if m.status != types.MemoryStatusCandidate {
 		return false
@@ -375,7 +382,7 @@ func (m *Memory) EligibleForDecay(policy types.MemoryDecayPolicy, now time.Time)
 		return false
 	}
 	cutoff := now.UTC().Add(-policy.OlderThan())
-	return m.updatedAt.UTC().Before(cutoff)
+	return m.createdAt.UTC().Before(cutoff)
 }
 
 // MarkCandidateSupersededByDuplicate transitions a candidate to superseded
@@ -389,15 +396,21 @@ func (m *Memory) MarkCandidateSupersededByDuplicate() error {
 	return nil
 }
 
-// RestoreToCandidate transitions an expired memory back to candidate and
-// clears the lifecycle expiresAt stamp so it re-enters the review inbox.
+// RestoreToCandidate transitions an expired memory back to candidate.
+// TTL sources get a fresh scheduled expires_at (now + default TTL);
+// other sources clear the stamp so they re-enter the inbox without a clock.
 func (m *Memory) RestoreToCandidate() error {
 	if m.status != types.MemoryStatusExpired {
 		return ErrInvalidMemoryState
 	}
 	m.status = types.MemoryStatusCandidate
-	m.expiresAt = types.None[time.Time]()
-	m.updatedAt = m.now()
+	now := m.now()
+	if types.CandidateTTLApplies(m.source) {
+		m.expiresAt = types.Some(now.Add(types.DefaultMemoryDecayOlderThan))
+	} else {
+		m.expiresAt = types.None[time.Time]()
+	}
+	m.updatedAt = now
 	return nil
 }
 

--- a/domain/model/memory.go
+++ b/domain/model/memory.go
@@ -370,16 +370,21 @@ func (m *Memory) Expire(expiresAt time.Time) error {
 }
 
 // EligibleForDecay reports whether this memory may be auto-expired under the
-// given policy at now. Only candidates with an allowed auto-source whose
-// created_at is strictly older than the policy threshold are eligible.
-// updated_at must not reset the clock (#2062). Accepted, rejected,
-// superseded, and expired memories never decay.
+// given policy at now. Only candidates with an allowed auto-source are
+// considered. A scheduled expires_at stamp is the clock when present
+// (so restore can grant a fresh TTL without rewriting created_at).
+// Unstamped rows fall back to created_at + olderThan. updated_at must
+// not reset the clock (#2062). Accepted, rejected, superseded, and
+// expired memories never decay.
 func (m *Memory) EligibleForDecay(policy types.MemoryDecayPolicy, now time.Time) bool {
 	if m.status != types.MemoryStatusCandidate {
 		return false
 	}
 	if !policy.AllowsSource(m.source) {
 		return false
+	}
+	if expiresAt, ok := m.expiresAt.Value(); ok {
+		return !now.UTC().Before(expiresAt.UTC())
 	}
 	cutoff := now.UTC().Add(-policy.OlderThan())
 	return m.createdAt.UTC().Before(cutoff)

--- a/domain/model/memory_repository.go
+++ b/domain/model/memory_repository.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"time"
 
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -19,4 +20,8 @@ type MemoryRepository interface {
 	// FindByID returns the memory for the given ID.
 	// Returns an empty Optional when the memory does not exist.
 	FindByID(ctx context.Context, memoryID types.MemoryID) (types.Optional[*Memory], error)
+	// BackfillCandidateTTLs stamps expires_at = created_at + olderThan on
+	// extracted / extracted-hidden candidates that have no scheduled TTL.
+	// Returns the number of rows stamped.
+	BackfillCandidateTTLs(ctx context.Context, olderThan time.Duration) (int, error)
 }

--- a/domain/model/memory_test.go
+++ b/domain/model/memory_test.go
@@ -452,6 +452,13 @@ func TestMemory_RestoreToCandidate(t *testing.T) {
 	if !got.After(time.Now().UTC().Add(types.DefaultMemoryDecayOlderThan - time.Minute)) {
 		t.Fatalf("restamped expires_at=%s, want ~now+30d", got)
 	}
+	policy, err := types.MemoryDecayPolicyOf(types.DefaultMemoryDecayOlderThan, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.EligibleForDecay(policy, time.Now().UTC()) {
+		t.Fatal("restored extracted candidate must not be immediately due")
+	}
 	if err := m.RestoreToCandidate(); !errors.Is(err, model.ErrInvalidMemoryState) {
 		t.Fatalf("restore non-expired err = %v", err)
 	}

--- a/domain/model/memory_test.go
+++ b/domain/model/memory_test.go
@@ -351,13 +351,58 @@ func TestMemory_EligibleForDecay(t *testing.T) {
 			t.Fatal("want eligible")
 		}
 	})
-	t.Run("returns false for remember-intent and manual sources regardless of age", func(t *testing.T) {
+	t.Run("returns false for remember-intent, manual, and compact-summary regardless of age", func(t *testing.T) {
 		t.Parallel()
-		for _, src := range []types.MemorySource{types.MemorySourceRememberIntent, types.MemorySourceManual} {
+		for _, src := range []types.MemorySource{types.MemorySourceRememberIntent, types.MemorySourceManual, types.MemorySourceCompactSummary} {
 			m := mustCandidate(t, src, old)
 			if m.EligibleForDecay(policy, now) {
 				t.Fatalf("source %s must not be eligible", src)
 			}
+		}
+	})
+	t.Run("uses created_at so a recent updated_at does not reset the TTL", func(t *testing.T) {
+		t.Parallel()
+		id, err := types.MemoryIDFrom("mem-decay-touched")
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := model.MemoryOf(
+			id,
+			types.MemoryTypeDecision,
+			types.WorkspaceScopeOf(types.Workspace("github.com/duck8823/traceary")),
+			"fact for decay tests",
+			types.MemoryStatusCandidate,
+			types.ConfidenceLow,
+			types.MemorySourceExtracted,
+			nil, nil,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			old,
+			types.None[time.Time](),
+			old,
+			now,
+		)
+		if !m.EligibleForDecay(policy, now) {
+			t.Fatal("want eligible from created_at even when updated_at is now")
+		}
+	})
+	t.Run("stamps scheduled expires_at on extracted candidates", func(t *testing.T) {
+		t.Parallel()
+		m := mustCandidate(t, types.MemorySourceExtracted, old)
+		got, ok := m.ExpiresAt().Value()
+		if !ok {
+			t.Fatal("extracted candidate must stamp expires_at")
+		}
+		want := old.Add(types.DefaultMemoryDecayOlderThan)
+		if !got.Equal(want) {
+			t.Fatalf("expires_at=%s, want %s", got, want)
+		}
+	})
+	t.Run("does not stamp expires_at on remember-intent", func(t *testing.T) {
+		t.Parallel()
+		m := mustCandidate(t, types.MemorySourceRememberIntent, old)
+		if _, ok := m.ExpiresAt().Value(); ok {
+			t.Fatal("remember-intent must not carry a candidate TTL")
 		}
 	})
 	t.Run("returns false for accepted memory", func(t *testing.T) {
@@ -400,8 +445,12 @@ func TestMemory_RestoreToCandidate(t *testing.T) {
 	if m.Status() != types.MemoryStatusCandidate {
 		t.Fatalf("status = %s", m.Status())
 	}
-	if _, ok := m.ExpiresAt().Value(); ok {
-		t.Fatal("expiresAt must be cleared")
+	got, ok := m.ExpiresAt().Value()
+	if !ok {
+		t.Fatal("extracted restore must restamp expires_at")
+	}
+	if !got.After(time.Now().UTC().Add(types.DefaultMemoryDecayOlderThan - time.Minute)) {
+		t.Fatalf("restamped expires_at=%s, want ~now+30d", got)
 	}
 	if err := m.RestoreToCandidate(); !errors.Is(err, model.ErrInvalidMemoryState) {
 		t.Fatalf("restore non-expired err = %v", err)

--- a/domain/types/memory_decay_policy.go
+++ b/domain/types/memory_decay_policy.go
@@ -60,3 +60,18 @@ func (p MemoryDecayPolicy) Sources() []MemorySource {
 func (p MemoryDecayPolicy) AllowsSource(source MemorySource) bool {
 	return slices.Contains(p.sources, source)
 }
+
+// DecayGrantStart is the start of the current TTL grant. Unstamped rows
+// use created_at. Stamped rows use expires_at minus the default TTL so a
+// restore restamp is a fresh window and --older-than still shortens it.
+func DecayGrantStart(createdAt time.Time, expiresAt Optional[time.Time]) time.Time {
+	if exp, ok := expiresAt.Value(); ok {
+		return exp.UTC().Add(-DefaultMemoryDecayOlderThan)
+	}
+	return createdAt.UTC()
+}
+
+// CandidateDue reports whether the grant is older than the policy window.
+func (p MemoryDecayPolicy) CandidateDue(createdAt time.Time, expiresAt Optional[time.Time], now time.Time) bool {
+	return DecayGrantStart(createdAt, expiresAt).Before(now.UTC().Add(-p.olderThan))
+}

--- a/domain/types/memory_decay_policy.go
+++ b/domain/types/memory_decay_policy.go
@@ -15,13 +15,19 @@ type MemoryDecayPolicy struct {
 }
 
 // DefaultDecaySources are the auto-extraction sources that may decay.
-// Explicit user intent (manual / remember-intent) and imports never decay.
+// Explicit user intent (manual / remember-intent), compact-summary, and
+// imports never decay — they wait for a human look (#2062).
 func DefaultDecaySources() []MemorySource {
 	return []MemorySource{
 		MemorySourceExtracted,
 		MemorySourceExtractedHidden,
-		MemorySourceCompactSummary,
 	}
+}
+
+// CandidateTTLApplies reports whether a candidate should carry a scheduled
+// expires_at stamp (created_at + DefaultMemoryDecayOlderThan).
+func CandidateTTLApplies(source MemorySource) bool {
+	return source == MemorySourceExtracted || source == MemorySourceExtractedHidden
 }
 
 // DefaultMemoryDecayOlderThan is 30 days — more conservative than the legacy

--- a/domain/types/memory_decay_policy_test.go
+++ b/domain/types/memory_decay_policy_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -24,5 +25,31 @@ func TestMemoryDecayPolicyOf_DefaultsSources(t *testing.T) {
 	}
 	if p.AllowsSource(types.MemorySourceManual) || p.AllowsSource(types.MemorySourceRememberIntent) || p.AllowsSource(types.MemorySourceCompactSummary) {
 		t.Fatal("manual/remember-intent/compact-summary must not be in default decay sources")
+	}
+}
+
+func TestMemoryDecayPolicy_CandidateDueHonorsShorterOlderThanAndRestore(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	sevenDays, err := types.MemoryDecayPolicyOf(7*24*time.Hour, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalStamp := types.Some(created.Add(types.DefaultMemoryDecayOlderThan))
+	if !sevenDays.CandidateDue(created, originalStamp, now) {
+		t.Fatal("original 30d stamp must still be due under --older-than 7d after 10 days")
+	}
+	fresh := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	if sevenDays.CandidateDue(fresh, types.Some(fresh.Add(types.DefaultMemoryDecayOlderThan)), now) {
+		t.Fatal("brand-new stamped candidate must not be due at create time")
+	}
+	restoreAt := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	restoredStamp := types.Some(restoreAt.Add(types.DefaultMemoryDecayOlderThan))
+	if sevenDays.CandidateDue(created, restoredStamp, restoreAt) {
+		t.Fatal("just-restored candidate must not be immediately due")
+	}
+	if !sevenDays.CandidateDue(created, restoredStamp, restoreAt.Add(8*24*time.Hour)) {
+		t.Fatal("restored candidate must be due after the shorter --older-than window")
 	}
 }

--- a/domain/types/memory_decay_policy_test.go
+++ b/domain/types/memory_decay_policy_test.go
@@ -19,10 +19,10 @@ func TestMemoryDecayPolicyOf_DefaultsSources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.AllowsSource(types.MemorySourceExtracted) || !p.AllowsSource(types.MemorySourceCompactSummary) {
-		t.Fatalf("default sources missing auto-extract sources: %#v", p.Sources())
+	if !p.AllowsSource(types.MemorySourceExtracted) || !p.AllowsSource(types.MemorySourceExtractedHidden) {
+		t.Fatalf("default sources missing TTL auto-extract sources: %#v", p.Sources())
 	}
-	if p.AllowsSource(types.MemorySourceManual) || p.AllowsSource(types.MemorySourceRememberIntent) {
-		t.Fatal("manual/remember-intent must not be in default decay sources")
+	if p.AllowsSource(types.MemorySourceManual) || p.AllowsSource(types.MemorySourceRememberIntent) || p.AllowsSource(types.MemorySourceCompactSummary) {
+		t.Fatal("manual/remember-intent/compact-summary must not be in default decay sources")
 	}
 }

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	_ "embed"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -40,6 +41,9 @@ var selectMemoryEvidenceRefsQuery string
 
 //go:embed sql/select_memory_artifact_refs.sql
 var selectMemoryArtifactRefsQuery string
+
+//go:embed sql/backfill_candidate_ttl.sql
+var backfillCandidateTTLQuery string
 
 const selectMemorySummaryColumnsQuery = `
 SELECT
@@ -297,6 +301,28 @@ func (d *MemoryDatasource) FindByID(ctx context.Context, memoryID types.MemoryID
 	}
 
 	return types.Some(memory), nil
+}
+
+// BackfillCandidateTTLs stamps expires_at = created_at + olderThan on
+// extracted / extracted-hidden candidates that have no scheduled TTL.
+func (d *MemoryDatasource) BackfillCandidateTTLs(ctx context.Context, olderThan time.Duration) (int, error) {
+	if olderThan <= 0 {
+		return 0, xerrors.Errorf("candidate TTL backfill older-than must be positive")
+	}
+	modifier := fmt.Sprintf("+%d seconds", int64(olderThan/time.Second))
+	var stamped int
+	err := d.runMemoryWriteTx(ctx, func(tx *sql.Tx) error {
+		n, execErr := execRowsAffected(ctx, tx, backfillCandidateTTLQuery, modifier)
+		if execErr != nil {
+			return execErr
+		}
+		stamped = n
+		return nil
+	})
+	if err != nil {
+		return 0, xerrors.Errorf("failed to backfill candidate TTL stamps: %w", err)
+	}
+	return stamped, nil
 }
 
 // GetDetails returns the details for a single memory.

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -1203,3 +1203,80 @@ func TestMemoryDatasource_ListUsesInjectedClockForDefaultAsOf(t *testing.T) {
 		t.Fatalf("List()[0] = %q, want %q", got, want)
 	}
 }
+
+func TestMemoryDatasource_BackfillCandidateTTLs(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/duck8823/traceary")
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	already := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	fixtures := []*model.Memory{
+		memoryOf(t, "mem-extracted-null", types.MemoryTypeLesson, scope, "extracted null", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), created, created),
+		memoryOf(t, "mem-hidden-null", types.MemoryTypeLesson, scope, "hidden null", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtractedHidden, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), created, created),
+		memoryOf(t, "mem-extracted-stamped", types.MemoryTypeLesson, scope, "already stamped", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.Some(already), created, created),
+		memoryOf(t, "mem-remember", types.MemoryTypePreference, scope, "remember", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceRememberIntent, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), created, created),
+		memoryOf(t, "mem-compact", types.MemoryTypeLesson, scope, "compact", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceCompactSummary, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), created, created),
+	}
+	for _, memory := range fixtures {
+		if err := sut.Save(ctx, memory); err != nil {
+			t.Fatalf("Save(%s) error = %v", memory.MemoryID(), err)
+		}
+	}
+	stamped, err := sut.BackfillCandidateTTLs(ctx, 30*24*time.Hour)
+	if err != nil {
+		t.Fatalf("BackfillCandidateTTLs() error = %v", err)
+	}
+	if stamped != 2 {
+		t.Fatalf("stamped=%d, want 2 (extracted+hidden NULL only)", stamped)
+	}
+	for _, id := range []string{"mem-extracted-null", "mem-hidden-null"} {
+		got, err := sut.FindByID(ctx, mustMemoryID(t, id))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mem, ok := got.Value()
+		if !ok {
+			t.Fatalf("%s missing after backfill", id)
+		}
+		exp, ok := mem.ExpiresAt().Value()
+		if !ok {
+			t.Fatalf("%s expires_at still NULL", id)
+		}
+		if exp.Before(created.Add(29*24*time.Hour)) || exp.After(created.Add(31*24*time.Hour)) {
+			t.Fatalf("%s expires_at=%s, want ~created+30d", id, exp)
+		}
+		if mem.Status() != types.MemoryStatusCandidate {
+			t.Fatalf("%s status=%s, backfill must not expire", id, mem.Status())
+		}
+	}
+	kept, err := sut.FindByID(ctx, mustMemoryID(t, "mem-extracted-stamped"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem, ok := kept.Value()
+	if !ok {
+		t.Fatal("stamped row missing")
+	}
+	got, ok := mem.ExpiresAt().Value()
+	if !ok || !got.Equal(already) {
+		t.Fatalf("pre-stamped expires_at=%v %v, want %s", got, ok, already)
+	}
+	for _, id := range []string{"mem-remember", "mem-compact"} {
+		got, err := sut.FindByID(ctx, mustMemoryID(t, id))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mem, ok := got.Value()
+		if !ok {
+			t.Fatalf("%s missing", id)
+		}
+		if _, present := mem.ExpiresAt().Value(); present {
+			t.Fatalf("%s must not receive a candidate TTL", id)
+		}
+	}
+}

--- a/infrastructure/sqlite/sql/backfill_candidate_ttl.sql
+++ b/infrastructure/sqlite/sql/backfill_candidate_ttl.sql
@@ -1,0 +1,8 @@
+-- Stamp scheduled candidate TTL on unreviewed auto-extracted rows that
+-- never received expires_at. Modifier is '+N seconds' from created_at.
+-- Does not change status; decay expire is a separate pass.
+UPDATE memories
+   SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', substr(created_at, 1, 19), ?)
+ WHERE status = 'candidate'
+   AND source IN ('extracted', 'extracted-hidden')
+   AND expires_at IS NULL

--- a/presentation/cli/memory_decay.go
+++ b/presentation/cli/memory_decay.go
@@ -52,7 +52,7 @@ func (c *RootCLI) newMemoryDecayCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
-	cmd.Flags().DurationVar(&input.olderThan, "older-than", domtypes.DefaultMemoryDecayOlderThan, Localize("only expire candidates not updated within this duration (default 720h)", "この duration 以上更新のない候補のみ expire (既定 720h)"))
+	cmd.Flags().DurationVar(&input.olderThan, "older-than", domtypes.DefaultMemoryDecayOlderThan, Localize("for unstamped candidates, expire when created_at is older than this (default 720h); stamped rows use expires_at", "未 stamp 候補は created_at がこの duration より古いとき expire (既定 720h)。stamp 済みは expires_at を使う"))
 	cmd.Flags().IntVar(&input.limit, "limit", 500, Localize("maximum candidates to expire in one run", "1 回の実行で expire する最大件数"))
 	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("filter by workspace scope", "workspace scope で絞り込む"))
 	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden sources (already in default policy)", "extracted-hidden を含める (既定ポリシーに含まれる)"))

--- a/presentation/cli/memory_decay.go
+++ b/presentation/cli/memory_decay.go
@@ -52,7 +52,7 @@ func (c *RootCLI) newMemoryDecayCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
-	cmd.Flags().DurationVar(&input.olderThan, "older-than", domtypes.DefaultMemoryDecayOlderThan, Localize("for unstamped candidates, expire when created_at is older than this (default 720h); stamped rows use expires_at", "未 stamp 候補は created_at がこの duration より古いとき expire (既定 720h)。stamp 済みは expires_at を使う"))
+	cmd.Flags().DurationVar(&input.olderThan, "older-than", domtypes.DefaultMemoryDecayOlderThan, Localize("expire when the current TTL grant is older than this (default 720h); restore starts a new grant", "いまの TTL grant がこの duration より古いとき expire (既定 720h)。restore は grant をやり直す"))
 	cmd.Flags().IntVar(&input.limit, "limit", 500, Localize("maximum candidates to expire in one run", "1 回の実行で expire する最大件数"))
 	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("filter by workspace scope", "workspace scope で絞り込む"))
 	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden sources (already in default policy)", "extracted-hidden を含める (既定ポリシーに含まれる)"))

--- a/presentation/cli/memory_decay.go
+++ b/presentation/cli/memory_decay.go
@@ -117,8 +117,8 @@ func (c *RootCLI) runMemoryDecay(ctx context.Context, output io.Writer, input me
 	if result.Applied {
 		mode = "applied"
 	}
-	_, err = fmt.Fprintf(output, "memory decay (%s): scanned=%d expired=%d superseded=%d remaining=%d older_than=%s\n",
-		mode, result.Scanned, len(result.ExpiredIDs), len(result.SupersededIDs), result.RemainingAfter, result.OlderThan)
+	_, err = fmt.Fprintf(output, "memory decay (%s): scanned=%d expired=%d superseded=%d remaining=%d backfilled=%d older_than=%s\n",
+		mode, result.Scanned, len(result.ExpiredIDs), len(result.SupersededIDs), result.RemainingAfter, result.Backfilled, result.OlderThan)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory decay summary", "memory decay サマリの出力に失敗しました"), err)
 	}

--- a/presentation/cli/memory_decay_test.go
+++ b/presentation/cli/memory_decay_test.go
@@ -47,7 +47,7 @@ func TestRootCLI_MemoryDecay_DryRun(t *testing.T) {
 	if stub.decayCall.Apply {
 		t.Fatal("default must be dry-run")
 	}
-	if !strings.Contains(stdout.String(), "dry-run") || !strings.Contains(stdout.String(), "expired=1") {
+	if !strings.Contains(stdout.String(), "dry-run") || !strings.Contains(stdout.String(), "expired=1") || !strings.Contains(stdout.String(), "backfilled=") {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
 }


### PR DESCRIPTION
Closes #2062
Leaves parent #2049 open

Unreviewed extracted / extracted-hidden candidates get a 30-day TTL from created_at. Decay backfills NULL expires_at on apply, clocks created_at (not updated_at), and leaves remember-intent / manual / compact-summary for a human look. Dry-run count line adds backfilled=.