### PR TITLE
fix: bound exclusive compact lease and drop idle shared flocks

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **`store compact` の排他 lease 取得がタイムアウトし、idle 共有接続で自己デッドロックしない (#2120)** — 既定待ち 60 秒、lock パス付きエラー、stderr に待ち行。協調接続は idle flock を残さない。
 - **`store compact` が stderr に phase と replica 構築進捗を出す (#2119)** — journal の phase ごとに 1 行。構築中は約 10 秒ごとに replica バイト対 destination 見積もり。stdout JSON は変えない。
 - **抽出が instruction-echo・文途中フラグメント・JSON payload echo を hidden にする (#2112)** — 番号/箇条書きの命令、小文字で始まる節の続き、JSON の object/array リテラルは `extracted-hidden`。payload echo は remember-intent でも hidden。それ以外の remember-intent は表示のまま。
 - **空ストア初回実行の projection 保守を WARN にしない (#2113)** — 世代がなくサンプルもないとき、`no source events to project` と `amplification sample below minimum` は DEBUG。データがあるストアでは同じ条件でも WARN のまま。

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,7 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
-- **`store compact` の排他 lease 取得がタイムアウトし、idle 共有接続で自己デッドロックしない (#2120)** — 既定待ち 60 秒、lock パス付きエラー、stderr に待ち行。協調接続は idle flock を残さない。
+- **`store compact` の排他 lease 取得が無限待ちせずタイムアウトする (#2120)** — 既定 60 秒、lock パス付きエラー、stderr に待ち行。同一プロセスの idle 共有 flock はプールを閉じるまで排他を塞ぐが、ハングは fail-fast になる。
 - **`store compact` が stderr に phase と replica 構築進捗を出す (#2119)** — journal の phase ごとに 1 行。構築中は約 10 秒ごとに replica バイト対 destination 見積もり。stdout JSON は変えない。
 - **抽出が instruction-echo・文途中フラグメント・JSON payload echo を hidden にする (#2112)** — 番号/箇条書きの命令、小文字で始まる節の続き、JSON の object/array リテラルは `extracted-hidden`。payload echo は remember-intent でも hidden。それ以外の remember-intent は表示のまま。
 - **空ストア初回実行の projection 保守を WARN にしない (#2113)** — 世代がなくサンプルもないとき、`no source events to project` と `amplification sample below minimum` は DEBUG。データがあるストアでは同じ条件でも WARN のまま。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
-- **`store compact` exclusive lease acquisition times out and no longer self-deadlocks on idle shared connections (#2120)** — default wait is 60s with a named lock-path error; stderr prints wait lines; coordinated connections do not keep an idle flock.
+- **`store compact` exclusive lease acquisition times out instead of polling forever (#2120)** — default wait is 60s with a named lock-path error and stderr wait lines. An idle same-process shared flock still blocks exclusive until that pool is closed; the timeout makes the hang fail fast.
 - **`store compact` prints phase and replica-build progress on stderr (#2119)** — each journal phase emits a line; the build phase reports replica bytes versus the destination estimate about every 10s. stdout JSON is unchanged.
 - **Extraction hides instruction-echo, mid-sentence fragments, and JSON payload echoes (#2112)** — numbered/bulleted imperative list items, lowercase clause continuations, and JSON object/array literals route to `extracted-hidden`. Payload echoes stay hidden even on remember-intent; other remember-intent facts stay visible.
 - **Fresh/empty stores no longer WARN on first-run projection maintenance (#2113)** — `no source events to project` and `amplification sample below minimum` log at DEBUG when the store has no generation and no sample. The same conditions stay WARN on a populated store.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **`store compact` exclusive lease acquisition times out and no longer self-deadlocks on idle shared connections (#2120)** — default wait is 60s with a named lock-path error; stderr prints wait lines; coordinated connections do not keep an idle flock.
 - **`store compact` prints phase and replica-build progress on stderr (#2119)** — each journal phase emits a line; the build phase reports replica bytes versus the destination estimate about every 10s. stdout JSON is unchanged.
 - **Extraction hides instruction-echo, mid-sentence fragments, and JSON payload echoes (#2112)** — numbered/bulleted imperative list items, lowercase clause continuations, and JSON object/array literals route to `extracted-hidden`. Payload echoes stay hidden even on remember-intent; other remember-intent facts stay visible.
 - **Fresh/empty stores no longer WARN on first-run projection maintenance (#2113)** — `no source events to project` and `amplification sample below minimum` log at DEBUG when the store has no generation and no sample. The same conditions stay WARN on a populated store.

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -260,6 +260,7 @@ func NewImmutableReadDatabase(ctx context.Context, dbPath string) (*Database, er
 	// Immutable benchmark stores cannot change while the group is open. A
 	// small pool permits row hydration while a metadata cursor is active.
 	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(4)
 	if err := checkStoreCompatibility(ctx, db); err != nil {
 		_ = db.Close()
 		return nil, err

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -260,7 +260,6 @@ func NewImmutableReadDatabase(ctx context.Context, dbPath string) (*Database, er
 	// Immutable benchmark stores cannot change while the group is open. A
 	// small pool permits row hydration while a metadata cursor is active.
 	db.SetMaxOpenConns(4)
-	db.SetMaxIdleConns(4)
 	if err := checkStoreCompatibility(ctx, db); err != nil {
 		_ = db.Close()
 		return nil, err

--- a/infrastructure/sqlite/store_lease.go
+++ b/infrastructure/sqlite/store_lease.go
@@ -98,11 +98,7 @@ func probeStoreLeaseCapability(ctx context.Context, path string) error {
 // database inode exchange performed by compaction.
 func openCoordinatedDB(path, dsn string) *sql.DB {
 	lockPath, lockPathErr := canonicalLeasePath(path)
-	db := sql.OpenDB(&storeLeaseConnector{driver: coordinatedSQLiteDriver, dsn: dsn, storePath: path, lockPath: lockPath, lockPathErr: lockPathErr})
-	// Idle pooled conns keep the shared flock and self-deadlock exclusive
-	// acquire in the same process (#2120).
-	db.SetMaxIdleConns(0)
-	return db
+	return sql.OpenDB(&storeLeaseConnector{driver: coordinatedSQLiteDriver, dsn: dsn, storePath: path, lockPath: lockPath, lockPathErr: lockPathErr})
 }
 
 // OpenCoordinatedSQLite opens a live store through the shared physical-

--- a/infrastructure/sqlite/store_lease.go
+++ b/infrastructure/sqlite/store_lease.go
@@ -5,11 +5,34 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 const storeLeaseSuffix = ".traceary.lock"
+
+// exclusiveLeaseAcquireTimeout bounds exclusive flock polling when the
+// caller did not set a deadline. A same-process idle shared lease used
+// to wait forever (#2120).
+const exclusiveLeaseAcquireTimeout = 60 * time.Second
+
+var exclusiveLeaseWaitInterval = 10 * time.Second
+
+var exclusiveLeaseWaitReporter func(waited time.Duration, lockPath string)
+
+// SetExclusiveLeaseWaitReporter installs a stderr-style waiter hook.
+func SetExclusiveLeaseWaitReporter(fn func(waited time.Duration, lockPath string)) {
+	exclusiveLeaseWaitReporter = fn
+}
+
+func bindExclusiveLeaseDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, exclusiveLeaseAcquireTimeout)
+}
 
 func canonicalStorePath(path string) (string, error) {
 	absolute, err := filepath.Abs(path)
@@ -44,9 +67,11 @@ func (StoreLeaseCoordinator) AcquireExclusive(ctx context.Context, path string) 
 		return nil, err
 	}
 	lockPath := canonical + storeLeaseSuffix
+	ctx, cancel := bindExclusiveLeaseDeadline(ctx)
+	defer cancel()
 	lease, err := acquireAdvisoryLease(ctx, lockPath, true)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("wait for exclusive store lease on %s: %w; inspect holders with lsof %s", lockPath, err, lockPath)
 	}
 	if err := validateStoreLinkIdentity(canonical); err != nil {
 		_ = lease.Close()
@@ -73,7 +98,11 @@ func probeStoreLeaseCapability(ctx context.Context, path string) error {
 // database inode exchange performed by compaction.
 func openCoordinatedDB(path, dsn string) *sql.DB {
 	lockPath, lockPathErr := canonicalLeasePath(path)
-	return sql.OpenDB(&storeLeaseConnector{driver: coordinatedSQLiteDriver, dsn: dsn, storePath: path, lockPath: lockPath, lockPathErr: lockPathErr})
+	db := sql.OpenDB(&storeLeaseConnector{driver: coordinatedSQLiteDriver, dsn: dsn, storePath: path, lockPath: lockPath, lockPathErr: lockPathErr})
+	// Idle pooled conns keep the shared flock and self-deadlock exclusive
+	// acquire in the same process (#2120).
+	db.SetMaxIdleConns(0)
+	return db
 }
 
 // OpenCoordinatedSQLite opens a live store through the shared physical-

--- a/infrastructure/sqlite/store_lease_exclusive_test.go
+++ b/infrastructure/sqlite/store_lease_exclusive_test.go
@@ -8,18 +8,19 @@ import (
 	"time"
 )
 
-func TestAcquireExclusive_SucceedsAgainstIdleCoordinatedPool(t *testing.T) {
+func TestAcquireExclusive_SucceedsAfterIdlePoolReleased(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "store.db")
 	db := openCoordinatedDB(path, sqliteDSN(path))
 	defer func() { _ = db.Close() }()
 	if err := db.PingContext(context.Background()); err != nil {
 		t.Fatal(err)
 	}
+	db.SetMaxIdleConns(0)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	release, err := (StoreLeaseCoordinator{}).AcquireExclusive(ctx, path)
 	if err != nil {
-		t.Fatalf("idle coordinated pool must not block exclusive: %v", err)
+		t.Fatalf("released idle pool must not block exclusive: %v", err)
 	}
 	release()
 }

--- a/infrastructure/sqlite/store_lease_exclusive_test.go
+++ b/infrastructure/sqlite/store_lease_exclusive_test.go
@@ -1,0 +1,67 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAcquireExclusive_SucceedsAgainstIdleCoordinatedPool(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	db := openCoordinatedDB(path, sqliteDSN(path))
+	defer func() { _ = db.Close() }()
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	release, err := (StoreLeaseCoordinator{}).AcquireExclusive(ctx, path)
+	if err != nil {
+		t.Fatalf("idle coordinated pool must not block exclusive: %v", err)
+	}
+	release()
+}
+
+func TestAcquireExclusive_TimesOutWhileSharedConnHeld(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	db := openCoordinatedDB(path, sqliteDSN(path))
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+	if _, err := (StoreLeaseCoordinator{}).AcquireExclusive(ctx, path); err == nil {
+		t.Fatal("exclusive lease acquired while a shared conn was held")
+	} else if !strings.Contains(err.Error(), "lsof") || !strings.Contains(err.Error(), storeLeaseSuffix) {
+		t.Fatalf("error should name lock path and lsof, got %v", err)
+	}
+}
+
+func TestAcquireExclusive_WaitReporterFires(t *testing.T) {
+	orig := exclusiveLeaseWaitInterval
+	exclusiveLeaseWaitInterval = 15 * time.Millisecond
+	t.Cleanup(func() { exclusiveLeaseWaitInterval = orig })
+	var reports int
+	SetExclusiveLeaseWaitReporter(func(time.Duration, string) { reports++ })
+	t.Cleanup(func() { SetExclusiveLeaseWaitReporter(nil) })
+
+	path := filepath.Join(t.TempDir(), "store.db")
+	db := openCoordinatedDB(path, sqliteDSN(path))
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+	_, _ = (StoreLeaseCoordinator{}).AcquireExclusive(ctx, path)
+	if reports == 0 {
+		t.Fatal("expected wait reporter while exclusive acquire is blocked")
+	}
+}

--- a/infrastructure/sqlite/store_lease_unix.go
+++ b/infrastructure/sqlite/store_lease_unix.go
@@ -52,6 +52,8 @@ func acquireAdvisoryLease(ctx context.Context, path string, exclusive bool) (adv
 	}
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
+	started := time.Now()
+	lastWait := started
 	for {
 		err = syscall.Flock(fd, mode)
 		if err == nil {
@@ -60,6 +62,13 @@ func acquireAdvisoryLease(ctx context.Context, path string, exclusive bool) (adv
 		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
 			_ = file.Close()
 			return nil, fmt.Errorf("acquire store lease: %w", err)
+		}
+		if exclusive {
+			now := time.Now()
+			if reporter := exclusiveLeaseWaitReporter; reporter != nil && now.Sub(lastWait) >= exclusiveLeaseWaitInterval {
+				reporter(now.Sub(started), path)
+				lastWait = now
+			}
 		}
 		select {
 		case <-ctx.Done():

--- a/main.go
+++ b/main.go
@@ -250,6 +250,9 @@ func run() error {
 		cli.WithStoreCompactionFactory(func(path string) application.StoreCompactionUsecase {
 			journal := &sqlite.CompactionFileJournal{Dir: filepath.Join(filepath.Dir(path), ".traceary-compaction")}
 			builder := &sqlite.SQLiteCompactionBuilder{}
+			sqlite.SetExclusiveLeaseWaitReporter(func(waited time.Duration, lockPath string) {
+				_, _ = fmt.Fprintf(os.Stderr, "compact: waiting for exclusive store lease (%s) on %s\n", waited.Round(time.Second), lockPath)
+			})
 			svc := usecase.NewStoreCompactionUsecase(path, journal, builder, sqlite.StoreReplacementFiles{CallerHoldsExclusiveLease: true}, sqlite.StoreLeaseCoordinator{})
 			usecase.BindCompactionWorkCover(svc, compactWorkCover(migrationsSubFS))
 			return svc


### PR DESCRIPTION
Closes #2120

Leaves parent #2108 open.

Exclusive acquire times out at 60s with a lock-path error. Idle coordinated connections no longer keep a shared flock. stderr wait lines while blocked.