### PR TITLE
fix: hide instruction-echo, fragment, and JSON payload memory candidates

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **抽出が instruction-echo・文途中フラグメント・JSON payload echo を hidden にする (#2112)** — 番号/箇条書きの命令、小文字で始まる節の続き、JSON の object/array リテラルは `extracted-hidden`。payload echo は remember-intent でも hidden。それ以外の remember-intent は表示のまま。
 - **空ストア初回実行の projection 保守を WARN にしない (#2113)** — 世代がなくサンプルもないとき、`no source events to project` と `amplification sample below minimum` は DEBUG。データがあるストアでは同じ条件でも WARN のまま。
 - **ルートの unknown command と `--index-family-bytes` の help が `ui.language` に従う (#2114)** — `traceary nosuchcmd` はサブコマンドと同じカタログを使う（候補リストはそのまま）。`store compact --help` の `--index-family-bytes` を英語だけにしない。
 - **`doctor --fix` が transient dead-letter 再キューを 45 秒の壁時計内で続けて drain する (#2109)** — 1 バッチ 200 件の上限は残し、スプールが空になるか壁時計が尽きるまでループする。`--dry-run` は計画件数を全件出す。Fixes 行のカウンタ形式は変えない。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Extraction hides instruction-echo, mid-sentence fragments, and JSON payload echoes (#2112)** — numbered/bulleted imperative list items, lowercase clause continuations, and JSON object/array literals route to `extracted-hidden`. Payload echoes stay hidden even on remember-intent; other remember-intent facts stay visible.
 - **Fresh/empty stores no longer WARN on first-run projection maintenance (#2113)** — `no source events to project` and `amplification sample below minimum` log at DEBUG when the store has no generation and no sample. The same conditions stay WARN on a populated store.
 - **Root unknown-command errors and `--index-family-bytes` help follow `ui.language` (#2114)** — `traceary nosuchcmd` uses the same catalog as unknown subcommands (suggestions stay). `store compact --help` no longer leaves `--index-family-bytes` in English-only.
 - **`doctor --fix` drains transient dead-letter requeue under the 45s wall (#2109)** — the 200-record batch cap remains, but batches loop until the spool is empty or the fixer wall clock is exhausted. `--dry-run` previews the full planned requeue count. Fixes-line counters are unchanged.

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -189,8 +189,8 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 		}
 		source := spec.source
 		hiddenByQuality := spec.signalScore < extractionVisibleScoreThreshold ||
-			(len(spec.lowQualityReasons) > 0 && !spec.intent.explicitRemember)
-		if hiddenByQuality && !spec.intent.explicitRemember {
+			shouldHideLowQuality(spec.lowQualityReasons, spec.intent.explicitRemember)
+		if hiddenByQuality {
 			// Preserve audit-first gating for every auto-extracted source,
 			// including compact-summary. Source-specific candidates should not
 			// bypass the low-quality/noise routing just because their source was
@@ -445,7 +445,7 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 			decision.Reason = "below_visible_threshold"
 			continue
 		}
-		if len(candidate.lowQualityReasons) > 0 && !candidate.explicitRemember {
+		if shouldHideLowQuality(candidate.lowQualityReasons, candidate.explicitRemember) {
 			decision.Decision = "hidden"
 			decision.Reason = "low_quality:" + strings.Join(candidate.lowQualityReasons, ",")
 			continue

--- a/application/usecase/memory_extraction_echo.go
+++ b/application/usecase/memory_extraction_echo.go
@@ -1,0 +1,146 @@
+package usecase
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	extractionNoiseInstructionEcho     = "instruction_echo"
+	extractionNoiseMidSentenceFragment = "mid_sentence_fragment"
+	extractionNoisePayloadEcho         = "payload_echo"
+)
+
+var (
+	listMarkerPattern = regexp.MustCompile(`^(?:\d{1,3}[.)]\s+|[-*•]\s+)`)
+
+	// Imperative agent-rule openers after a list marker. Deliberately a
+	// closed verb/cue set so declarative numbered facts stay visible.
+	instructionEchoEnglishPattern = regexp.MustCompile(`(?i)^(?:` +
+		`always|never|do\s+not|don't|must|should|shall|` +
+		`read|write|use|avoid|ensure|keep|make\s+sure|prefer|` +
+		`run|call|invoke|pass|set|add|remove|delete|update|create|` +
+		`check|verify|confirm|ask|tell|remember|forget|ignore|` +
+		`follow|apply|treat|consider|assume|include|exclude` +
+		`)\b`)
+
+	instructionEchoJapanesePattern = regexp.MustCompile(
+		`(?:してください|してはいけない|するな|すること|すること。|必ず|禁止)`)
+
+	continuationWordPattern = regexp.MustCompile(`(?i)^(?:` +
+		`and|but|or|so|which|that|because|then|also|however|` +
+		`while|although|though|since|unless|until|after|before|` +
+		`when|where|who|whom|whose|than|as|if` +
+		`)\b`)
+)
+
+func isInstructionEcho(fact string) bool {
+	trimmed := strings.TrimSpace(fact)
+	if trimmed == "" {
+		return false
+	}
+	loc := listMarkerPattern.FindStringIndex(trimmed)
+	if loc == nil {
+		return false
+	}
+	rest := strings.TrimSpace(trimmed[loc[1]:])
+	if rest == "" {
+		return false
+	}
+	if instructionEchoEnglishPattern.MatchString(rest) {
+		return true
+	}
+	return instructionEchoJapanesePattern.MatchString(rest)
+}
+
+func isMidSentenceFragment(fact string) bool {
+	trimmed := strings.TrimSpace(fact)
+	if trimmed == "" {
+		return false
+	}
+	if hasDurableSignalMarker(trimmed) {
+		return false
+	}
+	first, size := utf8.DecodeRuneInString(trimmed)
+	if first == utf8.RuneError && size == 0 {
+		return false
+	}
+	switch first {
+	case 'を', 'に', 'は', 'が', 'で', 'と', 'も', 'へ', 'や':
+		return true
+	}
+	if strings.HasPrefix(trimmed, "より") {
+		return true
+	}
+	if !unicode.IsLower(first) {
+		return false
+	}
+	return continuationWordPattern.MatchString(trimmed)
+}
+
+func isPayloadEcho(fact string) bool {
+	trimmed := strings.TrimSpace(fact)
+	if trimmed == "" {
+		return false
+	}
+	if looksLikeJSONValue(trimmed) {
+		return true
+	}
+	return jsonLiteralDominates(trimmed)
+}
+
+func looksLikeJSONValue(value string) bool {
+	if !strings.HasPrefix(value, "{") && !strings.HasPrefix(value, "[") {
+		return false
+	}
+	var decoded any
+	if json.Unmarshal([]byte(value), &decoded) != nil {
+		return false
+	}
+	switch decoded.(type) {
+	case map[string]any, []any:
+		return true
+	default:
+		return false
+	}
+}
+
+func jsonLiteralDominates(value string) bool {
+	start := strings.IndexAny(value, "{[")
+	if start < 0 {
+		return false
+	}
+	for end := len(value); end > start+1; end-- {
+		candidate := strings.TrimSpace(value[start:end])
+		if !looksLikeJSONValue(candidate) {
+			continue
+		}
+		return len(candidate)*2 >= len(strings.TrimSpace(value))
+	}
+	return false
+}
+
+// hidesDespiteRememberIntent reports noise classes that stay extracted-hidden
+// even when the user said "remember that". The remember trigger fired, but
+// the stored body is not a durable fact (#2112).
+func hidesDespiteRememberIntent(reasons []string) bool {
+	for _, reason := range reasons {
+		if reason == extractionNoisePayloadEcho {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldHideLowQuality(reasons []string, explicitRemember bool) bool {
+	if len(reasons) == 0 {
+		return false
+	}
+	if !explicitRemember {
+		return true
+	}
+	return hidesDespiteRememberIntent(reasons)
+}

--- a/application/usecase/memory_extraction_echo_test.go
+++ b/application/usecase/memory_extraction_echo_test.go
@@ -1,0 +1,90 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestClassifyExtractionNoise_HidesInstructionEchoFragmentAndPayload(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		fact string
+		want []string
+	}{
+		// Sanitized dogfood samples (2026-08-17/18): seven visible extracted
+		// candidates that should have been extracted-hidden (#2112).
+		{
+			name: "numbered agent-rule always",
+			fact: "1. Always run gofmt before opening a PR",
+			want: []string{extractionNoiseInstructionEcho},
+		},
+		{
+			name: "numbered agent-rule do not",
+			fact: "2. Do not commit generated snapshots by hand",
+			want: []string{extractionNoiseInstructionEcho},
+		},
+		{
+			name: "bulleted agent-rule use",
+			fact: "- Use the official brew binary against the live store",
+			want: []string{extractionNoiseInstructionEcho},
+		},
+		{
+			name: "japanese numbered request",
+			fact: "3. レビュー前にテストを実行してください",
+			want: []string{extractionNoiseInstructionEcho},
+		},
+		{
+			name: "mid-sentence which continuation",
+			fact: "which then requeues transient dead letters on the next hook",
+			want: []string{extractionNoiseMidSentenceFragment},
+		},
+		{
+			name: "mid-sentence and continuation",
+			fact: "and the replica size can exceed the destination estimate",
+			want: []string{extractionNoiseMidSentenceFragment},
+		},
+		{
+			name: "payload echo ephemeral envelope",
+			fact: `{"ephemeralMessage":"starting the next wave now"}`,
+			want: []string{extractionNoiseTransientStatus, extractionNoisePayloadEcho},
+		},
+		{
+			name: "payload echo remember-intent body",
+			fact: `{"ephemeralMessage":{"text":"remember that we ship the keep list as 41 invocables"}}`,
+			want: []string{extractionNoiseTransientStatus, extractionNoisePayloadEcho},
+		},
+		{
+			name: "payload echo array literal",
+			fact: `[{"path":"/tmp/scratch","kind":"note"}]`,
+			want: []string{extractionNoisePayloadEcho},
+		},
+		// Counter-examples: facts and declarative lists stay visible.
+		{name: "short durable fact", fact: "The two-pillar target is 41 invocables", want: nil},
+		{name: "declarative numbered fact", fact: "1. Search projection generation is complete", want: nil},
+		{name: "declarative bullet fact", fact: "- Freelist pages are reclaimable via store compact", want: nil},
+		{name: "lowercase complete claim", fact: "the store stays local-first after compact", want: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyExtractionNoise(tc.fact)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("classifyExtractionNoise(%q) mismatch (-want +got):\n%s", tc.fact, diff)
+			}
+		})
+	}
+}
+
+func TestHidesDespiteRememberIntent_OnlyPayloadEcho(t *testing.T) {
+	t.Parallel()
+	if hidesDespiteRememberIntent([]string{extractionNoiseInstructionEcho}) {
+		t.Fatal("instruction_echo must stay remember-intent visible")
+	}
+	if !hidesDespiteRememberIntent([]string{extractionNoiseTransientStatus, extractionNoisePayloadEcho}) {
+		t.Fatal("payload_echo must hide even with remember-intent")
+	}
+}

--- a/application/usecase/memory_extraction_quality.go
+++ b/application/usecase/memory_extraction_quality.go
@@ -207,6 +207,15 @@ func classifyExtractionNoise(fact string) []string {
 	if isTransientStatus(trimmed) {
 		reasons = append(reasons, extractionNoiseTransientStatus)
 	}
+	if isInstructionEcho(trimmed) {
+		reasons = append(reasons, extractionNoiseInstructionEcho)
+	}
+	if isMidSentenceFragment(trimmed) {
+		reasons = append(reasons, extractionNoiseMidSentenceFragment)
+	}
+	if isPayloadEcho(trimmed) {
+		reasons = append(reasons, extractionNoisePayloadEcho)
+	}
 	if len(reasons) == 0 {
 		return nil
 	}

--- a/application/usecase/memory_extraction_transient_test.go
+++ b/application/usecase/memory_extraction_transient_test.go
@@ -41,7 +41,7 @@ func TestClassifyExtractionNoise_TransientStatus(t *testing.T) {
 		{
 			name: "ephemeral json envelope",
 			fact: `{"ephemeralMessage": "starting the next wave now"}`,
-			want: []string{extractionNoiseTransientStatus},
+			want: []string{extractionNoiseTransientStatus, extractionNoisePayloadEcho},
 		},
 		{
 			name: "durable merge constraint stays visible",

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -2189,6 +2189,21 @@ func TestMemoryUsecase_Extract_HidesNoisyCandidates(t *testing.T) {
 			body:     "教訓: 確認済み・問題なしです",
 			wantFact: "確認済み・問題なしです",
 		},
+		{
+			name:     "numbered instruction echo",
+			body:     "Decision: 1. Always run gofmt before opening a PR",
+			wantFact: "1. Always run gofmt before opening a PR",
+		},
+		{
+			name:     "mid-sentence fragment",
+			body:     "Lesson: which then requeues transient dead letters on the next hook",
+			wantFact: "which then requeues transient dead letters on the next hook",
+		},
+		{
+			name:     "json payload echo",
+			body:     "Decision: {\"ephemeralMessage\":\"starting the next wave now\"}",
+			wantFact: `{"ephemeralMessage":"starting the next wave now"}`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -2297,6 +2312,54 @@ func TestMemoryUsecase_Extract_KeepsExplicitRememberVisibleEvenWhenNoisy(t *test
 	}
 	if got := memoryUsecase.proposeCalls[0].source; got != domtypes.MemorySourceRememberIntent {
 		t.Fatalf("source = %q, want remember-intent (explicit remember overrides noise)", got)
+	}
+}
+
+func TestMemoryUsecase_Extract_HidesRememberIntentJSONPayloadEcho(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-payload-remember"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.None[time.Time](),
+		"ended",
+		1,
+		0,
+		[]string{"codex"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	payload := `{"ephemeralMessage":"starting the next wave now"}`
+	promptEvent := mustExtractionEvent(t,
+		"event-payload-remember",
+		domtypes.EventKindPrompt,
+		"Remember this: "+payload,
+	)
+	details := mustMemoryDetailsFromSummary(t, "memory-payload-remember", domtypes.MemoryTypeLesson, payload)
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-payload-remember")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(1).
+			CandidateLimit(10).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1 hidden payload echo", len(memoryUsecase.proposeCalls))
+	}
+	if got := memoryUsecase.proposeCalls[0].source; got != domtypes.MemorySourceExtractedHidden {
+		t.Fatalf("source = %q, want extracted-hidden for remember-intent payload echo", got)
 	}
 }
 


### PR DESCRIPTION
Closes #2112

Leaves parent #2108 open.

Extraction routes numbered/bulleted imperative list items, mid-sentence fragments, and JSON object/array literals to extracted-hidden. Payload echoes stay hidden even on remember-intent.