### PR TITLE
docs: pin grok-plugin update checkout to running CLI version

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -18,6 +18,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 - **`traceary sessions` を削除 (#2061)** — `--snapshot` / `--snapshot --json` を含む。呼び出しは unknown command（非ゼロ、`DEPRECATED` なし）。`list` / `search` / `context` / `report` / `session handoff` を使います。hook の workspace 正規化向け List は残します。
 - **`traceary session latest` と `traceary session list` を削除 (#2057)** — どちらも unknown subcommand（非ゼロ、`DEPRECATED` なし）。hook の `[Traceary] Session <id>`、`list` / `search` / `context`、`report` を使います。handoff / hooks / context 向けの内部 Active/Latest/List クエリは残します。
 
+### Docs
+- Grok plugin の Update checkout を実行中の CLI バージョン（`traceary -v`）に合わせる。install clone と同じピン (#2065)。
+
 ## [v0.41.0] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 - **`traceary sessions` (#2061)** — including `--snapshot` / `--snapshot --json`. Invocations fail as an unknown command (non-zero, no `DEPRECATED` notice). Use `list` / `search` / `context` / `report` / `session handoff`. Internal session List stays for hook workspace canonicalization.
 - **`traceary session latest` and `traceary session list` (#2057)** — both fail as unknown subcommands (non-zero, no `DEPRECATED` notice). Use hook `[Traceary] Session <id>`, `list` / `search` / `context`, and `report`. Internal Active/Latest/List queries stay for handoff, hooks, and context.
 
+### Docs
+- Grok plugin Update checkout follows the running CLI version (`traceary -v`), matching the install clone pin (#2065).
+
 ## [v0.41.0] - 2026-08-17
 
 ### Added

--- a/docs/integrations/grok-plugin.ja.md
+++ b/docs/integrations/grok-plugin.ja.md
@@ -172,7 +172,7 @@ tag を取得して installer を再実行します。
 ```sh
 brew upgrade traceary
 git fetch --tags
-git checkout v0.23.0 # 導入済みTracearyのバージョンに置き換える
+git checkout "v$(traceary -v | awk '{print $2}')"
 ./scripts/install-grok-plugin.sh
 traceary doctor --client grok --project-dir . --json
 ```

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -181,7 +181,7 @@ CLI, check out the matching tag and rerun the installer:
 ```sh
 brew upgrade traceary
 git fetch --tags
-git checkout v0.23.0 # replace with the installed Traceary version
+git checkout "v$(traceary -v | awk '{print $2}')"
 ./scripts/install-grok-plugin.sh
 traceary doctor --client grok --project-dir . --json
 ```


### PR DESCRIPTION
## Summary
Grok plugin Update sections still pasted git checkout v0.23.0. Both language files now use the same dynamic tag as the install clone: v$(traceary -v). Historical v0.23.0 narrative is unchanged.

Closes #2065
Leaves parent #2049 open