### PR TITLE
fix: localize root unknown-command errors and index-family-bytes help

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **ルートの unknown command と `--index-family-bytes` の help が `ui.language` に従う (#2114)** — `traceary nosuchcmd` はサブコマンドと同じカタログを使う（候補リストはそのまま）。`store compact --help` の `--index-family-bytes` を英語だけにしない。
 - **`doctor --fix` が transient dead-letter 再キューを 45 秒の壁時計内で続けて drain する (#2109)** — 1 バッチ 200 件の上限は残し、スプールが空になるか壁時計が尽きるまでループする。`--dry-run` は計画件数を全件出す。Fixes 行のカウンタ形式は変えない。
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Root unknown-command errors and `--index-family-bytes` help follow `ui.language` (#2114)** — `traceary nosuchcmd` uses the same catalog as unknown subcommands (suggestions stay). `store compact --help` no longer leaves `--index-family-bytes` in English-only.
 - **`doctor --fix` drains transient dead-letter requeue under the 45s wall (#2109)** — the 200-record batch cap remains, but batches loop until the spool is empty or the fixer wall clock is exhausted. `--dry-run` previews the full planned requeue count. Fixes-line counters are unchanged.
 
 ### Docs

--- a/main.go
+++ b/main.go
@@ -437,6 +437,7 @@ func wrapCLIExecuteError(err error) error {
 	if errors.As(err, &exitCoder) {
 		return err
 	}
+	err = cli.LocalizeCobraExecuteError(err)
 	return xerrors.Errorf("failed to execute CLI command: %w", err)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"runtime/debug"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -221,6 +222,22 @@ func TestWrapCLIExecuteError_SkipsDiagnosticExitCodes(t *testing.T) {
 			t.Fatalf("wrapCLIExecuteError() = %q", err.Error())
 		}
 	})
+
+}
+
+func TestWrapCLIExecuteError_LocalizesCobraUnknownCommandInJapanese(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "ja")
+	err := wrapCLIExecuteError(errors.New("unknown command \"nosuchcmd\" for \"traceary\"\n\nDid you mean this?\n\tsearch"))
+	if err == nil {
+		t.Fatal("wrapCLIExecuteError() = nil")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "不明なコマンド") || strings.Contains(got, "unknown command") {
+		t.Fatalf("wrapCLIExecuteError() = %q, want Japanese unknown-command text", got)
+	}
+	if !strings.Contains(got, "Did you mean this?") {
+		t.Fatalf("wrapCLIExecuteError() = %q, want suggestion list", got)
+	}
 }
 
 func TestIsSilentCLIExitError(t *testing.T) {

--- a/presentation/cli/i18n.go
+++ b/presentation/cli/i18n.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/duck8823/traceary/presentation"
+	"golang.org/x/xerrors"
 )
 
 const cliLanguageEnvKey = "TRACEARY_LANG"
@@ -33,6 +35,33 @@ func Localizef(english string, japanese string, args ...any) string {
 
 func localizef(english string, japanese string, args ...any) string {
 	return Localizef(english, japanese, args...)
+}
+
+var cobraUnknownCommandPattern = regexp.MustCompile(`(?s)^unknown command "([^"]+)" for "([^"]+)"(.*)$`)
+
+// LocalizeCobraExecuteError rewrites Cobra's root-level unknown-command
+// message through the same catalog as applyStrictGroups. Suggestion lines
+// after the first paragraph are kept verbatim.
+func LocalizeCobraExecuteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	match := cobraUnknownCommandPattern.FindStringSubmatch(err.Error())
+	if match == nil {
+		return err
+	}
+	name := match[1]
+	path := match[2]
+	suffix := match[3]
+	localized := Localizef(
+		`unknown command %q for %q; run %q for available commands`,
+		`%q は %q の不明なコマンドです。利用可能なコマンドは %q を参照してください`,
+		name, path, path+" --help",
+	)
+	if suffix != "" {
+		localized += suffix
+	}
+	return xerrors.Errorf("%s", localized)
 }
 
 func isJapaneseCLI() bool {

--- a/presentation/cli/i18n.go
+++ b/presentation/cli/i18n.go
@@ -46,6 +46,9 @@ func LocalizeCobraExecuteError(err error) error {
 	if err == nil {
 		return nil
 	}
+	if !isJapaneseCLI() {
+		return err
+	}
 	match := cobraUnknownCommandPattern.FindStringSubmatch(err.Error())
 	if match == nil {
 		return err

--- a/presentation/cli/i18n_unknown_command_test.go
+++ b/presentation/cli/i18n_unknown_command_test.go
@@ -29,6 +29,18 @@ func TestLocalizeCobraExecuteError_JapaneseUnknownCommandKeepsSuggestions(t *tes
 	}
 }
 
+func TestLocalizeCobraExecuteError_LeavesEnglishWording(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "en")
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	in := errors.New("unknown command \"nosuchcmd\" for \"traceary\"\n\nDid you mean this?\n\tsearch")
+	got := LocalizeCobraExecuteError(in)
+	if got != in {
+		t.Fatalf("English unknown-command error rewritten: %v", got)
+	}
+}
+
 func TestLocalizeCobraExecuteError_LeavesOtherErrors(t *testing.T) {
 	in := xerrors.New("database query failed")
 	if got := LocalizeCobraExecuteError(in); got != in {

--- a/presentation/cli/i18n_unknown_command_test.go
+++ b/presentation/cli/i18n_unknown_command_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"golang.org/x/xerrors"
+)
+
+func TestLocalizeCobraExecuteError_JapaneseUnknownCommandKeepsSuggestions(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "ja")
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	err := LocalizeCobraExecuteError(errors.New("unknown command \"nosuchcmd\" for \"traceary\"\n\nDid you mean this?\n\tsearch"))
+	if err == nil {
+		t.Fatal("LocalizeCobraExecuteError() = nil")
+	}
+	got := err.Error()
+	if strings.Contains(got, "unknown command") {
+		t.Fatalf("error still English: %q", got)
+	}
+	if !strings.Contains(got, "不明なコマンド") || !strings.Contains(got, "nosuchcmd") {
+		t.Fatalf("error = %q, want Japanese unknown-command text", got)
+	}
+	if !strings.Contains(got, "Did you mean this?") || !strings.Contains(got, "search") {
+		t.Fatalf("error = %q, want cobra suggestion list kept", got)
+	}
+}
+
+func TestLocalizeCobraExecuteError_LeavesOtherErrors(t *testing.T) {
+	in := xerrors.New("database query failed")
+	if got := LocalizeCobraExecuteError(in); got != in {
+		t.Fatalf("LocalizeCobraExecuteError() = %v, want original", got)
+	}
+}
+
+func TestStoreCompactIndexFamilyBytesHelpIsJapanese(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "ja")
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	root := NewRootCLI().Command()
+	compact := findCommandOrNil(findCommandOrNil(root, "store"), "compact")
+	if compact == nil {
+		t.Fatal("store compact is not registered")
+	}
+	flag := compact.Flags().Lookup("index-family-bytes")
+	if flag == nil {
+		t.Fatal("--index-family-bytes is missing")
+	}
+	if strings.Contains(flag.Usage, "steady-state physical byte target") {
+		t.Fatalf("usage still English-only: %q", flag.Usage)
+	}
+	if !strings.Contains(flag.Usage, "物理バイト") {
+		t.Fatalf("usage=%q, want Japanese description", flag.Usage)
+	}
+}

--- a/presentation/cli/store_compaction.go
+++ b/presentation/cli/store_compaction.go
@@ -117,7 +117,7 @@ func (c *RootCLI) newStoreCompactionCommand() *cobra.Command {
 	cmd.Flags().Int64Var(&projectionBudget.decoded, "decoded-bytes", projectionBudget.decoded, Localize("with --projection-rebuild, maximum decoded source bytes", "--projection-rebuild 時の復号 source バイト上限"))
 	cmd.Flags().Int64Var(&projectionBudget.written, "write-bytes", projectionBudget.written, Localize("with --projection-rebuild, maximum logical write bytes", "--projection-rebuild 時の論理 write バイト上限"))
 	cmd.Flags().DurationVar(&projectionBudget.recentAge, "recent-age", projectionBudget.recentAge, Localize("with --projection-rebuild, recent projection age", "--projection-rebuild 時の recent projection 保持期間"))
-	cmd.Flags().Int64Var(&projectionBudget.indexFamilyBytes, "index-family-bytes", projectionBudget.indexFamilyBytes, "steady-state physical byte target for one completed search-index family after cleanup; not a rebuild-peak cap (two generations plus FTS delete postings can exceed it)")
+	cmd.Flags().Int64Var(&projectionBudget.indexFamilyBytes, "index-family-bytes", projectionBudget.indexFamilyBytes, Localize("steady-state physical byte target for one completed search-index family after cleanup; not a rebuild-peak cap (two generations plus FTS delete postings can exceed it)", "cleanup 後に完成した search-index family 1 本の定常時物理バイト目標。rebuild ピーク上限ではない（2 世代 + FTS delete postings は超え得る）"))
 	cmd.MarkFlagsMutuallyExclusive("archive", "archive-verify", "archive-restore", "retention-plan", "retention-apply", "projection-rebuild", "projection-abort")
 	cmd.AddCommand(c.newStoreCompactionRollbackCommand())
 	return cmd


### PR DESCRIPTION
Closes #2114

Leaves parent #2108 open.

Root unknown-command errors go through the CLI catalog (suggestions kept). store compact --index-family-bytes help is localized. English default wording unchanged.