### PR TITLE
fix: restore O(1) large-store doctor page and projection signals

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **既定の `doctor` が 2 GiB 以上のストアで O(1) の回収可能ページと projection generation を出す (#2110)** — `mode=ro` で `page_count` / `page_size` / `freelist_count` と `search_projection_state` singleton だけ読む。pragma が答えるとき `store-size` は growth unknown にしない。`store-capacity` は skip のまま。event body、dbstat、migration は読まない。不正な sparse fixture は fail-soft。
 - **`store compact` の排他 lease 取得が無限待ちせずタイムアウトする (#2120)** — 既定 60 秒、lock パス付きエラー、stderr に待ち行。同一プロセスの idle 共有 flock はプールを閉じるまで排他を塞ぐが、ハングは fail-fast になる。
 - **`store compact` が stderr に phase と replica 構築進捗を出す (#2119)** — journal の phase ごとに 1 行。構築中は約 10 秒ごとに replica バイト対 destination 見積もり。stdout JSON は変えない。
 - **抽出が instruction-echo・文途中フラグメント・JSON payload echo を hidden にする (#2112)** — 番号/箇条書きの命令、小文字で始まる節の続き、JSON の object/array リテラルは `extracted-hidden`。payload echo は remember-intent でも hidden。それ以外の remember-intent は表示のまま。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Default `doctor` reports O(1) reclaimable pages and projection generation on ≥2 GiB stores (#2110)** — `mode=ro` reads `page_count` / `page_size` / `freelist_count` plus the `search_projection_state` singleton. `store-size` no longer calls growth unknown when those pragmas answer it. `store-capacity` stays skip; event bodies, dbstat, and migrations stay unread. Invalid sparse fixtures fail-soft.
 - **`store compact` exclusive lease acquisition times out instead of polling forever (#2120)** — default wait is 60s with a named lock-path error and stderr wait lines. An idle same-process shared flock still blocks exclusive until that pool is closed; the timeout makes the hang fail fast.
 - **`store compact` prints phase and replica-build progress on stderr (#2119)** — each journal phase emits a line; the build phase reports replica bytes versus the destination estimate about every 10s. stdout JSON is unchanged.
 - **Extraction hides instruction-echo, mid-sentence fragments, and JSON payload echoes (#2112)** — numbered/bulleted imperative list items, lowercase clause continuations, and JSON object/array literals route to `extracted-hidden`. Payload echoes stay hidden even on remember-intent; other remember-intent facts stay visible.

--- a/application/page_metadata_inspector.go
+++ b/application/page_metadata_inspector.go
@@ -1,0 +1,14 @@
+package application
+
+import (
+	"context"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// PageMetadataInspector reads O(1) SQLite page accounting and the
+// search-projection generation singleton from a store path. It must not
+// walk dbstat, apply migrations, or take the coordinated store lease.
+type PageMetadataInspector interface {
+	InspectPageMetadata(ctx context.Context, dbPath string) (apptypes.StorePageMetadata, error)
+}

--- a/application/types/page_metadata.go
+++ b/application/types/page_metadata.go
@@ -1,0 +1,16 @@
+package types
+
+// StorePageMetadata is the O(1) large-store doctor snapshot: pragma page
+// accounting plus the search-projection generation singleton. It does not
+// include dbstat objects, payload classes, or event/audit bodies.
+type StorePageMetadata struct {
+	PageSizeBytes          int64
+	PageCount              int64
+	FreePages              int64
+	DatabaseBytes          int64
+	ReclaimableBytes       int64
+	ProjectionPresent      bool
+	ProjectionGenerationID string
+	ProjectionState        string
+	ProjectionPhase        string
+}

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -553,6 +553,17 @@ func sqliteReadOnlyDSN(dbPath string) string {
 	return (&url.URL{Scheme: "file", Path: dbPath, RawQuery: values.Encode()}).String()
 }
 
+// sqliteO1ReadOnlyDSN is mode=ro without a busy wait so a live writer
+// turns the large-store doctor probe into an immediate fail-soft.
+func sqliteO1ReadOnlyDSN(dbPath string) string {
+	values := url.Values{}
+	values.Add("mode", "ro")
+	values.Add("_pragma", "query_only(1)")
+	values.Add("_pragma", "busy_timeout(0)")
+	values.Add("_pragma", "foreign_keys(1)")
+	return (&url.URL{Scheme: "file", Path: dbPath, RawQuery: values.Encode()}).String()
+}
+
 func formatTimestamp(timestamp time.Time) string {
 	return timestamp.UTC().Format(time.RFC3339Nano)
 }

--- a/infrastructure/sqlite/page_metadata_inspector.go
+++ b/infrastructure/sqlite/page_metadata_inspector.go
@@ -1,0 +1,76 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// PageMetadataInspector opens a store mode=ro (not immutable, not
+// coordinated) and reads only PRAGMA page_count/page_size/freelist_count
+// plus the search_projection_state singleton.
+type PageMetadataInspector struct{}
+
+// NewPageMetadataInspector creates a path-based O(1) page-metadata reader.
+func NewPageMetadataInspector() *PageMetadataInspector {
+	return &PageMetadataInspector{}
+}
+
+var _ application.PageMetadataInspector = (*PageMetadataInspector)(nil)
+
+// InspectPageMetadata returns pragma page accounting. A missing projection
+// singleton is not an error: ProjectionPresent stays false. An invalid or
+// unreadable store returns an error so the caller can fail-soft.
+func (PageMetadataInspector) InspectPageMetadata(ctx context.Context, dbPath string) (_ apptypes.StorePageMetadata, err error) {
+	db, err := sql.Open("sqlite", sqliteO1ReadOnlyDSN(dbPath))
+	if err != nil {
+		return apptypes.StorePageMetadata{}, xerrors.Errorf("open store for O(1) page metadata: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = xerrors.Errorf("close O(1) page metadata inspection: %w", closeErr)
+		}
+	}()
+	if err := db.PingContext(ctx); err != nil {
+		return apptypes.StorePageMetadata{}, xerrors.Errorf("ping store for O(1) page metadata: %w", err)
+	}
+	var meta apptypes.StorePageMetadata
+	if err := db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&meta.PageSizeBytes); err != nil {
+		return apptypes.StorePageMetadata{}, xerrors.Errorf("read page_size: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&meta.PageCount); err != nil {
+		return apptypes.StorePageMetadata{}, xerrors.Errorf("read page_count: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, "PRAGMA freelist_count").Scan(&meta.FreePages); err != nil {
+		return apptypes.StorePageMetadata{}, xerrors.Errorf("read freelist_count: %w", err)
+	}
+	meta.DatabaseBytes = meta.PageSizeBytes * meta.PageCount
+	meta.ReclaimableBytes = meta.PageSizeBytes * meta.FreePages
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(active_generation_id,''), COALESCE(state,''), COALESCE(phase,'') FROM search_projection_state WHERE singleton=1`).Scan(
+		&meta.ProjectionGenerationID,
+		&meta.ProjectionState,
+		&meta.ProjectionPhase,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) || isMissingProjectionStateTable(err) {
+			return meta, nil
+		}
+		return apptypes.StorePageMetadata{}, xerrors.Errorf("read search_projection_state singleton: %w", err)
+	}
+	meta.ProjectionPresent = true
+	return meta, nil
+}
+
+func isMissingProjectionStateTable(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no such table") && strings.Contains(message, "search_projection_state")
+}

--- a/infrastructure/sqlite/page_metadata_inspector_test.go
+++ b/infrastructure/sqlite/page_metadata_inspector_test.go
@@ -1,0 +1,108 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestPageMetadataInspectorReadsPragmasAndProjectionSingleton(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pages.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := "PRIVATE-SENTINEL-page-metadata"
+	statements := []string{
+		`PRAGMA journal_mode=WAL`,
+		`CREATE TABLE events (id TEXT PRIMARY KEY, body TEXT)`,
+		`INSERT INTO events VALUES ('evt-1', ?)`,
+		`CREATE TABLE scratch (payload BLOB)`,
+		`INSERT INTO scratch(payload) VALUES (zeroblob(65536))`,
+		`DELETE FROM scratch`,
+		`CREATE TABLE search_projection_state (
+			singleton INTEGER PRIMARY KEY CHECK (singleton=1),
+			active_generation_id TEXT,
+			state TEXT,
+			phase TEXT
+		)`,
+		`INSERT INTO search_projection_state(singleton, active_generation_id, state, phase)
+		 VALUES (1, 'gen-o1', 'complete', 'idle')`,
+	}
+	for index, statement := range statements {
+		var execErr error
+		if strings.Contains(statement, "?") {
+			_, execErr = db.Exec(statement, strings.Repeat(secret, 20))
+		} else {
+			_, execErr = db.Exec(statement)
+		}
+		if execErr != nil {
+			t.Fatalf("exec fixture statement %d: %v", index, execErr)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := infra.NewPageMetadataInspector().InspectPageMetadata(context.Background(), path)
+	if err != nil {
+		t.Fatalf("InspectPageMetadata() error = %v", err)
+	}
+	if meta.PageSizeBytes <= 0 || meta.PageCount <= 0 {
+		t.Fatalf("page accounting missing: %+v", meta)
+	}
+	if meta.DatabaseBytes != meta.PageSizeBytes*meta.PageCount {
+		t.Fatalf("database bytes = %d, want %d*%d", meta.DatabaseBytes, meta.PageSizeBytes, meta.PageCount)
+	}
+	if meta.ReclaimableBytes != meta.PageSizeBytes*meta.FreePages {
+		t.Fatalf("reclaimable = %d, want %d*%d", meta.ReclaimableBytes, meta.PageSizeBytes, meta.FreePages)
+	}
+	if meta.FreePages == 0 || meta.ReclaimableBytes == 0 {
+		t.Fatalf("want a non-zero freelist after delete, got %+v", meta)
+	}
+	if !meta.ProjectionPresent || meta.ProjectionGenerationID != "gen-o1" || meta.ProjectionState != "complete" || meta.ProjectionPhase != "idle" {
+		t.Fatalf("projection singleton = %+v", meta)
+	}
+}
+
+func TestPageMetadataInspectorOmitsMissingProjectionTable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-projection.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE sample (value TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := infra.NewPageMetadataInspector().InspectPageMetadata(context.Background(), path)
+	if err != nil {
+		t.Fatalf("InspectPageMetadata() error = %v", err)
+	}
+	if meta.ProjectionPresent || meta.ProjectionGenerationID != "" {
+		t.Fatalf("want absent projection, got %+v", meta)
+	}
+	if meta.PageCount == 0 {
+		t.Fatalf("want pragma page_count, got %+v", meta)
+	}
+}
+
+func TestPageMetadataInspectorRejectsInvalidSQLiteFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-sqlite.db")
+	if err := os.WriteFile(path, []byte("not a database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := infra.NewPageMetadataInspector().InspectPageMetadata(context.Background(), path)
+	if err == nil {
+		t.Fatal("InspectPageMetadata() error = nil, want invalid-file failure")
+	}
+}

--- a/infrastructure/sqlite/sqlite_open_inventory_test.go
+++ b/infrastructure/sqlite/sqlite_open_inventory_test.go
@@ -19,6 +19,7 @@ func TestRuntimeSQLiteOpenInventoryIsExplicit(t *testing.T) {
 		"infrastructure/sqlite/compaction_sqlite.go":                  2, // EX-held source/candidate only.
 		"infrastructure/sqlite/compaction_copy_filter.go":             2, // EX-held work copy plus EX-held in-place incremental vacuum.
 		"infrastructure/sqlite/database.go":                           1, // in-memory driver probe only.
+		"infrastructure/sqlite/page_metadata_inspector.go":            1, // mode=ro O(1) doctor probe; no coordinated lease, no dbstat.
 		"infrastructure/sqlite/payload_rehearsal.go":                  7, // copied rehearsal targets only.
 		"infrastructure/sqlite/payload_rehearsal_migration.go":        1, // copied migration target.
 		"infrastructure/sqlite/payload_rehearsal_target.go":           1, // copied rehearsal target.

--- a/main.go
+++ b/main.go
@@ -242,6 +242,7 @@ func run() error {
 		cli.WithContext(contextUsecase),
 		cli.WithStoreManagement(storeManagementUsecase),
 		cli.WithCapacityInspector(sqlite.NewCapacityInspector(db)),
+		cli.WithPageMetadataInspector(sqlite.NewPageMetadataInspector()),
 		cli.WithOperatorCostInspector(sqlite.NewOperatorCostInspector(db)),
 		cli.WithPayloadCodecInspector(sqlite.NewPayloadCodecInspector(db)),
 		cli.WithAttestationAnchorInspector(sqlite.NewAttestationAnchorInspector(db)),

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -346,7 +346,8 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		report.Mode = doctorModeMetadataOnlyLargeStore
 		residentCost := residentOnlyOperatorCost(snapshot.Size)
 		report.OperatorCost = &residentCost
-		report.Checks = append(report.Checks, unknownStoreGrowthCheck(snapshot.Size, resolvedDBPath, "default doctor is filesystem-metadata-only for stores at or above 2 GiB; inspect a reviewed copy for detailed signals"))
+		pageMeta, pageErr := c.inspectLargeStorePageMetadata(ctx, resolvedDBPath)
+		report.Checks = append(report.Checks, largeStoreSizeCheck(snapshot, resolvedDBPath, pageMeta, pageErr))
 		// Do not call InspectCapacity here: that opens SQLite and may walk
 		// dbstat. The store-capacity check is filesystem-metadata only.
 		report.Checks = append(report.Checks, skippedStoreCapacityCheck(
@@ -359,16 +360,18 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		report.Checks = append(report.Checks, inspectCompactRollbackCopies(resolvedDBPath))
 		report.Checks = append(report.Checks, buildOperatorCostCheck(residentCost))
 		report.Checks = append(report.Checks, inspectTracearyOnPath())
-		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(snapshot, resolvedDBPath))
+		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(snapshot, resolvedDBPath, pageErr == nil))
+		report.Checks = append(report.Checks, largeStoreProjectionGenerationCheck(pageMeta, pageErr))
 		if c.attestationAnchorInspector != nil {
 			report.Checks = append(report.Checks, c.inspectAttestationAnchor(ctx, resolvedDBPath, false))
 		}
-		// This is an intentional, successful bounded outcome. Do not initialize
-		// SQLite, list events, open spool payloads, inspect payload codec, or
-		// inspect client state here: those operations can block behind a live
-		// writer and some inspect event bodies/payloads. Hook spool is still
-		// reported via directory entry counts and byte sizes only (pending /
-		// stale inflight / dead-letter).
+		// This is an intentional, successful bounded outcome. The only SQLite
+		// open is the O(1) mode=ro pragma + projection-state read. Do not
+		// initialize, list events, open spool payloads, inspect payload codec,
+		// walk dbstat, or inspect client state here: those operations can
+		// block behind a live writer and some inspect event bodies/payloads.
+		// Hook spool is still reported via directory entry counts and byte
+		// sizes only (pending / stale inflight / dead-letter).
 		report.Checks = append(report.Checks, inspectHookSpoolFilesystemMetadata())
 		if c.workspaceIdentity != nil {
 			report.Checks = append(report.Checks, skippedWorkspaceAliasesCheck())

--- a/presentation/cli/doctor_report.go
+++ b/presentation/cli/doctor_report.go
@@ -137,7 +137,7 @@ func buildDoctorSections(checks []doctorCheck) []doctorSection {
 
 func doctorSectionNameForCheck(name string) string {
 	switch {
-	case name == "db-path" || name == "db-write" || name == "store-capacity" || name == "search-projection-budget" || name == "search-projection-parked" || name == "stale-active-sessions" || name == "archive-retention" || name == "offline-migrations" || name == "workspace-aliases" || strings.HasSuffix(name, "-capacity-retention") || name == "audit-reliability" || name == "content-event-reliability" || name == "sensitive-access-audit" || name == "retry-loops" || name == "body-codec":
+	case name == "db-path" || name == "db-write" || name == "store-capacity" || name == "search-projection-budget" || name == "search-projection-parked" || name == "search-projection-generation" || name == "stale-active-sessions" || name == "archive-retention" || name == "offline-migrations" || name == "workspace-aliases" || strings.HasSuffix(name, "-capacity-retention") || name == "audit-reliability" || name == "content-event-reliability" || name == "sensitive-access-audit" || name == "retry-loops" || name == "body-codec":
 		return "Database"
 	case name == "config" || name == "project-dir" || name == "version" || name == "path":
 		return "Environment"

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,8 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	apptypes "github.com/duck8823/traceary/application/types"
 )
+
+var errLargeStorePageMetadataUnavailable = errors.New("page metadata inspector unavailable")
 
 // storeSizeWarnBytes is the on-disk size above which multi-GB cold opens
 // routinely approach host hook budgets (10s packaged). Measured dogfood
@@ -22,6 +27,7 @@ const (
 	projectionGrowthWarnBytes  = int64(256 << 20)
 	doctorGrowthLatencyWarn    = 1500 * time.Millisecond
 	doctorGrowthInspectTimeout = 2 * time.Second
+	largeStoreO1InspectTimeout = 500 * time.Millisecond
 )
 
 type storeGrowthEvidence struct {
@@ -365,8 +371,8 @@ const (
 	doctorModeMetadataOnlyLargeStore = "metadata_only_large_store"
 	// doctorLargeStoreMetadataOnlyBytes is an operational threshold, not a
 	// retention target or a store-size limit. Above it, the default doctor
-	// command returns a finite metadata-only result instead of opening SQLite
-	// and traversing content-bearing diagnostics.
+	// command returns a finite metadata-only result: O(1) pragma reads only,
+	// never dbstat, migrations, or content-bearing diagnostics.
 	doctorLargeStoreMetadataOnlyBytes int64 = 2 << 30 // 2 GiB
 )
 
@@ -377,7 +383,120 @@ func isLargeStoreForBoundedDoctor(snapshot storeFileSnapshot) bool {
 	return snapshot.Err == nil && snapshot.Exists && snapshot.Regular && snapshot.Size >= doctorLargeStoreMetadataOnlyBytes
 }
 
-func boundedLargeStoreDoctorCheck(snapshot storeFileSnapshot, dbPath string) doctorCheck {
+func (c *RootCLI) inspectLargeStorePageMetadata(ctx context.Context, dbPath string) (apptypes.StorePageMetadata, error) {
+	if c == nil || c.pageMetadataInspector == nil {
+		return apptypes.StorePageMetadata{}, errLargeStorePageMetadataUnavailable
+	}
+	inspectCtx, cancel := context.WithTimeout(ctx, largeStoreO1InspectTimeout)
+	defer cancel()
+	meta, err := c.pageMetadataInspector.InspectPageMetadata(inspectCtx, dbPath)
+	if err != nil {
+		return apptypes.StorePageMetadata{}, xerrors.Errorf("inspect O(1) page metadata: %w", err)
+	}
+	return meta, nil
+}
+
+func largeStoreSizeCheck(snapshot storeFileSnapshot, dbPath string, meta apptypes.StorePageMetadata, inspectErr error) doctorCheck {
+	if inspectErr != nil {
+		return unknownStoreGrowthCheck(snapshot.Size, dbPath, "O(1) page metadata unavailable")
+	}
+	evidence := storeGrowthEvidence{
+		DatabaseBytes:    meta.DatabaseBytes,
+		ReclaimableBytes: meta.ReclaimableBytes,
+	}
+	if evidence.DatabaseBytes == 0 {
+		evidence.DatabaseBytes = snapshot.Size
+	}
+	if free, freeErr := inspectDoctorDiskFree(dbPath); freeErr == nil {
+		evidence.FilesystemFreeBytes = free
+		evidence.FilesystemFreeAvailable = true
+	}
+	check := evaluateLargeStoreGrowthBudget(snapshot.Size, evidence)
+	check.FixCommand = "traceary store compact --db-path " + shellQuote(dbPath)
+	return check
+}
+
+func evaluateLargeStoreGrowthBudget(filesystemBytes int64, e storeGrowthEvidence) doctorCheck {
+	reasons := make([]string, 0, 3)
+	compareAgainst := e.DatabaseBytes
+	if filesystemBytes > compareAgainst {
+		compareAgainst = filesystemBytes
+	}
+	if e.ReclaimableBytes >= 256<<20 && ratioAtLeast(e.ReclaimableBytes, compareAgainst, 10) {
+		reasons = append(reasons, "reclaimable")
+	}
+	if !e.FilesystemFreeAvailable {
+		reasons = append(reasons, "headroom_unknown")
+	} else if e.FilesystemFreeBytes <= compactionHeadroomThreshold(compareAgainst) {
+		reasons = append(reasons, "headroom")
+	}
+	if len(reasons) == 0 {
+		return doctorCheck{
+			Name:   "store-size",
+			Status: doctorStatusPass,
+			Message: localizef(
+				"store growth signals (O(1) large-store): filesystem=%s database=%s reclaimable=%s free=%s",
+				"store growth signal (O(1) large-store): filesystem=%s database=%s reclaimable=%s free=%s",
+				formatByteSize(filesystemBytes),
+				formatByteSize(e.DatabaseBytes),
+				formatByteSize(e.ReclaimableBytes),
+				formatDoctorFree(e),
+			),
+		}
+	}
+	return doctorCheck{
+		Name:   "store-size",
+		Status: doctorStatusWarn,
+		Message: localizef(
+			"store growth warning (%s): filesystem=%s database=%s reclaimable=%s free=%s",
+			"store growth warning (%s): filesystem=%s database=%s reclaimable=%s free=%s",
+			strings.Join(reasons, ","),
+			formatByteSize(filesystemBytes),
+			formatByteSize(e.DatabaseBytes),
+			formatByteSize(e.ReclaimableBytes),
+			formatDoctorFree(e),
+		),
+		Hint: Localize(
+			"rewrite with `traceary store compact` to return reclaimable pages (copy-filter, body discard, VACUUM INTO, atomic exchange). This is not a preview. Keep the rollback file until you accept the result (`traceary store compact rollback RUN_ID`). Do not run in-place VACUUM",
+			"書き換えは `traceary store compact` です（copy-filter、本文破棄、VACUUM INTO、atomic exchange）。preview ではありません。受け入れるまで rollback ファイルを残してください（`traceary store compact rollback RUN_ID`）。in-place VACUUM は使わないでください",
+		),
+	}
+}
+
+func largeStoreProjectionGenerationCheck(meta apptypes.StorePageMetadata, inspectErr error) doctorCheck {
+	const name = "search-projection-generation"
+	if inspectErr != nil {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusSkip,
+			Message: Localize("search-projection generation was not read (O(1) page metadata unavailable)", "search-projection generation は読み取れませんでした（O(1) page metadata を取得できません）"),
+		}
+	}
+	if !meta.ProjectionPresent {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusSkip,
+			Message: Localize("search-projection generation singleton is not present", "search-projection generation singleton はありません"),
+		}
+	}
+	status := doctorStatusPass
+	if meta.ProjectionState != "" && meta.ProjectionState != "complete" {
+		status = doctorStatusWarn
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: status,
+		Message: localizef(
+			"search-projection generation=%s state=%s phase=%s",
+			"search-projection generation=%s state=%s phase=%s",
+			meta.ProjectionGenerationID,
+			meta.ProjectionState,
+			meta.ProjectionPhase,
+		),
+	}
+}
+
+func boundedLargeStoreDoctorCheck(snapshot storeFileSnapshot, dbPath string, o1ProbeOK bool) doctorCheck {
 	if snapshot.Err != nil || !snapshot.Exists || !snapshot.Regular {
 		return doctorCheck{
 			Name:    "large-store-diagnostics",
@@ -386,14 +505,22 @@ func boundedLargeStoreDoctorCheck(snapshot storeFileSnapshot, dbPath string) doc
 		}
 	}
 	quoted := shellQuote(dbPath)
-	return doctorCheck{
-		Name:   "large-store-diagnostics",
-		Status: doctorStatusWarn,
-		Message: localizef(
-			"bounded metadata-only doctor result for %s store: SQLite open, migrations, event bodies, command payloads, hook spools, credentials, and identifier samples were not read",
-			"%s のストアに対する bounded metadata-only doctor 結果です。SQLite の open、migration、event body、command payload、hook spool、credential、identifier sample は読み取りませんでした",
+	message := localizef(
+		"bounded metadata-only doctor result for %s store: SQLite open, migrations, event bodies, command payloads, hook spools, credentials, and identifier samples were not read",
+		"%s のストアに対する bounded metadata-only doctor 結果です。SQLite の open、migration、event body、command payload、hook spool、credential、identifier sample は読み取りませんでした",
+		formatByteSize(snapshot.Size),
+	)
+	if o1ProbeOK {
+		message = localizef(
+			"bounded metadata-only doctor result for %s store: O(1) pragma and projection-state reads only; migrations, event bodies, command payloads, hook spool payloads, credentials, identifier samples, and dbstat were not read",
+			"%s のストアに対する bounded metadata-only doctor 結果です。O(1) の pragma と projection-state だけを読みます。migration、event body、command payload、hook spool payload、credential、identifier sample、dbstat は読み取りませんでした",
 			formatByteSize(snapshot.Size),
-		),
+		)
+	}
+	return doctorCheck{
+		Name:    "large-store-diagnostics",
+		Status:  doctorStatusWarn,
+		Message: message,
 		// Whether the retired legacy search index is present cannot be known
 		// without opening SQLite, which this mode exists to avoid. compact
 		// drops the family if it is still there.

--- a/presentation/cli/doctor_store_size_test.go
+++ b/presentation/cli/doctor_store_size_test.go
@@ -225,7 +225,7 @@ func TestStoreSnapshotSurvivesDeleteAfterSingleStat(t *testing.T) {
 	if !isLargeStoreForBoundedDoctor(snapshot) {
 		t.Fatal("snapshot lost large-store decision after delete")
 	}
-	check := boundedLargeStoreDoctorCheck(snapshot, "/tmp/other store.db")
+	check := boundedLargeStoreDoctorCheck(snapshot, "/tmp/other store.db", false)
 	if check.Status != doctorStatusWarn || !strings.Contains(check.Message, "were not read") {
 		t.Fatalf("check=%#v", check)
 	}
@@ -245,6 +245,51 @@ func TestStoreGrowthMessageDistinguishesUnknownAndMeasuredZeroFree(t *testing.T)
 	}
 	if !strings.Contains(zero.Message, "free=0 B") {
 		t.Fatalf("zero=%q", zero.Message)
+	}
+}
+
+func TestEvaluateLargeStoreGrowthBudgetReportsReclaimable(t *testing.T) {
+	pass := evaluateLargeStoreGrowthBudget(3<<30, storeGrowthEvidence{
+		DatabaseBytes:           3 << 30,
+		ReclaimableBytes:        64 << 20,
+		FilesystemFreeBytes:     20 << 30,
+		FilesystemFreeAvailable: true,
+	})
+	if pass.Status != doctorStatusPass || !strings.Contains(pass.Message, "reclaimable=64.0 MiB") {
+		t.Fatalf("pass=%#v", pass)
+	}
+	if strings.Contains(pass.Message, "unknowable") || strings.Contains(pass.Message, "不明") {
+		t.Fatalf("pass still treats growth as unknown: %q", pass.Message)
+	}
+	warn := evaluateLargeStoreGrowthBudget(3<<30, storeGrowthEvidence{
+		DatabaseBytes:           3 << 30,
+		ReclaimableBytes:        400 << 20,
+		FilesystemFreeBytes:     20 << 30,
+		FilesystemFreeAvailable: true,
+	})
+	if warn.Status != doctorStatusWarn || !strings.Contains(warn.Message, "reclaimable") {
+		t.Fatalf("warn=%#v", warn)
+	}
+	if !strings.Contains(warn.Message, "reclaimable=400.0 MiB") {
+		t.Fatalf("warn message = %q", warn.Message)
+	}
+}
+
+func TestLargeStoreSizeCheckFailSoftWhenInspectorErrors(t *testing.T) {
+	snapshot := storeFileSnapshot{Size: 2 << 30, Regular: true, Exists: true}
+	check := largeStoreSizeCheck(snapshot, "/tmp/large.db", apptypes.StorePageMetadata{}, errLargeStorePageMetadataUnavailable)
+	if check.Status != doctorStatusWarn || !strings.Contains(check.Message, "unknown") {
+		t.Fatalf("check=%#v", check)
+	}
+	generation := largeStoreProjectionGenerationCheck(apptypes.StorePageMetadata{}, errLargeStorePageMetadataUnavailable)
+	if generation.Status != doctorStatusSkip {
+		t.Fatalf("generation=%#v", generation)
+	}
+}
+
+func TestDoctorSectionNameForCheckMapsProjectionGenerationToDatabase(t *testing.T) {
+	if got := doctorSectionNameForCheck("search-projection-generation"); got != "Database" {
+		t.Fatalf("section=%q", got)
 	}
 }
 

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,10 +14,12 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	_ "modernc.org/sqlite"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
@@ -618,6 +621,119 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 	if residueFixes > 1 {
 		t.Fatalf("hook-state-residue fix ran %d times, want at most 1", residueFixes)
 	}
+	generation := statusByName(report, "search-projection-generation")
+	if generation.Status != "skip" {
+		t.Fatalf("search-projection-generation = %#v, want skip on invalid sparse fixture", generation)
+	}
+}
+
+func TestRootCLI_DoctorLargeStoreReportsO1PageAndProjectionSignals(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	setTracearyPathToCurrentExecutable(t)
+	largeStore := writeValidSparseLargeStore(t)
+	store := &storeManagementUsecaseStub{}
+	events := &eventUsecaseStub{}
+	capacity := &panicCapacityInspector{}
+	codec := &panicPayloadCodecInspector{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(store),
+		cli.WithEvent(events),
+		cli.WithCapacityInspector(capacity),
+		cli.WithPageMetadataInspector(infra.NewPageMetadataInspector()),
+		cli.WithPayloadCodecInspector(codec),
+	).Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", largeStore, "--json", "--warnings-ok"})
+
+	started := time.Now()
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("O(1) large-store doctor took %s, want <= 1s", elapsed)
+	}
+	report := decodeDoctorReport(t, stdout.Bytes())
+	if report.Mode != "metadata_only_large_store" {
+		t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
+	}
+	if store.initCalled {
+		t.Fatal("large-store doctor initialized SQLite")
+	}
+	if events.listCalls != 0 {
+		t.Fatalf("large-store doctor listed %d events", events.listCalls)
+	}
+	if capacity.calls != 0 {
+		t.Fatalf("large-store capacity calls=%d, want zero", capacity.calls)
+	}
+	size := statusByName(report, "store-size")
+	if strings.Contains(size.Message, "unknown") || strings.Contains(size.Message, "不明") {
+		t.Fatalf("store-size still unknown: %#v", size)
+	}
+	if !strings.Contains(size.Message, "reclaimable=") {
+		t.Fatalf("store-size = %#v, want reclaimable bytes", size)
+	}
+	capacityCheck := statusByName(report, "store-capacity")
+	if capacityCheck.Status != "skip" || !strings.Contains(capacityCheck.Message, "filesystem-metadata-only") {
+		t.Fatalf("store-capacity = %#v, want skip", capacityCheck)
+	}
+	generation := statusByName(report, "search-projection-generation")
+	if generation.Status != "pass" || !strings.Contains(generation.Message, "generation=gen-o1") || !strings.Contains(generation.Message, "state=complete") {
+		t.Fatalf("search-projection-generation = %#v", generation)
+	}
+	if generation.Section != "Database" {
+		t.Fatalf("search-projection-generation section = %q", generation.Section)
+	}
+	diag := statusByName(report, "large-store-diagnostics")
+	if diag.Status != "warn" || !strings.Contains(diag.Message, "were not read") {
+		t.Fatalf("large-store-diagnostics = %#v", diag)
+	}
+	assertDoctorCheckNamesUnique(t, report)
+}
+
+func writeValidSparseLargeStore(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "valid-large.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("Open sqlite fixture: %v", err)
+	}
+	statements := []string{
+		`PRAGMA journal_mode=WAL`,
+		`CREATE TABLE scratch (payload BLOB)`,
+		`INSERT INTO scratch(payload) VALUES (zeroblob(65536))`,
+		`DELETE FROM scratch`,
+		`CREATE TABLE search_projection_state (
+			singleton INTEGER PRIMARY KEY CHECK (singleton=1),
+			active_generation_id TEXT,
+			state TEXT,
+			phase TEXT
+		)`,
+		`INSERT INTO search_projection_state(singleton, active_generation_id, state, phase)
+		 VALUES (1, 'gen-o1', 'complete', 'idle')`,
+	}
+	for index, statement := range statements {
+		if _, execErr := db.Exec(statement); execErr != nil {
+			_ = db.Close()
+			t.Fatalf("exec fixture statement %d: %v", index, execErr)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close sqlite fixture: %v", err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile for truncate: %v", err)
+	}
+	if err := file.Truncate(2 << 30); err != nil {
+		_ = file.Close()
+		t.Fatalf("Truncate() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close truncated fixture: %v", err)
+	}
+	return path
 }
 
 func TestRootCLI_DoctorJSONIncludesOperatorCost(t *testing.T) {

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -41,6 +41,7 @@ type RootCLI struct {
 	context                    usecase.ContextUsecase
 	storeManagement            usecase.StoreManagementUsecase
 	capacityInspector          application.CapacityInspector
+	pageMetadataInspector      application.PageMetadataInspector
 	operatorCostInspector      application.OperatorCostInspector
 	payloadCodecInspector      application.PayloadCodecInspector
 	attestationAnchorInspector application.AttestationAnchorInspector
@@ -221,6 +222,11 @@ func WithStoreManagement(storeManagement usecase.StoreManagementUsecase) RootCLI
 // WithCapacityInspector injects metadata-only SQLite capacity diagnostics.
 func WithCapacityInspector(inspector application.CapacityInspector) RootCLIOption {
 	return func(c *RootCLI) { c.capacityInspector = inspector }
+}
+
+// WithPageMetadataInspector injects the O(1) large-store pragma reader.
+func WithPageMetadataInspector(inspector application.PageMetadataInspector) RootCLIOption {
+	return func(c *RootCLI) { c.pageMetadataInspector = inspector }
 }
 
 // WithOperatorCostInspector injects this-store measured cost for doctor.


### PR DESCRIPTION
Closes #2110

Leaves parent #2108 open.

Default doctor on stores at or above 2 GiB now reads page/freelist pragmas and the search-projection generation singleton via mode=ro. store-size reports reclaimable bytes. store-capacity stays skip. Invalid sparse fixtures fail-soft. No InspectCapacity, dbstat, or migrations.