### PR TITLE
fix: disclose memory inbox candidate pool size

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **`memory inbox list` が候補プール件数を出す (#2064)** — テキストはページの後に `showing N of M candidates (source split)` を出す。`--source` 未指定なら `extracted-hidden` も含む。JSON は既存の item 配列のまま。
 - **抽出がオーケストレーション進捗のナレーションを hidden にする (#2063)** — sprint/wave 状況、markdown の status 表、scratch パス、`ephemeralMessage` 包みを `extracted-hidden`（`transient_status`）へ。always/never/must の durable 事実は表示されたまま。
 - **未レビューの extracted メモリ候補に 30 日 TTL を付ける (#2062)** — 提案時に `expires_at` を刻み、`memory decay --apply` で NULL を backfill する。decay の時計は `created_at`（`updated_at` ではない）。`remember-intent` / `manual` / `compact-summary` は対象外。dry-run 件数に `backfilled=` を出す。
 - **`store search-projection status` が dbstat を歩かない (#2059)** — 物理バイトは `store capacity` の sidecar cache（`physical_evidence.status=cached`）か、即座の `unavailable`。lifecycle 欄は control snapshot のまま。大きい store でも数秒で答えるのが目標。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **`memory inbox list` discloses the candidate pool size (#2064)** — text mode prints `showing N of M candidates (source split)` after the page, including `extracted-hidden` unless `--source` is set. JSON stays the existing item array.
 - **Extraction hides orchestration progress narration (#2063)** — sprint/wave status, markdown status-table rows, scratch-path lines, and `ephemeralMessage` envelopes are routed to `extracted-hidden` (`transient_status`). Durable always/never/must facts stay visible.
 - **Unreviewed extracted memory candidates now carry a 30-day TTL (#2062)** — `expires_at` is stamped at propose time and backfilled on `memory decay --apply`. Decay clocks `created_at` (not `updated_at`). `remember-intent` / `manual` / `compact-summary` stay exempt. Dry-run counts include `backfilled=`.
 - **`store search-projection status` no longer walks dbstat (#2059)** — physical bytes come from the `store capacity` sidecar cache (`physical_evidence.status=cached`) or are immediately `unavailable`. Lifecycle fields stay on the control snapshot. Target is low-second answers on large stores.

--- a/application/queryservice/memory_query.go
+++ b/application/queryservice/memory_query.go
@@ -27,6 +27,14 @@ type MemoryStatusCountQueryService interface {
 	CountByStatus(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error)
 }
 
+// MemorySourceCountQueryService is the additive read-side query used by
+// `memory inbox list` to disclose the candidate pool size (#2064).
+type MemorySourceCountQueryService interface {
+	// CountBySource returns the true per-source row counts matching the
+	// criteria, ignoring its Limit/Offset.
+	CountBySource(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemorySourceCounts, error)
+}
+
 // StaleMemoryQueryService provides the additive read-side query used by
 // `traceary top --snapshot --json` to surface stale durable memories without
 // introducing a write-side use case.

--- a/application/types/memory_source_counts.go
+++ b/application/types/memory_source_counts.go
@@ -1,0 +1,36 @@
+package types
+
+import "github.com/duck8823/traceary/domain/types"
+
+// MemorySourceCounts is the true per-source candidate count matching a
+// list filter, independent of Limit/Offset. It backs the inbox list
+// pool-size summary (#2064).
+type MemorySourceCounts struct {
+	total    int
+	bySource map[types.MemorySource]int
+}
+
+// MemorySourceCountsFrom builds counts from a per-source map.
+func MemorySourceCountsFrom(bySource map[types.MemorySource]int) MemorySourceCounts {
+	copied := make(map[types.MemorySource]int, len(bySource))
+	total := 0
+	for source, count := range bySource {
+		if count <= 0 {
+			continue
+		}
+		copied[source] = count
+		total += count
+	}
+	return MemorySourceCounts{total: total, bySource: copied}
+}
+
+// Total returns the sum of all source buckets.
+func (c MemorySourceCounts) Total() int { return c.total }
+
+// Count returns the bucket for source, or 0.
+func (c MemorySourceCounts) Count(source types.MemorySource) int {
+	if c.bySource == nil {
+		return 0
+	}
+	return c.bySource[source]
+}

--- a/application/types/memory_source_counts_test.go
+++ b/application/types/memory_source_counts_test.go
@@ -1,0 +1,31 @@
+package types_test
+
+import (
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemorySourceCountsFromIgnoresNonPositiveBuckets(t *testing.T) {
+	t.Parallel()
+
+	counts := apptypes.MemorySourceCountsFrom(map[types.MemorySource]int{
+		types.MemorySourceExtracted:       3,
+		types.MemorySourceExtractedHidden: 0,
+		types.MemorySourceRememberIntent:  -1,
+		types.MemorySourceManual:          2,
+	})
+	if counts.Total() != 5 {
+		t.Fatalf("Total() = %d, want 5", counts.Total())
+	}
+	if counts.Count(types.MemorySourceExtracted) != 3 {
+		t.Fatalf("extracted = %d, want 3", counts.Count(types.MemorySourceExtracted))
+	}
+	if counts.Count(types.MemorySourceExtractedHidden) != 0 {
+		t.Fatalf("hidden zero bucket leaked: %d", counts.Count(types.MemorySourceExtractedHidden))
+	}
+	if counts.Count(types.MemorySourceImported) != 0 {
+		t.Fatalf("missing source must be 0, got %d", counts.Count(types.MemorySourceImported))
+	}
+}

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -610,6 +610,23 @@ func (u *memoryUsecase) CountByStatus(ctx context.Context, criteria apptypes.Mem
 	return counts, nil
 }
 
+// CountBySource returns the true per-source durable-memory counts, ignoring
+// the criteria's Limit/Offset.
+func (u *memoryUsecase) CountBySource(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemorySourceCounts, error) {
+	if u.memoryQuery == nil {
+		return apptypes.MemorySourceCounts{}, xerrors.Errorf("memory query service is not configured")
+	}
+	counter, ok := u.memoryQuery.(queryservice.MemorySourceCountQueryService)
+	if !ok {
+		return apptypes.MemorySourceCounts{}, xerrors.Errorf("memory query service does not support source counts")
+	}
+	counts, err := counter.CountBySource(ctx, criteria)
+	if err != nil {
+		return apptypes.MemorySourceCounts{}, xerrors.Errorf("failed to count durable memories by source: %w", err)
+	}
+	return counts, nil
+}
+
 func (u *memoryUsecase) ListStale(ctx context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {
 	if u.memoryQuery == nil {
 		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("memory query service is not configured")

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -337,6 +337,8 @@ durable memory を一覧表示します。scope flag を明示しない場合は
 
 主な flag: `--workspace`, `--agent`, `--session-family`, `--type`, `--source` (manual / extracted / extracted-hidden / imported / remember-intent / compact-summary), `--include-hidden`, `--limit`, `--offset`, `--json`。
 
+テキスト出力の末尾にプール件数行（`showing N of M candidates (source split)`）を出します。`--limit` のページの裏に 3 万件が隠れないようにするためです。`--source` 未指定なら `extracted-hidden` も含みます。`--json` は従来どおり item の配列です。
+
 `--source` は extraction / import 経路との相性が良い filter です。
 
 - `--source imported` は host-native source (Codex 等、`memory admin import codex` 参照) から取り込まれた memory に絞ります。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -337,6 +337,8 @@ Review the memory review queue. `list` surfaces `candidate` memories together wi
 
 Useful flags: `--workspace`, `--agent`, `--session-family`, `--type`, `--source` (manual / extracted / extracted-hidden / imported / remember-intent / compact-summary), `--include-hidden`, `--limit`, `--offset`, `--json`.
 
+Text mode ends with a pool-size line (`showing N of M candidates (source split)`) so a `--limit` page cannot hide a 30k inbox. The count includes `extracted-hidden` unless `--source` is set. `--json` stays a top-level item array.
+
 The `--source` filter pairs naturally with the extraction and import paths:
 
 - `--source imported` focuses on memories read from host-native sources such as Codex (see `memory admin import codex`).

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -119,7 +119,7 @@ v0.21.0 以降、完全な構造を持つ unified-diff / git metadata のみ aut
 
 #### 候補の hygiene
 
-旧 sessions snapshot の hygiene pane は v0.42.0 で `traceary sessions` とともに削除されました（#2061）。候補 backlog の把握と掃除は `traceary memory inbox list` と dry-run 既定の `traceary memory inbox cleanup --quality low` を使います（`--apply` で match を reject。cleanup は候補を reject するだけで、削除や auto-accept はしません）。`traceary memory admin hygiene scan` は exact な同一 scope・memory type・fact を超えた similarity ベースの重複検出を追加します。
+旧 sessions snapshot の hygiene pane は v0.42.0 で `traceary sessions` とともに削除されました（#2061）。候補 backlog の把握と掃除は `traceary memory inbox list`（テキストは `showing N of M candidates`。`--source` 未指定なら hidden も含む）と dry-run 既定の `traceary memory inbox cleanup --quality low` を使います（`--apply` で match を reject。cleanup は候補を reject するだけで、削除や auto-accept はしません）。`traceary memory admin hygiene scan` は exact な同一 scope・memory type・fact を超えた similarity ベースの重複検出を追加します。
 
 #### context boundary からの抽出
 

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -119,7 +119,7 @@ Since v0.21.0, only fully-formed unified-diff / git metadata is **dropped entire
 
 #### Candidate hygiene
 
-The former sessions snapshot hygiene pane was removed with `traceary sessions` in v0.42.0 (#2061). Gauge and clear the candidate backlog with `traceary memory inbox list` and the dry-run-first `traceary memory inbox cleanup --quality low` (add `--apply` to reject matches; cleanup only rejects candidates; it never deletes or auto-accepts). `traceary memory admin hygiene scan` adds similarity-based duplicate detection beyond exact same-scope / memory-type / fact matches.
+The former sessions snapshot hygiene pane was removed with `traceary sessions` in v0.42.0 (#2061). Gauge and clear the candidate backlog with `traceary memory inbox list` (text mode prints `showing N of M candidates`, including hidden unless `--source` is set) and the dry-run-first `traceary memory inbox cleanup --quality low` (add `--apply` to reject matches; cleanup only rejects candidates; it never deletes or auto-accepts). `traceary memory admin hygiene scan` adds similarity-based duplicate detection beyond exact same-scope / memory-type / fact matches.
 
 #### Context-boundary extraction
 

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -109,10 +109,12 @@ func NewMemoryDatasourceWithClock(db *Database, clock types.Clock) *MemoryDataso
 }
 
 var (
-	_ model.MemoryRepository               = (*MemoryDatasource)(nil)
-	_ queryservice.MemoryQueryService      = (*MemoryDatasource)(nil)
-	_ queryservice.MemoryHygieneScanSource = (*MemoryDatasource)(nil)
-	_ queryservice.StaleMemoryQueryService = (*MemoryDatasource)(nil)
+	_ model.MemoryRepository                     = (*MemoryDatasource)(nil)
+	_ queryservice.MemoryQueryService            = (*MemoryDatasource)(nil)
+	_ queryservice.MemoryHygieneScanSource       = (*MemoryDatasource)(nil)
+	_ queryservice.StaleMemoryQueryService       = (*MemoryDatasource)(nil)
+	_ queryservice.MemoryStatusCountQueryService = (*MemoryDatasource)(nil)
+	_ queryservice.MemorySourceCountQueryService = (*MemoryDatasource)(nil)
 )
 
 // Save persists a memory aggregate together with its refs.
@@ -446,6 +448,53 @@ func (d *MemoryDatasource) CountByStatus(ctx context.Context, criteria apptypes.
 	}
 
 	return counts, nil
+}
+
+// CountBySource returns the true per-source row counts matching the criteria,
+// ignoring its Limit/Offset. It backs the inbox list pool-size summary (#2064).
+func (d *MemoryDatasource) CountBySource(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemorySourceCounts, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return apptypes.MemorySourceCounts{}, xerrors.Errorf("failed to open DB for memory source count: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	query, args, err := buildMemoryCountBySourceQuery(criteria, d.clock)
+	if err != nil {
+		return apptypes.MemorySourceCounts{}, xerrors.Errorf("failed to build memory source count query: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return apptypes.MemorySourceCounts{}, xerrors.Errorf("failed to count memories by source: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	bySource := make(map[types.MemorySource]int)
+	for rows.Next() {
+		var source string
+		var count int
+		if err := rows.Scan(&source, &count); err != nil {
+			return apptypes.MemorySourceCounts{}, xerrors.Errorf("failed to scan memory source count row: %w", err)
+		}
+		parsed, err := types.MemorySourceFrom(source)
+		if err != nil {
+			return apptypes.MemorySourceCounts{}, xerrors.Errorf("failed to parse memory source: %w", err)
+		}
+		bySource[parsed] = count
+	}
+	if err := rows.Err(); err != nil {
+		return apptypes.MemorySourceCounts{}, xerrors.Errorf("failed to iterate memory source count rows: %w", err)
+	}
+	return apptypes.MemorySourceCountsFrom(bySource), nil
 }
 
 // ListStale returns stale memory rows plus the total count before paging.
@@ -909,6 +958,19 @@ func buildMemoryCountByStatusQuery(criteria apptypes.MemoryListCriteria, clock t
 	args = appendMemoryValidityWindowFilter(&builder, args, criteria.AsOf(), criteria.IncludeExpiredByValidity(), clock)
 	args = appendMemoryUpdatedAtFilter(&builder, args, criteria.UpdatedBefore(), criteria.UpdatedAfter())
 	builder.WriteString(" GROUP BY m.status")
+	return builder.String(), args, nil
+}
+
+func buildMemoryCountBySourceQuery(criteria apptypes.MemoryListCriteria, clock types.Clock) (string, []any, error) {
+	var builder strings.Builder
+	builder.WriteString("SELECT m.source, COUNT(*) FROM memories m WHERE 1 = 1")
+	args, err := appendMemoryFilters(&builder, nil, criteria.Scopes(), criteria.Statuses(), criteria.MemoryTypes(), criteria.Sources())
+	if err != nil {
+		return "", nil, err
+	}
+	args = appendMemoryValidityWindowFilter(&builder, args, criteria.AsOf(), criteria.IncludeExpiredByValidity(), clock)
+	args = appendMemoryUpdatedAtFilter(&builder, args, criteria.UpdatedBefore(), criteria.UpdatedAfter())
+	builder.WriteString(" GROUP BY m.source")
 	return builder.String(), args, nil
 }
 

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -708,6 +708,51 @@ func TestMemoryDatasource_CountByStatus(t *testing.T) {
 	}
 }
 
+func TestMemoryDatasource_CountBySourceIgnoresLimit(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	ws := mustWorkspaceScope(t, "github.com/duck8823/traceary")
+	base := time.Date(2026, 4, 12, 8, 0, 0, 0, time.UTC)
+	fixtures := []*model.Memory{
+		memoryOf(t, "ext-1", types.MemoryTypeLesson, ws, "e1", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "ext-2", types.MemoryTypeLesson, ws, "e2", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "hid-1", types.MemoryTypeLesson, ws, "h1", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtractedHidden, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "rem-1", types.MemoryTypePreference, ws, "r1", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceRememberIntent, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "acc-1", types.MemoryTypeDecision, ws, "a1", types.MemoryStatusAccepted, types.ConfidenceHigh, types.MemorySourceManual, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+	}
+	for _, memory := range fixtures {
+		if err := sut.Save(ctx, memory); err != nil {
+			t.Fatalf("Save(%s) error = %v", memory.MemoryID(), err)
+		}
+	}
+	counts, err := sut.CountBySource(ctx, apptypes.NewMemoryListCriteriaBuilder(1).
+		Statuses([]types.MemoryStatus{types.MemoryStatusCandidate}).
+		Build())
+	if err != nil {
+		t.Fatalf("CountBySource() error = %v", err)
+	}
+	if counts.Total() != 4 {
+		t.Fatalf("Total=%d, want 4 candidates (limit must not cap COUNT)", counts.Total())
+	}
+	if counts.Count(types.MemorySourceExtracted) != 2 {
+		t.Fatalf("extracted=%d, want 2", counts.Count(types.MemorySourceExtracted))
+	}
+	if counts.Count(types.MemorySourceExtractedHidden) != 1 {
+		t.Fatalf("hidden=%d, want 1", counts.Count(types.MemorySourceExtractedHidden))
+	}
+	if counts.Count(types.MemorySourceRememberIntent) != 1 {
+		t.Fatalf("remember-intent=%d, want 1", counts.Count(types.MemorySourceRememberIntent))
+	}
+	if counts.Count(types.MemorySourceManual) != 0 {
+		t.Fatal("accepted manual must not be counted as a candidate")
+	}
+}
+
 func TestMemoryDatasource_List_RememberIntentPriorityAppliesBeforePagination(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -307,7 +307,7 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 	if input.asJSON {
 		return nil
 	}
-	return c.writeMemoryInboxListPoolSummary(ctx, output, criteriaBuilder, countSources, len(items))
+	return c.writeMemoryInboxListPoolSummary(ctx, output, criteriaBuilder, countSources, len(items), quality)
 }
 
 func (c *RootCLI) runMemoryInboxShow(ctx context.Context, output io.Writer, input memoryInboxShowCommandInput) error {
@@ -756,6 +756,7 @@ func (c *RootCLI) writeMemoryInboxListPoolSummary(
 	criteriaBuilder *apptypes.MemoryListCriteriaBuilder,
 	countSources []domtypes.MemorySource,
 	shown int,
+	quality memoryInboxQuality,
 ) error {
 	counter, ok := c.memory.(memorySourceCounter)
 	if !ok || criteriaBuilder == nil {
@@ -766,19 +767,22 @@ func (c *RootCLI) writeMemoryInboxListPoolSummary(
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to count memory review queue candidates", "メモリ候補の確認キューの件数取得に失敗しました"), err)
 	}
-	if _, err := fmt.Fprintln(output, formatMemoryInboxPoolSummary(shown, counts)); err != nil {
+	if _, err := fmt.Fprintln(output, formatMemoryInboxPoolSummary(shown, counts, quality)); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory review queue pool summary", "メモリ候補の確認キュー件数行の出力に失敗しました"), err)
 	}
 	return nil
 }
 
-func formatMemoryInboxPoolSummary(shown int, counts apptypes.MemorySourceCounts) string {
-	split := formatMemoryInboxSourceSplit(counts)
+func formatMemoryInboxPoolSummary(shown int, counts apptypes.MemorySourceCounts, quality memoryInboxQuality) string {
+	shownLabel := formatGroupedInt(shown)
+	if quality != memoryInboxQualityAny {
+		shownLabel = fmt.Sprintf("%s (quality=%s)", shownLabel, quality)
+	}
 	return fmt.Sprintf(
 		"showing %s of %s candidates%s — use --offset/--limit, --source to narrow",
-		formatGroupedInt(shown),
+		shownLabel,
 		formatGroupedInt(counts.Total()),
-		split,
+		formatMemoryInboxSourceSplit(counts),
 	)
 }
 

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -254,7 +255,14 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 	// reviewer is not drowned by low-quality auto-extractions. The
 	// rows are still in the store for audit; `--include-hidden`
 	// surfaces them. Explicit `--source` always wins (#810/#830).
-	sources = applyExtractedHiddenDefault(sources, input.includeHidden)
+	listSources := applyExtractedHiddenDefault(sources, input.includeHidden)
+	// Pool-size COUNT includes extracted-hidden unless the operator
+	// named a source. A hidden-only 31k inbox must still be visible
+	// as a total on the default page (#2064).
+	countSources := sources
+	if len(input.sources) == 0 && !input.rememberIntent {
+		countSources = nil
+	}
 
 	// Inbox is always scoped to candidate — that is the point of the view.
 	// Source filters go into the criteria so pagination is consistent: if
@@ -274,7 +282,7 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 		Scopes(scopes).
 		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}).
 		MemoryTypes(memoryTypes).
-		Sources(sources).
+		Sources(listSources).
 		RememberIntentPriority(true)
 	criteriaBuilder = applyMemoryInboxAgeFilters(criteriaBuilder, input.olderThan, input.newerThan, time.Now())
 	criteria := criteriaBuilder.Build()
@@ -293,7 +301,13 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 			items = append(items, details)
 		}
 	}
-	return writeMemoryInboxList(output, items, input.asJSON)
+	if err := writeMemoryInboxList(output, items, input.asJSON); err != nil {
+		return err
+	}
+	if input.asJSON {
+		return nil
+	}
+	return c.writeMemoryInboxListPoolSummary(ctx, output, criteriaBuilder, countSources, len(items))
 }
 
 func (c *RootCLI) runMemoryInboxShow(ctx context.Context, output io.Writer, input memoryInboxShowCommandInput) error {
@@ -727,6 +741,93 @@ func applyExtractedHiddenDefault(sources []domtypes.MemorySource, includeHidden 
 		domtypes.MemorySourceCompactSummary,
 		domtypes.MemorySourceImported,
 	}
+}
+
+// memorySourceCounter is the additive CountBySource capability used by
+// `memory inbox list` to disclose the candidate pool. It is not on
+// MemoryUsecase so existing callers stay unchanged.
+type memorySourceCounter interface {
+	CountBySource(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemorySourceCounts, error)
+}
+
+func (c *RootCLI) writeMemoryInboxListPoolSummary(
+	ctx context.Context,
+	output io.Writer,
+	criteriaBuilder *apptypes.MemoryListCriteriaBuilder,
+	countSources []domtypes.MemorySource,
+	shown int,
+) error {
+	counter, ok := c.memory.(memorySourceCounter)
+	if !ok || criteriaBuilder == nil {
+		return nil
+	}
+	countCriteria := criteriaBuilder.Sources(countSources).Build()
+	counts, err := counter.CountBySource(ctx, countCriteria)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to count memory review queue candidates", "メモリ候補の確認キューの件数取得に失敗しました"), err)
+	}
+	if _, err := fmt.Fprintln(output, formatMemoryInboxPoolSummary(shown, counts)); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory review queue pool summary", "メモリ候補の確認キュー件数行の出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func formatMemoryInboxPoolSummary(shown int, counts apptypes.MemorySourceCounts) string {
+	split := formatMemoryInboxSourceSplit(counts)
+	return fmt.Sprintf(
+		"showing %s of %s candidates%s — use --offset/--limit, --source to narrow",
+		formatGroupedInt(shown),
+		formatGroupedInt(counts.Total()),
+		split,
+	)
+}
+
+func formatMemoryInboxSourceSplit(counts apptypes.MemorySourceCounts) string {
+	type bucket struct {
+		source domtypes.MemorySource
+		label  string
+	}
+	order := []bucket{
+		{domtypes.MemorySourceExtracted, "extracted"},
+		{domtypes.MemorySourceExtractedHidden, "hidden"},
+		{domtypes.MemorySourceRememberIntent, "remember-intent"},
+		{domtypes.MemorySourceCompactSummary, "compact-summary"},
+		{domtypes.MemorySourceImported, "imported"},
+		{domtypes.MemorySourceManual, "manual"},
+	}
+	parts := make([]string, 0, len(order))
+	for _, item := range order {
+		n := counts.Count(item.source)
+		if n <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s %s", formatGroupedInt(n), item.label))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, " / ") + ")"
+}
+
+func formatGroupedInt(n int) string {
+	sign := ""
+	if n < 0 {
+		sign = "-"
+		n = -n
+	}
+	digits := strconv.Itoa(n)
+	first := len(digits) % 3
+	if first == 0 {
+		first = 3
+	}
+	var b strings.Builder
+	b.WriteString(sign)
+	b.WriteString(digits[:first])
+	for i := first; i < len(digits); i += 3 {
+		b.WriteByte(',')
+		b.WriteString(digits[i : i+3])
+	}
+	return b.String()
 }
 
 func writeMemoryInboxList(output io.Writer, items []apptypes.MemoryDetails, asJSON bool) error {

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -466,6 +466,9 @@ func TestMemoryInboxList_AgeAndQualityFilters(t *testing.T) {
 	if _, ok := memoryStub.listCriteria.UpdatedAfter().Value(); !ok {
 		t.Fatalf("--newer-than should set UpdatedAfter in list criteria")
 	}
+	if !strings.Contains(out, "showing 1 (quality=low) of 2 candidates") {
+		t.Fatalf("quality-filtered page must not look like the SQL pool is all low-quality:\n%s", out)
+	}
 }
 
 func TestMemoryInboxCleanup_DryRunDoesNotReject(t *testing.T) {

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -713,6 +713,135 @@ func TestMemoryInboxList_RememberIntentPriorityFlagSetOnCriteria(t *testing.T) {
 	}
 }
 
+func TestMemoryInboxList_PoolSummaryDisclosesHiddenTotal(t *testing.T) {
+	t.Parallel()
+
+	visible := buildInboxCandidateDetails(t, "memory-extracted", "keep CI green", domtypes.MemorySourceExtracted)
+	memoryStub := &memoryUsecaseStub{
+		listResult:      []apptypes.MemorySummary{visible.Summary()},
+		showDetails:     visible,
+		sourceCountsSet: true,
+		sourceCounts: apptypes.MemorySourceCountsFrom(map[domtypes.MemorySource]int{
+			domtypes.MemorySourceExtracted:       24962,
+			domtypes.MemorySourceExtractedHidden: 5827,
+			domtypes.MemorySourceRememberIntent:  519,
+		}),
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "list", "--db-path", t.TempDir() + "/t.db", "--limit", "1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	want := "showing 1 of 31,308 candidates (24,962 extracted / 5,827 hidden / 519 remember-intent) — use --offset/--limit, --source to narrow"
+	if !strings.Contains(stdout.String(), want) {
+		t.Fatalf("pool summary missing:\n%s", stdout.String())
+	}
+	if got := memoryStub.countBySourceCriteria.Sources(); len(got) != 0 {
+		t.Fatalf("default COUNT must include hidden (empty Sources), got %v", got)
+	}
+	if got := memoryStub.listCriteria.Sources(); len(got) == 0 {
+		t.Fatal("default list must still exclude extracted-hidden")
+	}
+}
+
+func TestMemoryInboxList_EmptyVisiblePageStillSummarizesPool(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{
+		sourceCountsSet: true,
+		sourceCounts: apptypes.MemorySourceCountsFrom(map[domtypes.MemorySource]int{
+			domtypes.MemorySourceExtractedHidden: 5827,
+		}),
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "list", "--db-path", t.TempDir() + "/t.db"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "showing 0 of 5,827 candidates (5,827 hidden) — use --offset/--limit, --source to narrow") {
+		t.Fatalf("hidden-only pool must still print a summary:\n%s", out)
+	}
+}
+
+func TestMemoryInboxList_JSONLeavesArrayUntouched(t *testing.T) {
+	t.Parallel()
+
+	imported := buildInboxCandidateDetails(t, "memory-json", "from host", domtypes.MemorySourceImported)
+	memoryStub := &memoryUsecaseStub{
+		listResult:      []apptypes.MemorySummary{imported.Summary()},
+		showDetails:     imported,
+		sourceCountsSet: true,
+		sourceCounts: apptypes.MemorySourceCountsFrom(map[domtypes.MemorySource]int{
+			domtypes.MemorySourceImported: 99,
+		}),
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "list", "--db-path", t.TempDir() + "/t.db", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &items); err != nil {
+		t.Fatalf("JSON must stay a top-level array: %v (body=%s)", err, stdout.String())
+	}
+	if len(items) != 1 {
+		t.Fatalf("JSON items = %d, want 1", len(items))
+	}
+	if strings.Contains(stdout.String(), "showing ") || strings.Contains(stdout.String(), "\"total\"") {
+		t.Fatalf("JSON must not grow a totals envelope:\n%s", stdout.String())
+	}
+}
+
+func TestMemoryInboxList_ExplicitSourceNarrowsCount(t *testing.T) {
+	t.Parallel()
+
+	imported := buildInboxCandidateDetails(t, "memory-imported", "from host", domtypes.MemorySourceImported)
+	memoryStub := &memoryUsecaseStub{
+		listResult:  []apptypes.MemorySummary{imported.Summary()},
+		showDetails: imported,
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "list", "--db-path", t.TempDir() + "/t.db", "--source", "imported"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := memoryStub.countBySourceCriteria.Sources()
+	if len(got) != 1 || got[0] != domtypes.MemorySourceImported {
+		t.Fatalf("explicit --source must pin COUNT sources, got %v", got)
+	}
+}
+
 func TestMemoryInboxAccept_BatchIDs(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -576,12 +576,16 @@ type memoryUsecaseStub struct {
 		evidenceRefs []types.EvidenceRef
 		artifactRefs []types.ArtifactRef
 	}
-	listCriteria   apptypes.MemoryListCriteria
-	staleCriteria  apptypes.StaleMemoryListCriteria
-	staleCalls     int
-	searchCriteria apptypes.MemorySearchCriteria
-	showMemoryID   types.MemoryID
-	acceptCall     struct {
+	listCriteria          apptypes.MemoryListCriteria
+	sourceCounts          apptypes.MemorySourceCounts
+	sourceCountsSet       bool
+	sourceCountErr        error
+	countBySourceCriteria apptypes.MemoryListCriteria
+	staleCriteria         apptypes.StaleMemoryListCriteria
+	staleCalls            int
+	searchCriteria        apptypes.MemorySearchCriteria
+	showMemoryID          types.MemoryID
+	acceptCall            struct {
 		memoryID   types.MemoryID
 		confidence types.Optional[types.Confidence]
 	}
@@ -696,6 +700,21 @@ func (s *memoryUsecaseStub) SetValidity(_ context.Context, memoryID types.Memory
 func (s *memoryUsecaseStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
 	s.listCriteria = criteria
 	return s.listResult, s.listErr
+}
+
+func (s *memoryUsecaseStub) CountBySource(_ context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemorySourceCounts, error) {
+	s.countBySourceCriteria = criteria
+	if s.sourceCountErr != nil {
+		return apptypes.MemorySourceCounts{}, s.sourceCountErr
+	}
+	if s.sourceCountsSet {
+		return s.sourceCounts, nil
+	}
+	bySource := make(map[types.MemorySource]int)
+	for _, item := range s.listResult {
+		bySource[item.Source()]++
+	}
+	return apptypes.MemorySourceCountsFrom(bySource), nil
 }
 
 func (s *memoryUsecaseStub) ListStale(_ context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {


### PR DESCRIPTION
## Summary
`memory inbox list` printed a `--limit` page with no pool size, so a 31k inbox looked like 20 rows. Text mode now prints an additive `showing N of M candidates (source split)` line after the page (and on an empty visible page). The count includes `extracted-hidden` unless `--source` is set. JSON stays the existing top-level item array.

## Test
- `go test ./presentation/cli/ ./application/types/ ./application/usecase/ ./infrastructure/sqlite/`
- `go tool golangci-lint run` on the touched packages

Closes #2064
Leaves parent #2049 open