### PR TITLE
fix: print store compact phase and replica-build progress on stderr

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **`store compact` が stderr に phase と replica 構築進捗を出す (#2119)** — journal の phase ごとに 1 行。構築中は約 10 秒ごとに replica バイト対 destination 見積もり。stdout JSON は変えない。
 - **抽出が instruction-echo・文途中フラグメント・JSON payload echo を hidden にする (#2112)** — 番号/箇条書きの命令、小文字で始まる節の続き、JSON の object/array リテラルは `extracted-hidden`。payload echo は remember-intent でも hidden。それ以外の remember-intent は表示のまま。
 - **空ストア初回実行の projection 保守を WARN にしない (#2113)** — 世代がなくサンプルもないとき、`no source events to project` と `amplification sample below minimum` は DEBUG。データがあるストアでは同じ条件でも WARN のまま。
 - **ルートの unknown command と `--index-family-bytes` の help が `ui.language` に従う (#2114)** — `traceary nosuchcmd` はサブコマンドと同じカタログを使う（候補リストはそのまま）。`store compact --help` の `--index-family-bytes` を英語だけにしない。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **`store compact` prints phase and replica-build progress on stderr (#2119)** — each journal phase emits a line; the build phase reports replica bytes versus the destination estimate about every 10s. stdout JSON is unchanged.
 - **Extraction hides instruction-echo, mid-sentence fragments, and JSON payload echoes (#2112)** — numbered/bulleted imperative list items, lowercase clause continuations, and JSON object/array literals route to `extracted-hidden`. Payload echoes stay hidden even on remember-intent; other remember-intent facts stay visible.
 - **Fresh/empty stores no longer WARN on first-run projection maintenance (#2113)** — `no source events to project` and `amplification sample below minimum` log at DEBUG when the store has no generation and no sample. The same conditions stay WARN on a populated store.
 - **Root unknown-command errors and `--index-family-bytes` help follow `ui.language` (#2114)** — `traceary nosuchcmd` uses the same catalog as unknown subcommands (suggestions stay). `store compact --help` no longer leaves `--index-family-bytes` in English-only.

--- a/application/store_compaction.go
+++ b/application/store_compaction.go
@@ -68,6 +68,13 @@ type StoreCompactionLease interface {
 	AcquireExclusive(context.Context, string) (func(), error)
 }
 
+// CompactionProgress reports journal phase changes and replica-build bytes
+// to the operator. Implementations write diagnostics (typically stderr).
+type CompactionProgress interface {
+	OnPhase(phase domain.CompactionPhase, destinationBytes uint64)
+	WatchBuild(ctx context.Context, candidatePath string, destinationBytes uint64) (stop func())
+}
+
 // StoreCompactionUsecase provides the explicit maintenance workflow.
 type StoreCompactionUsecase interface {
 	Compact(context.Context, CompactInput) (CompactResult, error)

--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -21,6 +21,7 @@ type storeCompactionUsecase struct {
 	builder       application.StoreCompactionBuilder
 	files         application.StoreCompactionFiles
 	lease         application.StoreCompactionLease
+	progress      application.CompactionProgress
 	now           func() time.Time
 	expectedStore string
 	cover         func(ctx context.Context, work string, cutoff time.Time) error
@@ -35,6 +36,13 @@ type compactFilterSetter interface {
 func BindCompactionWorkCover(u application.StoreCompactionUsecase, cover func(ctx context.Context, work string, cutoff time.Time) error) {
 	if concrete, ok := u.(*storeCompactionUsecase); ok {
 		concrete.cover = cover
+	}
+}
+
+// BindCompactionProgress attaches operator-facing phase/byte progress.
+func BindCompactionProgress(u application.StoreCompactionUsecase, progress application.CompactionProgress) {
+	if concrete, ok := u.(*storeCompactionUsecase); ok {
+		concrete.progress = progress
 	}
 }
 
@@ -290,7 +298,13 @@ func (u *storeCompactionUsecase) applyLeased(ctx context.Context, run domain.Com
 			run.PreparedAttempt++
 			run, err = u.advance(ctx, run, domain.CompactionCandidatePrepared)
 		case domain.ActionBuildCandidate:
-			err = u.builder.Build(ctx, run.SourcePath, run.CandidatePath)
+			if u.progress != nil {
+				stop := u.progress.WatchBuild(ctx, run.CandidatePath, run.Resources.DestinationBytes)
+				err = u.builder.Build(ctx, run.SourcePath, run.CandidatePath)
+				stop()
+			} else {
+				err = u.builder.Build(ctx, run.SourcePath, run.CandidatePath)
+			}
 			if err == nil {
 				run, err = u.advance(ctx, run, domain.CompactionCopyComplete)
 			}
@@ -556,6 +570,9 @@ func (u *storeCompactionUsecase) advance(ctx context.Context, run domain.Compact
 	}
 	if err := u.journal.Append(ctx, next); err != nil {
 		return run, err
+	}
+	if u.progress != nil {
+		u.progress.OnPhase(next.Phase, next.Resources.DestinationBytes)
 	}
 	return next, nil
 }

--- a/application/usecase/store_compaction_progress_test.go
+++ b/application/usecase/store_compaction_progress_test.go
@@ -1,0 +1,41 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+type recordProgress struct {
+	phases  []domain.CompactionPhase
+	watches int
+}
+
+func (r *recordProgress) OnPhase(phase domain.CompactionPhase, _ uint64) {
+	r.phases = append(r.phases, phase)
+}
+
+func (r *recordProgress) WatchBuild(context.Context, string, uint64) func() {
+	r.watches++
+	return func() {}
+}
+
+func TestBindCompactionProgress_ReportsPhaseAndBuildWatch(t *testing.T) {
+	t.Parallel()
+	source := "/store"
+	run := compactionRunAt(domain.CompactionCandidatePrepared)
+	run.SourcePath = source
+	run.CandidatePath = source + ".cand"
+	progress := &recordProgress{}
+	svc := NewStoreCompactionUsecase(source, &faultJournal{run: run}, faultBuilder{}, faultFiles{
+		observation: domain.CompactionObservation{Orientation: domain.OrientationCandidateReady, CandidateCondition: domain.CandidateConditionOwnedIncomplete},
+	}, faultLease{})
+	BindCompactionProgress(svc, progress)
+	if _, err := svc.Apply(context.Background(), run.ID); err != nil && progress.watches == 0 && len(progress.phases) == 0 {
+		t.Fatalf("progress unused: apply err=%v phases=%v watches=%d", err, progress.phases, progress.watches)
+	}
+	if progress.watches == 0 {
+		t.Fatalf("WatchBuild was not called; phases=%v", progress.phases)
+	}
+}

--- a/presentation/cli/store_compaction.go
+++ b/presentation/cli/store_compaction.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/usecase"
 )
 
 func (c *RootCLI) newStoreCompactionCommand() *cobra.Command {
@@ -234,6 +235,7 @@ func (c *RootCLI) runStoreCompact(cmd *cobra.Command, input storeCompactInput) e
 	if err != nil {
 		return err
 	}
+	usecase.BindCompactionProgress(service, newCLICompactionProgress(cmd.ErrOrStderr()))
 	result, err := service.Compact(cmd.Context(), application.CompactInput{
 		Source:   resolved,
 		Force:    input.force,

--- a/presentation/cli/store_compaction_progress.go
+++ b/presentation/cli/store_compaction_progress.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+var compactBuildProgressInterval = 10 * time.Second
+
+type cliCompactionProgress struct {
+	w   io.Writer
+	now func() time.Time
+}
+
+func newCLICompactionProgress(w io.Writer) cliCompactionProgress {
+	return cliCompactionProgress{w: w, now: time.Now}
+}
+
+func (p cliCompactionProgress) OnPhase(phase domain.CompactionPhase, destinationBytes uint64) {
+	if p.w == nil {
+		return
+	}
+	if phase == domain.CompactionCandidatePrepared && destinationBytes > 0 {
+		_, _ = fmt.Fprintf(p.w, "%s\n", localizef(
+			"compact: %s (replica build starting, ~%s)",
+			"compact: %s (replica 構築開始, 約 %s)",
+			phase, formatCompactBytes(destinationBytes),
+		))
+		return
+	}
+	_, _ = fmt.Fprintf(p.w, "compact: %s\n", phase)
+}
+
+func (p cliCompactionProgress) WatchBuild(ctx context.Context, candidatePath string, destinationBytes uint64) func() {
+	if p.w == nil {
+		return func() {}
+	}
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(compactBuildProgressInterval)
+		defer ticker.Stop()
+		p.emitBuildProgress(candidatePath, destinationBytes)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			case <-ticker.C:
+				p.emitBuildProgress(candidatePath, destinationBytes)
+			}
+		}
+	}()
+	return func() { close(done) }
+}
+
+func (p cliCompactionProgress) emitBuildProgress(candidatePath string, destinationBytes uint64) {
+	info, err := os.Stat(candidatePath)
+	if err != nil {
+		return
+	}
+	written := uint64(info.Size())
+	if destinationBytes == 0 {
+		_, _ = fmt.Fprintf(p.w, "%s\n", localizef(
+			"compact: build %s written",
+			"compact: 構築 %s 書き込み済み",
+			formatCompactBytes(written),
+		))
+		return
+	}
+	_, _ = fmt.Fprintf(p.w, "%s\n", localizef(
+		"compact: build %s / %s (%s)",
+		"compact: 構築 %s / %s (%s)",
+		formatCompactBytes(written),
+		formatCompactBytes(destinationBytes),
+		formatCompactPercent(written, destinationBytes),
+	))
+}
+
+func formatCompactPercent(written, destination uint64) string {
+	if destination == 0 {
+		return "0%"
+	}
+	if written >= destination {
+		return ">100%"
+	}
+	return fmt.Sprintf("%d%%", written*100/destination)
+}
+
+func formatCompactBytes(n uint64) string {
+	const giB = 1024 * 1024 * 1024
+	const miB = 1024 * 1024
+	switch {
+	case n >= giB:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(giB))
+	case n >= miB:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(miB))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/presentation/cli/store_compaction_progress_test.go
+++ b/presentation/cli/store_compaction_progress_test.go
@@ -24,7 +24,6 @@ func TestCLICompactionProgress_OnPhaseWritesStderrOnlyShape(t *testing.T) {
 }
 
 func TestCLICompactionProgress_WatchBuildReportsPercentAndCapsOverEstimate(t *testing.T) {
-	t.Parallel()
 	dir := t.TempDir()
 	candidate := filepath.Join(dir, "replica")
 	if err := os.WriteFile(candidate, bytes.Repeat([]byte("x"), 200), 0o600); err != nil {

--- a/presentation/cli/store_compaction_progress_test.go
+++ b/presentation/cli/store_compaction_progress_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+func TestCLICompactionProgress_OnPhaseWritesStderrOnlyShape(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	p := newCLICompactionProgress(&buf)
+	p.OnPhase(domain.CompactionCandidatePrepared, 35*1024*1024*1024)
+	got := buf.String()
+	if !strings.Contains(got, "compact: candidate_prepared") || !strings.Contains(got, "35.0 GiB") {
+		t.Fatalf("phase line = %q", got)
+	}
+}
+
+func TestCLICompactionProgress_WatchBuildReportsPercentAndCapsOverEstimate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	candidate := filepath.Join(dir, "replica")
+	if err := os.WriteFile(candidate, bytes.Repeat([]byte("x"), 200), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	p := newCLICompactionProgress(&buf)
+	orig := compactBuildProgressInterval
+	compactBuildProgressInterval = 20 * time.Millisecond
+	t.Cleanup(func() { compactBuildProgressInterval = orig })
+	stop := p.WatchBuild(context.Background(), candidate, 100)
+	time.Sleep(50 * time.Millisecond)
+	stop()
+	got := buf.String()
+	if !strings.Contains(got, ">100%") {
+		t.Fatalf("progress = %q, want >100%% cap", got)
+	}
+}
+
+func TestFormatCompactPercent(t *testing.T) {
+	t.Parallel()
+	if got := formatCompactPercent(50, 100); got != "50%" {
+		t.Fatalf("got %q", got)
+	}
+	if got := formatCompactPercent(100, 100); got != ">100%" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #2119

Leaves parent #2108 open.

stderr phase lines and ~10s replica-build byte progress. stdout JSON unchanged.