### PR TITLE
feat: absorb timeline into list --blocks and remove timeline

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -15,6 +15,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 - **parked な search-projection が毎コマンド WARN しない (#2058)** — skip WARN は store あたり 24 時間に 1 回。`doctor` と `store search-projection status` は毎回 parked 理由を出す。復旧文言は `start` のあと `resume --until-complete`。
 
 ### Removed
+- **`traceary timeline` を削除 (#2069)** — 呼び出しは unknown command（非ゼロ、`DEPRECATED` なし）。`traceary list --blocks` を使う（同じギャップ検出ブロック・scan-cap 開示・`workspace_breakdown` JSON）。`--gap` は `list` に移した。
 - **`traceary tail` を削除 (#2068)** — 呼び出しは unknown command（非ゼロ、`DEPRECATED` なし）。`traceary list --follow` を使う（同じストリーム・フィルタ・描画）。`--follow-session` は `list` に移した。
 - **`traceary sessions` を削除 (#2061)** — `--snapshot` / `--snapshot --json` を含む。呼び出しは unknown command（非ゼロ、`DEPRECATED` なし）。`list` / `search` / `context` / `report` / `session handoff` を使います。hook の workspace 正規化向け List は残します。
 - **`traceary session latest` と `traceary session list` を削除 (#2057)** — どちらも unknown subcommand（非ゼロ、`DEPRECATED` なし）。hook の `[Traceary] Session <id>`、`list` / `search` / `context`、`report` を使います。handoff / hooks / context 向けの内部 Active/Latest/List クエリは残します。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 - **Parked search-projection catch-up no longer warns on every command (#2058)** — the skip WARN is rate-limited to once per 24h per store. `doctor` and `store search-projection status` still always show the parked reason. Recovery text names `start` then `resume --until-complete`.
 
 ### Removed
+- **`traceary timeline` (#2069)** — invocations fail as an unknown command (non-zero, no `DEPRECATED` notice). Use `traceary list --blocks` (same gap-detected blocks, scan-cap disclosure, and `workspace_breakdown` JSON). `--gap` moved onto `list`.
 - **`traceary tail` (#2068)** — invocations fail as an unknown command (non-zero, no `DEPRECATED` notice). Use `traceary list --follow` (same stream, filters, and rendering). `--follow-session` moved onto `list`.
 - **`traceary sessions` (#2061)** — including `--snapshot` / `--snapshot --json`. Invocations fail as an unknown command (non-zero, no `DEPRECATED` notice). Use `list` / `search` / `context` / `report` / `session handoff`. Internal session List stays for hook workspace canonicalization.
 - **`traceary session latest` and `traceary session list` (#2057)** — both fail as unknown subcommands (non-zero, no `DEPRECATED` notice). Use hook `[Traceary] Session <id>`, `list` / `search` / `context`, and `report`. Internal Active/Latest/List queries stay for handoff, hooks, and context.

--- a/README.ja.md
+++ b/README.ja.md
@@ -169,7 +169,7 @@ Traceary は補完的なビューを用意していて、「いま何が起き�
 |---|---|---|
 | command surface を確認する | `traceary` / `traceary --help` | help を表示（TTY / 非 TTY とも） |
 | いま動いているものを追う | `traceary list --follow` | hook が発火しているか / 失敗がリアルタイムで見えているかを確認 |
-| ある期間の流れを俯瞰する | `traceary timeline` | アイドルギャップ区切りの作業ブロックを workspace 別のアクティビティ要約付きで表示 |
+| ある期間の流れを俯瞰する | `traceary list --blocks` | アイドルギャップ区切りの作業ブロックを workspace 別のアクティビティ要約付きで表示 |
 | 生 event を直接掘る | `traceary list` / `traceary search` | kind / session / query をピンポイントで指定 |
 | 引き継ぎコンテキストで再開する | `traceary session handoff` | 整形済みの working memory を次のセッションへ |
 
@@ -184,10 +184,10 @@ $ traceary list --follow --limit 3
 
 デフォルトは 1 行コンパクト形式（現地時刻）で約 100 カラムに収まります。`--wide --utc` で v0.6.1 以前の tab 区切り 7 カラムをバイト単位で再現でき、`--json` を使えば NDJSON でパイプに流せます。
 
-### `traceary timeline`
+### `traceary list --blocks`
 
 ```text
-$ traceary timeline --limit 2
+$ traceary list --blocks --limit 2
 2026-04-15 06:37 - 07:06 (29m21s) total events: 165
   github.com/duck8823/traceary (153) — 自律的に進めてください。
   github.com/duck8823/dotfiles  ( 12) — rust インストールしました

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Traceary ships complementary inspection views so you can switch between "what's 
 |---|---|---|
 | Discovering the command surface | `traceary` / `traceary --help` | print help (TTY and non-TTY) |
 | Following what is happening now | `traceary list --follow` | confirm hooks are firing, watch failures in real time |
-| Understanding what happened across a span | `traceary timeline` | see gap-separated work blocks with a per-workspace activity summary |
+| Understanding what happened across a span | `traceary list --blocks` | see gap-separated work blocks with a per-workspace activity summary |
 | Inspecting raw events directly | `traceary list` / `traceary search` | jump to an exact kind / session / query |
 | Resuming with assembled working memory | `traceary session handoff` | start a follow-up session with curated context |
 
@@ -187,10 +187,10 @@ $ traceary list --follow --limit 3
 
 Compact single-line rows (local time by default) fit inside ~100 columns. Add `--wide --utc` to restore the pre-v0.6.1 tab-separated seven-column layout byte-for-byte, or `--json` for NDJSON when piping into tooling.
 
-### `traceary timeline`
+### `traceary list --blocks`
 
 ```text
-$ traceary timeline --limit 2
+$ traceary list --blocks --limit 2
 2026-04-15 06:37 - 07:06 (29m21s) total events: 165
   github.com/duck8823/traceary (153) — 自律的に進めてください。
   github.com/duck8823/dotfiles  ( 12) — rust インストールしました

--- a/docs/cli-stability.ja.md
+++ b/docs/cli-stability.ja.md
@@ -34,7 +34,7 @@ Traceary の各サブコマンドは必ず以下のいずれか 1 ティアに�
 v0.15 以降に追加された互換 alias も含む現在の公開コマンド（用途別）。可視の public / admin leaf の出荷分類は `presentation/cli/pillar_inventory.go`（#1692）です。
 
 - **イベント記録** — `traceary log`、`traceary audit`
-- **読み取り / 観察** — `traceary list`（`--follow` を含む）、`traceary search`、`traceary timeline`、`traceary show`、`traceary context`
+- **読み取り / 観察** — `traceary list`（`--follow` と `--blocks` を含む）、`traceary search`、`traceary show`、`traceary context`
 - **セッション** — `traceary session start`、`traceary session end`、`traceary session run`、`traceary session handoff`（`--compact-only` を含む）、`traceary session refine`
 - **durable memory 日常 read** — `traceary memory list`、`traceary memory search`、`traceary memory show`
 - **durable memory inbox** — `traceary memory inbox list`、`traceary memory inbox show`、`traceary memory inbox accept`、`traceary memory inbox reject`、`traceary memory inbox attach`、`traceary memory inbox cleanup`、`traceary memory inbox restore`、`traceary memory inbox review`（TTY のみ）
@@ -45,7 +45,7 @@ v0.15 以降に追加された互換 alias も含む現在の公開コマンド�
 - **replay / archive** — `traceary replay`
 - **bundle import / export** — `traceary bundle export`、`traceary bundle import`
 
-`traceary doctor` の JSON envelope（`sections` / `summary` / `exit_code` / 各 check のフィールド）、`traceary timeline --json`（`workspace_breakdown`）、`traceary session handoff` の構造化テキストのフィールドラベルはいずれも公開契約の一部です。これらは `presentation/cli/testdata/` で golden test により固定されています。詳細は [JSON / snapshot contract test](./operations/json-contract-tests.ja.md) を参照してください。
+`traceary doctor` の JSON envelope（`sections` / `summary` / `exit_code` / 各 check のフィールド）、`traceary list --blocks --json`（`workspace_breakdown`。旧 `traceary timeline --json`）、`traceary session handoff` の構造化テキストのフィールドラベルはいずれも公開契約の一部です。これらは `presentation/cli/testdata/` で golden test により固定されています。詳細は [JSON / snapshot contract test](./operations/json-contract-tests.ja.md) を参照してください。
 
 `traceary doctor` は既定で、全 check が pass なら exit code `0`、1 件でも fail があれば `1`、warning-only report なら `2` で終了します。warning を operator-visible な drift として見たいが、壊れた install だけを失敗扱いにしたい automation では `--warnings-ok` を指定してください。この場合 warning-only report は `0`、failure は引き続き `1` で終了し、JSON の `summary` と各 check の severity は変わりません。
 
@@ -89,10 +89,11 @@ v0.35 時点の admin コマンド：
 
 #1692 は可視の public / admin leaf を 2 本の柱（記録 = 捕捉 / 要約 / 圧縮 / 破棄、記憶 = 統合して自動供給）に突き合わせました。hidden な hook 入口は plumbing のままです（後述）。出荷テーブルは `presentation/cli/pillar_inventory.go` で、可視 action を行なしで追加するとテストが失敗します。
 
-削除根拠は空の backing、重複、柱なしだけです。usage 件数は理由にしません。#1870 の 97→29 keep-list に残っているグループは v0.34 の非推奨 registry に無いので、v0.35 では削除しません。予定している吸収（`list --blocks`、`hooks install --dry-run`、`memory search --all`）は、その flag ができるまで通知しません。`list --follow` は v0.42.0（#2068）で入りました。`replay` は単一ファイル HTML export だけで、#1870 も usage を弱い削除根拠だと書いています。
+削除根拠は空の backing、重複、柱なしだけです。usage 件数は理由にしません。#1870 の 97→29 keep-list に残っているグループは v0.34 の非推奨 registry に無いので、v0.35 では削除しません。予定している吸収（`hooks install --dry-run`、`memory search --all`）は、その flag ができるまで通知しません。`list --follow` は v0.42.0（#2068）で入りました。`list --blocks` は v0.42.0（#2069）で入りました。`replay` は単一ファイル HTML export だけで、#1870 も usage を弱い削除根拠だと書いています。
 
 過去の削除履歴：
 
+- v0.42.0 で削除（#2069）: `traceary timeline`。呼び出しは unknown command として非ゼロ終了し、`DEPRECATED` 通知は出しません。one-minor deprecation window の明示的なポリシー例外です（owner 決定 2026-08-17）。代わりに `traceary list --blocks` を使います（同じギャップ検出ブロック、#2033 scan-cap 開示、`workspace_breakdown` JSON。`--gap` は `list` に移しました）。
 - v0.42.0 で削除（#2068）: `traceary tail`。呼び出しは unknown command として非ゼロ終了し、`DEPRECATED` 通知は出しません。one-minor deprecation window の明示的なポリシー例外です（owner 決定 2026-08-17）。代わりに `traceary list --follow` を使います（同じストリーム・フィルタ・描画。`--follow-session` は `list` に移しました）。
 - v0.42.0 で削除（#2061）: `traceary sessions`（`--snapshot` / `--snapshot --json` を含む）。呼び出しは unknown command として非ゼロ終了し、`DEPRECATED` 通知は出しません。one-minor deprecation window の明示的なポリシー例外です（owner 決定 2026-08-17）。代わりに `list` / `search` / `context` / `report` / `session handoff` を使います。hook の workspace 正規化向け `Session.List` と `list_sessions.sql` は残します。
 - v0.42.0 で削除（#2057）: `traceary session latest`（`--active` を含む）と `traceary session list`。呼び出しは unknown subcommand として非ゼロ終了し、`DEPRECATED` 通知は出しません。one-minor deprecation window の明示的なポリシー例外です（owner 決定 2026-08-17）。open session の ID は hook メッセージ（`[Traceary] Session <id>`）で渡り、直近の作業は `list` / `search` / `context`、期間サマリーは `report` です。内部の `Active` / `Latest` / `List` クエリは handoff / hooks / context / memory extract のために残します。

--- a/docs/cli-stability.md
+++ b/docs/cli-stability.md
@@ -34,7 +34,7 @@ The public surface is the operator-facing daily-use surface. Public commands kee
 Current public commands, including compatibility aliases introduced after v0.15, are grouped by intent. The shipped classification of every visible public/admin leaf is `presentation/cli/pillar_inventory.go` (#1692).
 
 - **Event recording** — `traceary log`, `traceary audit`
-- **Read / inspection** — `traceary list` (including `--follow`), `traceary search`, `traceary timeline`, `traceary show`, `traceary context`
+- **Read / inspection** — `traceary list` (including `--follow` and `--blocks`), `traceary search`, `traceary show`, `traceary context`
 - **Sessions** — `traceary session start`, `traceary session end`, `traceary session run`, `traceary session handoff` (including `--compact-only`), `traceary session refine`
 - **Durable memory daily read** — `traceary memory list`, `traceary memory search`, `traceary memory show`
 - **Durable memory inbox** — `traceary memory inbox list`, `traceary memory inbox show`, `traceary memory inbox accept`, `traceary memory inbox reject`, `traceary memory inbox attach`, `traceary memory inbox cleanup`, `traceary memory inbox restore`, `traceary memory inbox review` (TTY-only)
@@ -45,7 +45,7 @@ Current public commands, including compatibility aliases introduced after v0.15,
 - **Replay / archive** — `traceary replay`
 - **Bundle import / export** — `traceary bundle export`, `traceary bundle import`
 
-The `traceary doctor` JSON envelope (`sections` / `summary` / `exit_code` / per-check fields), `traceary timeline --json` (`workspace_breakdown`), and the structured-text `traceary session handoff` field labels are all part of the public contract. They are golden-tested under `presentation/cli/testdata/` — see [JSON and snapshot contract tests](./operations/json-contract-tests.md) for the contract test workflow.
+The `traceary doctor` JSON envelope (`sections` / `summary` / `exit_code` / per-check fields), `traceary list --blocks --json` (`workspace_breakdown`; formerly `traceary timeline --json`), and the structured-text `traceary session handoff` field labels are all part of the public contract. They are golden-tested under `presentation/cli/testdata/` — see [JSON and snapshot contract tests](./operations/json-contract-tests.md) for the contract test workflow.
 
 `traceary doctor` defaults to exit code `0` for all-pass reports, `1` when any check fails, and `2` for warning-only reports. Automation that treats warnings as operator-visible drift but not a broken install should pass `--warnings-ok`; in that mode warning-only reports exit `0`, failures still exit `1`, and the JSON `summary` / per-check severities remain unchanged.
 
@@ -89,10 +89,11 @@ Currently deprecated:
 
 #1692 walked every visible public/admin leaf against the two pillars (記録 = capture / summarise / compress / evict; 記憶 = consolidate and supply automatically). Hidden hook entrypoints stay plumbing (see below). The shipped table is `presentation/cli/pillar_inventory.go`; a test fails if a visible action is added without a row.
 
-A command is removed only for empty backing data, duplication, or serving no pillar. Usage counts are not grounds. Remaining groups from the #1870 97→29 keep-list were never in the v0.34 deprecation registry, so v0.35 does not delete them. Planned absorbs (`list --blocks`, `hooks install --dry-run`, `memory search --all`) are not noticed until those flags exist. `list --follow` landed in v0.42.0 (#2068). `replay` stays: it is the only single-file HTML export, and #1870 called usage a weak removal basis.
+A command is removed only for empty backing data, duplication, or serving no pillar. Usage counts are not grounds. Remaining groups from the #1870 97→29 keep-list were never in the v0.34 deprecation registry, so v0.35 does not delete them. Planned absorbs (`hooks install --dry-run`, `memory search --all`) are not noticed until those flags exist. `list --follow` landed in v0.42.0 (#2068). `list --blocks` landed in v0.42.0 (#2069). `replay` stays: it is the only single-file HTML export, and #1870 called usage a weak removal basis.
 
 Historical removal log:
 
+- Removed in v0.42.0 (#2069): `traceary timeline`. Invocations fail as an unknown command with a non-zero exit and no `DEPRECATED` notice. This is an explicit policy exception to the one-minor deprecation window (owner decision 2026-08-17). Use `traceary list --blocks` (same gap-detected blocks, #2033 scan-cap disclosure, and `workspace_breakdown` JSON; `--gap` moved onto `list`).
 - Removed in v0.42.0 (#2068): `traceary tail`. Invocations fail as an unknown command with a non-zero exit and no `DEPRECATED` notice. This is an explicit policy exception to the one-minor deprecation window (owner decision 2026-08-17). Use `traceary list --follow` (same stream, filters, and rendering; `--follow-session` moved onto `list`).
 - Removed in v0.42.0 (#2061): `traceary sessions` (including `--snapshot` / `--snapshot --json`). Invocations fail as an unknown command with a non-zero exit and no `DEPRECATED` notice. This is an explicit policy exception to the one-minor deprecation window (owner decision 2026-08-17). Use `list` / `search` / `context` / `report` / `session handoff`. Internal `Session.List` remains for hook workspace canonicalization; `list_sessions.sql` is kept for that caller.
 - Removed in v0.42.0 (#2057): `traceary session latest` (including `--active`) and `traceary session list`. Invocations fail as unknown subcommands with a non-zero exit and no `DEPRECATED` notice. This is an explicit policy exception to the one-minor deprecation window (owner decision 2026-08-17). Open-session identity is delivered in hook messages (`[Traceary] Session <id>`); recent work is read with `list` / `search` / `context`; period summaries use `report`. Internal `Active` / `Latest` / `List` queries remain for handoff, hooks, context, and memory extract.

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -116,6 +116,8 @@ subcommand なしの `traceary` は TTY / 非 TTY とも常に help を表示し
 - `--failures` — この 記録 フィルタは残す。`command_audits.failed = 1` または取得済みの非ゼロ `exit_code` に一致する。現行の書き込みは構造化された host のツール失敗を `unknown` ではなく `host_error` として保存する。分類器以前の `unknown`+`failed=1` はフラグ側で一致する。意味は [failed-flag の意味](../research/failed-flag-meaning.ja.md) を見てください。
 - `--follow` — 新しい一致イベントを追跡表示する（旧 `traceary tail`）。`--limit 0` は新規のみ。`--json` はスナップショット配列ではなく NDJSON。`--offset`、`--from`/`--since`/`--to`/`--until`、`--sensitive`、`--source-hook` とは同時に使えない。
 - `--follow-session <prefix>` — `--follow` 時に 1 つの session へ先頭一致（最低 8 文字）。
+- `--blocks` — ギャップ検出した作業ブロックを表示する（旧 `traceary timeline`）。`--limit` はブロック数上限。`--json` は `workspace_breakdown` 付きブロック配列で、スナップショットの event 配列ではない。`--follow`、`--offset`、イベントフィルタ（`--kind` / `--client` / `--agent` / `--session-id` / `--failures` / `--sensitive` / `--source-hook`）、`--wide` / `--fields` / `--preset` / `--color`、`--timezone` とは同時に使えない。
+- `--gap` — `--blocks` 時のアイドル判定閾値（分、既定 15）。
 
 ### `traceary search [<query>]`
 
@@ -152,22 +154,6 @@ complete な世代はスナップショットなので、その後に記録さ�
 - `--preset`
 - `--color`
 
-### `traceary timeline`
-
-ギャップ検出による作業タイムラインを、ワークスペース単位のアクティビティ要約付きで表示します。
-
-`timeline` は直近のイベントをアイドルギャップ（デフォルト 15 分）で区切って連続する作業ブロックに分け、各ブロック内で workspace ごとに整列された 1 行を表示します。ワークスペース単位のアクティビティ要約は **`compact_summary` → 最初の `prompt` → kind counts** のフォールバック順で選ばれ、そのブロック内でそのワークスペースに存在するシグナルが 1 行に展開されます。デフォルトのテキスト出力は現地時刻 (local time) で、`--utc` で UTC に切り替えられます。`--json` は UTC RFC3339Nano の `start` / `end`、数値の `duration_sec`、および `workspace_breakdown` 配列 (`{workspace, event_count, kind_counts, agents, summary, summary_source}`) を出力します。
-
-主な flag:
-
-- `--workspace`
-- `--from`
-- `--to`
-- `--gap` (アイドルギャップ閾値/分)
-- `--limit`
-- `--json`
-- `--utc`
-
 ### `traceary replay`
 
 最近のセッション・イベント・durable memory を single-file HTML で書き出します。外部スクリプト・フォント・CDN に依存しない自己完結ファイルなので、オフラインでも閲覧可能です。インシデントレビュー・週次 retrospective・CLI を持たないチームメンバーへの共有に使います。
@@ -181,7 +167,7 @@ complete な世代はスナップショットなので、その後に記録さ�
 - `--timeline-blocks` (既定 20) — timeline パネルに描画するブロック数。0 以下でパネル自体を省く
 - `--hotspots` (既定 10) — failure hotspot パネルに描画するクラスタ数。0 以下でパネル自体を省く
 
-replay HTML は sessions / timeline blocks / failure hotspots / durable memories の 4 パネル + generated-at footer の構成です。timeline と hotspot パネルは `traceary timeline` / `traceary list --failures-only` と同一意味を持つので、両方の描画を相互参照できます。
+replay HTML は sessions / timeline blocks / failure hotspots / durable memories の 4 パネル + generated-at footer の構成です。timeline と hotspot パネルは `traceary list --blocks` / `traceary list --failures` と同一意味を持つので、両方の描画を相互参照できます。
 
 例: `traceary replay --out /tmp/replay.html`
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -116,6 +116,8 @@ Useful flags:
 - `--failures` — keep this 記録 filter. It matches `command_audits.failed = 1` or a captured non-zero `exit_code`. Current writes store structured host tool failures as `host_error` (not `unknown`). Pre-classifier `unknown`+`failed=1` rows still match the flag half. See [failed-flag meaning](../research/failed-flag-meaning.md).
 - `--follow` — keep printing new matching events (the former `traceary tail` stream). `--limit 0` prints only new events. `--json` is NDJSON (one event per line), not a snapshot array. Incompatible with `--offset`, `--from`/`--since`/`--to`/`--until`, `--sensitive`, and `--source-hook`.
 - `--follow-session <prefix>` — with `--follow`, prefix-match one session (minimum 8 runes).
+- `--blocks` — print gap-detected work blocks (the former `traceary timeline`). `--limit` is the block cap. `--json` is the block array with `workspace_breakdown`, not the snapshot event array. Incompatible with `--follow`, `--offset`, event filters (`--kind` / `--client` / `--agent` / `--session-id` / `--failures` / `--sensitive` / `--source-hook`), `--wide` / `--fields` / `--preset` / `--color`, and `--timezone`.
+- `--gap` — with `--blocks`, idle gap threshold in minutes (default 15).
 
 ### `traceary search [<query>]`
 
@@ -152,22 +154,6 @@ Useful flags:
 - `--preset`
 - `--color`
 
-### `traceary timeline`
-
-Show work timeline with gap-based block detection and per-workspace activity summaries.
-
-`timeline` groups recent events into contiguous work blocks separated by idle gaps (default: 15 minutes) and prints one aligned sub-row per workspace inside each block. The per-workspace activity summary is picked using the fallback chain **`compact_summary` → first `prompt` → kind counts**, so whichever signal exists for that workspace in the block lights up the line. Default text output uses local time; pass `--utc` for UTC. `--json` emits UTC RFC3339Nano `start` / `end` timestamps, numeric `duration_sec`, and a `workspace_breakdown` array (`{workspace, event_count, kind_counts, agents, summary, summary_source}`).
-
-Useful flags:
-
-- `--workspace`
-- `--from`
-- `--to`
-- `--gap` (idle gap threshold in minutes)
-- `--limit`
-- `--json`
-- `--utc`
-
 ### `traceary replay`
 
 Export a single-file HTML replay of recent sessions, events, and durable memories. The output is one self-contained `.html` — no external scripts, no fonts, no CDN — so it opens on an air-gapped laptop. Intended for incident reviews, weekly retrospectives, and sharing Traceary session history with teammates who don't run the CLI.
@@ -181,7 +167,7 @@ Useful flags:
 - `--timeline-blocks` (default 20) — timeline blocks rendered in the timeline panel; `<= 0` skips the panel
 - `--hotspots` (default 10) — failure-hotspot clusters rendered in the hotspot panel; `<= 0` skips the panel
 
-The replay HTML contains four panels (sessions, timeline blocks, failure hotspots, durable memories) plus a generated-at footer. The timeline and hotspot panels share the semantics of `traceary timeline` and `traceary list --failures-only` so operators can cross-reference either rendering.
+The replay HTML contains four panels (sessions, timeline blocks, failure hotspots, durable memories) plus a generated-at footer. The timeline and hotspot panels share the semantics of `traceary list --blocks` and `traceary list --failures` so operators can cross-reference either rendering.
 
 Example: `traceary replay --out /tmp/replay.html`
 

--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -150,7 +150,7 @@ payload の `prompt` フィールドをそのまま記録し、redaction は適�
 
 Claude client に限り、`hooks install` / `hooks print` で `--matcher <preset>` が使えます。`PostToolUse` / `PostToolUseFailure` の対象を切り替えます。
 
-- `minimal` — `Bash` + `mcp__.*` のみ。v0.8-6 以前の Traceary と同じセットです。built-in tool の監査が `list --follow` / `timeline` のノイズになり過ぎるときに選びます。
+- `minimal` — `Bash` + `mcp__.*` のみ。v0.8-6 以前の Traceary と同じセットです。built-in tool の監査が `list --follow` / `list --blocks` のノイズになり過ぎるときに選びます。
 - `default`（`--matcher` を省略したとき） — v0.8-6b で導入した built-in tool 列 (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`) を含みます。配布 plugin も同じセットです。
 - `all` — built-in 列の代わりに `.*` を適用し、すべての tool を拾います。plugin 独自 tool やプロジェクト固有 tool も含まれるため、明示的にオプトインする用途向けです。
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -150,7 +150,7 @@ Default destinations:
 
 For the Claude client, `hooks install` and `hooks print` accept `--matcher <preset>` to control which tool categories `PostToolUse` / `PostToolUseFailure` watch:
 
-- `minimal` — `Bash` + `mcp__.*` only. Same set Traceary shipped before v0.8-6. Pick this when built-in tool captures generate too much `list --follow` / `timeline` volume for the current project.
+- `minimal` — `Bash` + `mcp__.*` only. Same set Traceary shipped before v0.8-6. Pick this when built-in tool captures generate too much `list --follow` / `list --blocks` volume for the current project.
 - `default` (or omit `--matcher`) — Adds the v0.8-6b built-in tool list (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`). This is what packaged installs use.
 - `all` — Replaces the built-in list with `.*` so every tool kind is captured. Intentional opt-in; this will include plugin- and project-specific tools that the default excludes.
 

--- a/docs/hooks/lifecycle-events.ja.md
+++ b/docs/hooks/lifecycle-events.ja.md
@@ -30,7 +30,7 @@
 
 ### `prompt`
 
-- ユーザの指示を redact 後そのまま記録。`traceary timeline` / `traceary search` / `traceary context` の本体に出る。
+- ユーザの指示を redact 後そのまま記録。`traceary list --blocks` / `traceary search` / `traceary context` の本体に出る。
 - Claude Code (`UserPromptSubmit`), Codex CLI (`UserPromptSubmit`), Gemini CLI (`BeforeAgent`) すべてが発行（[host-coverage.ja.md](./host-coverage.ja.md) 参照）。
 - Body marker なし（生テキスト）。アシスタント側は `transcript` と区別する。
 

--- a/docs/hooks/lifecycle-events.md
+++ b/docs/hooks/lifecycle-events.md
@@ -30,7 +30,7 @@ All event bodies pass through built-in secret redaction plus operator-configured
 
 ### `prompt`
 
-- Captures the user's instruction text verbatim (after redaction). Visible in `traceary timeline`, `traceary search`, and `traceary context`.
+- Captures the user's instruction text verbatim (after redaction). Visible in `traceary list --blocks`, `traceary search`, and `traceary context`.
 - Claude Code (`UserPromptSubmit`), Codex CLI (`UserPromptSubmit`), and Gemini CLI (`BeforeAgent`) all emit this — see [host-coverage.md](./host-coverage.md).
 - Body marker: none (raw text). Distinct from `transcript`, which is the assistant side.
 

--- a/docs/landing/components.jsx
+++ b/docs/landing/components.jsx
@@ -118,11 +118,11 @@ const inspectViews = {
     )
   },
   timeline: {
-    cmd: 'traceary timeline --limit 2',
+    cmd: 'traceary list --blocks --limit 2',
     title: 'gap-separated work blocks',
     body: (
       <>
-        <div className="term-line"><span className="term-prompt">$</span><span className="term-cmd">traceary timeline --limit 2</span></div>
+        <div className="term-line"><span className="term-prompt">$</span><span className="term-cmd">traceary list --blocks --limit 2</span></div>
         <div className="term-out" dangerouslySetInnerHTML={{__html:
           '<span class="ts">2026-04-15 06:37 - 07:06</span> (29m21s) total events: 165\n' +
           '  <span class="ws">github.com/duck8823/traceary</span> (153) — 自律的に進めてください。\n' +
@@ -180,7 +180,7 @@ function InspectSection() {
   const items = [
     { id: 'list', cmd: 'traceary list', desc: 'Scan recent events with workspace, session, and kind filters' },
     { id: 'tail', cmd: 'traceary list --follow', desc: 'Confirm hooks are firing, watch failures in real time' },
-    { id: 'timeline', cmd: 'traceary timeline', desc: 'See gap-separated work blocks with per-workspace summaries' },
+    { id: 'timeline', cmd: 'traceary list --blocks', desc: 'See gap-separated work blocks with per-workspace summaries' },
     { id: 'search', cmd: 'traceary search', desc: 'Jump to an exact kind, session, or query' },
     { id: 'handoff', cmd: 'traceary session handoff', desc: 'Resume with curated working memory' },
   ];

--- a/presentation/cli/deprecation_cli_test.go
+++ b/presentation/cli/deprecation_cli_test.go
@@ -138,6 +138,42 @@ func TestRootCLI_TailIsUnknownCommand(t *testing.T) {
 	}
 }
 
+func TestRootCLI_TimelineIsUnknownCommand(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "bare timeline", args: []string{"timeline"}},
+		{name: "timeline json", args: []string{"timeline", "--json"}},
+		{name: "timeline help", args: []string{"timeline", "--help"}},
+		{name: "timeline workspace", args: []string{"timeline", "--workspace", "ws"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			root := cli.NewRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithEvent(&eventUsecaseStub{}),
+			).Command()
+			root.SetOut(stdout)
+			root.SetErr(stderr)
+			root.SetArgs(tt.args)
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("Execute(%v) error = nil, want unknown-command error", tt.args)
+			}
+			if !strings.Contains(err.Error(), `unknown command "timeline"`) {
+				t.Fatalf("Execute(%v) error = %q, want unknown command \"timeline\"", tt.args, err.Error())
+			}
+			if strings.Contains(stderr.String(), "DEPRECATED:") || strings.Contains(stdout.String(), "DEPRECATED:") {
+				t.Errorf("unexpected deprecation notice:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
 func TestRootCLI_SessionsIsUnknownCommand(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
 	tests := []struct {

--- a/presentation/cli/golden_test.go
+++ b/presentation/cli/golden_test.go
@@ -518,7 +518,7 @@ func TestTimeline_JSON_Golden(t *testing.T) {
 	).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
-	rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test-traceary.db", "--json"})
+	rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test-traceary.db", "--json"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -149,6 +149,10 @@ type listCommandInput struct {
 	follow           bool
 	followSession    string
 	followSessionSet bool
+	timezoneSet      bool
+	blocks           bool
+	gap              int
+	gapSet           bool
 }
 
 // logCommandInput is the resolved input to the `traceary log` command.
@@ -214,7 +218,8 @@ type sessionBoundaryCommandInput struct {
 	asJSON          bool
 }
 
-// timelineCommandInput is the resolved input to the `traceary timeline` command.
+// timelineCommandInput is the resolved input to `traceary list --blocks`
+// (the former `traceary timeline` work-block view).
 type timelineCommandInput struct {
 	dbPath    string
 	workspace string

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -42,6 +42,8 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 		color         string
 		follow        bool
 		followSession string
+		blocks        bool
+		gap           int
 	)
 
 	listCmd := &cobra.Command{
@@ -85,11 +87,15 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 				follow:           follow,
 				followSession:    followSession,
 				followSessionSet: cmd.Flags().Changed("follow-session"),
+				timezoneSet:      cmd.Flags().Changed("timezone"),
+				blocks:           blocks,
+				gap:              gap,
+				gapSet:           cmd.Flags().Changed("gap"),
 			})
 		},
 	}
 	listCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
-	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("number of events to display; with --follow, 0 prints only new events", "表示件数。--follow 時は 0 で新規イベントのみ"))
+	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("number of events to display; with --follow, 0 prints only new events; with --blocks, maximum blocks", "表示件数。--follow 時は 0 で新規イベントのみ。--blocks 時はブロック数上限"))
 	listCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of events to skip before listing", "一覧表示前にスキップする件数"))
 	listCmd.Flags().BoolVar(&sensitiveOnly, "sensitive", false, Localize("list only command audits that match sensitive-path patterns (compute-on-read; not redaction)", "sensitive-path パターンに一致した command audit のみ一覧する（compute-on-read。redaction とは別）"))
 	listCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)"))
@@ -115,6 +121,8 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 		"with --follow, tail events only from the given session id (prefix match, minimum 8 runes)",
 		"--follow 時に指定した session id のイベントだけを追跡する (先頭一致、最低 8 文字)",
 	))
+	listCmd.Flags().BoolVar(&blocks, "blocks", false, Localize("print gap-detected work blocks instead of event rows", "イベント行の代わりにギャップ検出した作業ブロックを表示する"))
+	listCmd.Flags().IntVar(&gap, "gap", defaultGapMinutes, Localize("with --blocks, idle gap threshold in minutes", "--blocks 時のアイドル判定閾値（分）"))
 
 	return listCmd
 }
@@ -166,7 +174,77 @@ func (c *RootCLI) runListFollow(ctx context.Context, warnWriter io.Writer, outpu
 	})
 }
 
+func (c *RootCLI) runListBlocks(ctx context.Context, output io.Writer, input listCommandInput) error {
+	if input.limit < 1 {
+		return xerrors.New(Localize("limit must be greater than or equal to 1", "limit は 1 以上である必要があります"))
+	}
+	if input.offset != 0 {
+		return xerrors.New(Localize("--blocks cannot be combined with --offset", "--blocks は --offset と同時に使えません"))
+	}
+	if input.followSessionSet || strings.TrimSpace(input.followSession) != "" {
+		return xerrors.New(Localize("--blocks cannot be combined with --follow-session", "--blocks は --follow-session と同時に使えません"))
+	}
+	if input.kindSet || strings.TrimSpace(input.kind) != "" {
+		return xerrors.New(Localize("--blocks cannot be combined with --kind", "--blocks は --kind と同時に使えません"))
+	}
+	if input.clientSet || strings.TrimSpace(input.client) != "" {
+		return xerrors.New(Localize("--blocks cannot be combined with --client", "--blocks は --client と同時に使えません"))
+	}
+	if input.agentSet || strings.TrimSpace(input.agent) != "" {
+		return xerrors.New(Localize("--blocks cannot be combined with --agent", "--blocks は --agent と同時に使えません"))
+	}
+	if input.sessionIDSet || strings.TrimSpace(input.sessionID) != "" {
+		return xerrors.New(Localize("--blocks cannot be combined with --session-id", "--blocks は --session-id と同時に使えません"))
+	}
+	if input.failuresOnly {
+		return xerrors.New(Localize("--blocks cannot be combined with --failures", "--blocks は --failures と同時に使えません"))
+	}
+	if input.sensitiveOnly {
+		return xerrors.New(Localize("--blocks cannot be combined with --sensitive", "--blocks は --sensitive と同時に使えません"))
+	}
+	if input.sourceHookSet || strings.TrimSpace(input.sourceHook) != "" {
+		return xerrors.New(Localize("--blocks cannot be combined with --source-hook", "--blocks は --source-hook と同時に使えません"))
+	}
+	if input.wide {
+		return xerrors.New(Localize("--blocks cannot be combined with --wide", "--blocks は --wide と同時に使えません"))
+	}
+	if input.fieldsSet {
+		return xerrors.New(Localize("--blocks cannot be combined with --fields", "--blocks は --fields と同時に使えません"))
+	}
+	if input.presetSet {
+		return xerrors.New(Localize("--blocks cannot be combined with --preset", "--blocks は --preset と同時に使えません"))
+	}
+	if input.colorSet {
+		return xerrors.New(Localize("--blocks cannot be combined with --color", "--blocks は --color と同時に使えません"))
+	}
+	if input.timezoneSet {
+		return xerrors.New(Localize("--blocks cannot be combined with --timezone", "--blocks は --timezone と同時に使えません"))
+	}
+	return c.runTimeline(ctx, output, timelineCommandInput{
+		dbPath:    input.dbPath,
+		workspace: input.repo,
+		from:      input.from,
+		since:     input.since,
+		to:        input.to,
+		until:     input.until,
+		gap:       input.gap,
+		limit:     input.limit,
+		asJSON:    input.asJSON,
+		utc:       input.utc,
+		location:  input.location,
+	})
+}
+
 func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.Writer, input listCommandInput) error {
+	if input.follow && input.blocks {
+		return xerrors.New(Localize("--follow cannot be combined with --blocks", "--follow は --blocks と同時に使えません"))
+	}
+	if input.blocks {
+		return c.runListBlocks(ctx, output, input)
+	}
+	if input.gapSet {
+		return xerrors.New(Localize("--gap requires --blocks", "--gap には --blocks が必要です"))
+	}
 	if input.follow {
 		return c.runListFollow(ctx, warnWriter, output, input)
 	}

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -468,3 +468,36 @@ func TestRootCLI_ListFollowLimitZeroUsesShippedFollowPath(t *testing.T) {
 		t.Fatalf("list --follow --limit 0 error = %v, want nil (cancelled follow loop)", err)
 	}
 }
+
+func TestRootCLI_ListBlocksRejectsIncompatibleFlags(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	tests := []struct {
+		name       string
+		args       []string
+		wantErrHas string
+	}{
+		{name: "offset", args: []string{"list", "--blocks", "--offset", "1"}, wantErrHas: "--blocks cannot be combined with --offset"},
+		{name: "kind", args: []string{"list", "--blocks", "--kind", "note"}, wantErrHas: "--blocks cannot be combined with --kind"},
+		{name: "follow", args: []string{"list", "--blocks", "--follow"}, wantErrHas: "--follow cannot be combined with --blocks"},
+		{name: "gap without blocks", args: []string{"list", "--gap", "10"}, wantErrHas: "--gap requires --blocks"},
+		{name: "timezone", args: []string{"list", "--blocks", "--timezone", "UTC"}, wantErrHas: "--blocks cannot be combined with --timezone"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := cli.NewRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithEvent(&eventUsecaseStub{}),
+			).Command()
+			rootCmd.SetOut(&bytes.Buffer{})
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetArgs(append(tt.args, "--db-path", t.TempDir()+"/t.db"))
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatalf("Execute() error = nil, want %q", tt.wantErrHas)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrHas) {
+				t.Fatalf("Execute() error = %q, want substring %q", err.Error(), tt.wantErrHas)
+			}
+		})
+	}
+}

--- a/presentation/cli/pillar_inventory.go
+++ b/presentation/cli/pillar_inventory.go
@@ -34,9 +34,8 @@ type pillarInventoryEntry struct {
 var pillarInventory = []pillarInventoryEntry{
 	{Path: "audit", Pillar: pillarRecord, Reason: "persist command-audit records"},
 	{Path: "log", Pillar: pillarRecord, Reason: "persist a manual event"},
-	{Path: "list", Pillar: pillarRecord, Reason: "read recorded events; --follow absorbs the former tail live stream"},
+	{Path: "list", Pillar: pillarRecord, Reason: "read recorded events; --follow absorbs tail; --blocks absorbs timeline"},
 	{Path: "search", Pillar: pillarRecord, Reason: "search recorded events and session summaries"},
-	{Path: "timeline", Pillar: pillarRecord, Reason: "workspace timeline of recorded work; list --blocks does not exist"},
 	{Path: "show", Pillar: pillarRecord, Reason: "show one recorded event"},
 	{Path: "context", Pillar: pillarRecord, Reason: "assemble recorded context for a session"},
 	{Path: "session start", Pillar: pillarRecord, Reason: "open a recorded session"},

--- a/presentation/cli/pillar_inventory_test.go
+++ b/presentation/cli/pillar_inventory_test.go
@@ -40,7 +40,7 @@ func TestRootCLI_SurfacesWithoutV036Notice(t *testing.T) {
 	}{
 		{name: "propose", args: []string{"memory", "store", "propose", "--db-path", "/tmp/test-traceary.db", "--type", "decision", "--fact", "Candidate"}},
 		{name: "list follow", args: []string{"list", "--follow", "--help"}},
-		{name: "timeline", args: []string{"timeline", "--help"}},
+		{name: "list blocks", args: []string{"list", "--blocks", "--help"}},
 		{name: "handoff", args: []string{"session", "handoff", "--help"}},
 		{name: "hooks print", args: []string{"hooks", "print", "--help"}},
 		{name: "replay", args: []string{"replay", "--help"}},

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -441,7 +441,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	rootCmd.AddCommand(c.newHookCommand())
 	rootCmd.AddCommand(c.newSessionCommand())
 	rootCmd.AddCommand(c.newMemoryCommand())
-	rootCmd.AddCommand(c.newTimelineCommand())
+
 	rootCmd.AddCommand(c.newCompletionCommand(rootCmd))
 	rootCmd.AddCommand(c.newHooksCommand())
 	rootCmd.AddCommand(c.newDoctorCommand())

--- a/presentation/cli/timeline.go
+++ b/presentation/cli/timeline.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
@@ -19,54 +18,6 @@ const (
 	defaultGapMinutes      = 15
 	timelineSummaryMaxRune = 72
 )
-
-func (c *RootCLI) newTimelineCommand() *cobra.Command {
-	var (
-		dbPath    string
-		workspace string
-		from      string
-		since     string
-		to        string
-		until     string
-		gap       int
-		limit     int
-		asJSON    bool
-		utc       bool
-	)
-
-	cmd := &cobra.Command{
-		Use:   "timeline",
-		Short: Localize("Show work timeline with gap-based block detection", "ギャップ検出による作業タイムラインを表示する"),
-		Args:  noArgsLocalized(),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return c.runTimeline(cmd.Context(), cmd.OutOrStdout(), timelineCommandInput{
-				dbPath:    dbPath,
-				workspace: workspace,
-				from:      from,
-				since:     since,
-				to:        to,
-				until:     until,
-				gap:       gap,
-				limit:     limit,
-				asJSON:    asJSON,
-				utc:       utc,
-			})
-		},
-	}
-
-	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
-	cmd.Flags().StringVar(&workspace, "workspace", "", Localize("filter by workspace", "ワークスペースでフィルタ"))
-	cmd.Flags().StringVar(&from, "from", "", Localize("start date (YYYY-MM-DD or RFC3339; alias: --since)", "開始日 (YYYY-MM-DD または RFC3339; 別名: --since)"))
-	cmd.Flags().StringVar(&since, "since", "", Localize("start date (alias for --from)", "開始日 (--from の別名)"))
-	cmd.Flags().StringVar(&to, "to", "", Localize("end date (YYYY-MM-DD or RFC3339; alias: --until)", "終了日 (YYYY-MM-DD または RFC3339; 別名: --until)"))
-	cmd.Flags().StringVar(&until, "until", "", Localize("end date (alias for --to)", "終了日 (--to の別名)"))
-	cmd.Flags().IntVar(&gap, "gap", defaultGapMinutes, Localize("idle gap threshold in minutes", "アイドル判定の閾値（分）"))
-	cmd.Flags().IntVar(&limit, "limit", 20, Localize("maximum number of blocks to display", "表示するブロック数の上限"))
-	cmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
-	cmd.Flags().BoolVar(&utc, "utc", false, Localize("print text timestamps in UTC instead of local time", "テキスト出力のタイムスタンプを現地時刻ではなく UTC で出力する"))
-
-	return cmd
-}
 
 func (c *RootCLI) runTimeline(ctx context.Context, output io.Writer, input timelineCommandInput) error {
 	if c.event == nil {

--- a/presentation/cli/timeline_test.go
+++ b/presentation/cli/timeline_test.go
@@ -55,7 +55,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--from", "2026-04-10", "--utc"})
+		rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test.db", "--from", "2026-04-10", "--utc"})
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -86,7 +86,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--since", "2026-04-10", "--until", "2026-04-11"})
+		rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test.db", "--since", "2026-04-10", "--until", "2026-04-11"})
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -108,7 +108,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--until", "2026-04-26"})
+		rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test.db", "--until", "2026-04-26"})
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -130,7 +130,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db"})
+		rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test.db"})
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -172,7 +172,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--json"})
+		rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test.db", "--json"})
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -196,7 +196,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		).Command()
 		rootCmd.SetOut(&bytes.Buffer{})
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--from", "not-a-date"})
+		rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test.db", "--from", "not-a-date"})
 
 		err := rootCmd.Execute()
 		if err == nil {
@@ -233,7 +233,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--utc"})
+		rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test.db", "--utc"})
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -263,7 +263,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--json"})
+		rootCmd.SetArgs([]string{"list", "--blocks", "--db-path", "/tmp/test.db", "--json"})
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)


### PR DESCRIPTION
Absorb `timeline` into `list --blocks` and remove the `timeline` command.

- `list --blocks` reuses the shipped `runTimeline` path (gap blocks, scan-cap disclosure)
- `list --blocks --json` keeps the `workspace_breakdown` contract
- `timeline` is an unknown command (non-zero exit, no DEPRECATED stub)
- `--gap` moves onto `list` and requires `--blocks`

Closes #2069
Leaves parent #2049 open