### PR TITLE
fix: count and prune orphan hook-spool tmp files

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **`doctor` が hook-spool の orphan `*.tmp` を `stale_inflight` に数え、14 日超を prune する (#2115)** — 1 時間超は既存カウンタへ。`doctor --fix` / `--dry-run` に `pruned_tmp=` を追加。直後の write-rename 一時ファイルは数えも消しもしない。
 - **`store compact --projection-rebuild` の JSON に `result_kind` を付ける (#2111)** — start/置き換えは `generation`、hash 一致 resume は `run`。既存フィールドはそのまま。分岐は `result_kind`。`--projection-abort` は変えない。
 - **既定の `doctor` が 2 GiB 以上のストアで O(1) の回収可能ページと projection generation を出す (#2110)** — `mode=ro` で `page_count` / `page_size` / `freelist_count` と `search_projection_state` singleton だけ読む。pragma が答えるとき `store-size` は growth unknown にしない。`store-capacity` は skip のまま。event body、dbstat、migration は読まない。不正な sparse fixture は fail-soft。
 - **`store compact` の排他 lease 取得が無限待ちせずタイムアウトする (#2120)** — 既定 60 秒、lock パス付きエラー、stderr に待ち行。同一プロセスの idle 共有 flock はプールを閉じるまで排他を塞ぐが、ハングは fail-fast になる。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **`doctor` counts orphan hook-spool `*.tmp` leftovers as `stale_inflight` and prunes them after 14 days (#2115)** — files older than 1h enter the existing counter; `doctor --fix` / `--dry-run` add `pruned_tmp=`. Fresh write-rename temps are neither counted nor deleted.
 - **`store compact --projection-rebuild` JSON carries `result_kind` (#2111)** — start/replace emit `generation`; matching-hash resume emits `run`. Existing fields stay. Branch on `result_kind`; do not sniff the shape. `--projection-abort` is unchanged.
 - **Default `doctor` reports O(1) reclaimable pages and projection generation on ≥2 GiB stores (#2110)** — `mode=ro` reads `page_count` / `page_size` / `freelist_count` plus the `search_projection_state` singleton. `store-size` no longer calls growth unknown when those pragmas answer it. `store-capacity` stays skip; event bodies, dbstat, and migrations stay unread. Invalid sparse fixtures fail-soft.
 - **`store compact` exclusive lease acquisition times out instead of polling forever (#2120)** — default wait is 60s with a named lock-path error and stderr wait lines. An idle same-process shared flock still blocks exclusive until that pool is closed; the timeout makes the hang fail fast.

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -42,7 +42,12 @@ const (
 	// one minute belongs to a process that did not finish its normal
 	// success/failure transition and is safe to make replayable.
 	hookSpoolInflightStaleAge = time.Minute
-	hookSpoolDeadDirName      = "dead"
+	// hookSpoolTmpStaleAge is how old a write-rename leftover (*.tmp) must
+	// be before doctor counts it as stale_inflight. The publish window is
+	// seconds; one hour is a generous bound so a live writer is never
+	// counted (#2115).
+	hookSpoolTmpStaleAge = time.Hour
+	hookSpoolDeadDirName = "dead"
 	// Dead-letter is append-only unless the operator asks doctor --fix to
 	// prune files older than the retention window (#2007).
 	hookSpoolDeadWarnCount    = 100
@@ -895,36 +900,52 @@ func inspectHookSpoolFilesystemStats(now time.Time) (hookSpoolFilesystemStats, e
 		return stats, xerrors.Errorf("failed to read hook spool directory: %w", err)
 	}
 	for _, entry := range entries {
-		name := entry.Name()
-		path := filepath.Join(dir, name)
-		if entry.IsDir() {
-			if name != hookSpoolDeadDirName {
-				continue
-			}
-			deadCount, deadBytes, deadErr := countDirJSONEntries(path)
-			if deadErr != nil {
-				return stats, deadErr
-			}
-			stats.DeadCount = deadCount
-			stats.DeadBytes = deadBytes
-			continue
-		}
-		info, infoErr := entry.Info()
-		if infoErr != nil {
-			return stats, xerrors.Errorf("failed to inspect hook spool entry: %w", infoErr)
-		}
-		switch {
-		case strings.HasSuffix(name, ".json"):
-			stats.PendingCount++
-			stats.PendingBytes += info.Size()
-		case strings.HasSuffix(name, ".inflight"):
-			if now.Sub(info.ModTime()) >= hookSpoolInflightStaleAge {
-				stats.StaleInflightCount++
-				stats.StaleInflightBytes += info.Size()
-			}
+		if addErr := addHookSpoolFilesystemEntry(&stats, dir, entry, now); addErr != nil {
+			return stats, addErr
 		}
 	}
 	return stats, nil
+}
+
+func addHookSpoolFilesystemEntry(stats *hookSpoolFilesystemStats, dir string, entry os.DirEntry, now time.Time) error {
+	name := entry.Name()
+	path := filepath.Join(dir, name)
+	if entry.IsDir() {
+		if name != hookSpoolDeadDirName {
+			return nil
+		}
+		deadCount, deadBytes, deadErr := countDirJSONEntries(path)
+		if deadErr != nil {
+			return deadErr
+		}
+		stats.DeadCount = deadCount
+		stats.DeadBytes = deadBytes
+		return nil
+	}
+	info, infoErr := entry.Info()
+	if infoErr != nil {
+		// A write-rename can remove *.tmp between ReadDir and Info.
+		if os.IsNotExist(infoErr) && strings.HasSuffix(name, ".tmp") {
+			return nil
+		}
+		return xerrors.Errorf("failed to inspect hook spool entry: %w", infoErr)
+	}
+	switch {
+	case strings.HasSuffix(name, ".json"):
+		stats.PendingCount++
+		stats.PendingBytes += info.Size()
+	case strings.HasSuffix(name, ".inflight"):
+		if now.Sub(info.ModTime()) >= hookSpoolInflightStaleAge {
+			stats.StaleInflightCount++
+			stats.StaleInflightBytes += info.Size()
+		}
+	case strings.HasSuffix(name, ".tmp"):
+		if now.Sub(info.ModTime()) >= hookSpoolTmpStaleAge {
+			stats.StaleInflightCount++
+			stats.StaleInflightBytes += info.Size()
+		}
+	}
+	return nil
 }
 
 func countDirJSONEntries(dir string) (int, int64, error) {
@@ -1113,6 +1134,50 @@ func pruneHookSpoolDeadLetters(now time.Time, dryRun bool) (pruned, remaining in
 	return pruned, remaining, nil
 }
 
+func pruneHookSpoolOrphanTmpFiles(now time.Time, dryRun bool) (pruned, remaining int, err error) {
+	dir, err := hookSpoolDir()
+	if err != nil {
+		return 0, 0, err
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, xerrors.Errorf("failed to read hook spool directory: %w", err)
+	}
+	cutoff := now.Add(-hookSpoolDeadRetention)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tmp") {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			if os.IsNotExist(infoErr) {
+				continue
+			}
+			return pruned, remaining, xerrors.Errorf("failed to inspect hook spool tmp file: %w", infoErr)
+		}
+		if !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if pruned >= hookSpoolDeadPruneLimit {
+			remaining++
+			continue
+		}
+		if dryRun {
+			pruned++
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+			return pruned, remaining, xerrors.Errorf("failed to prune orphan hook spool tmp file: %w", removeErr)
+		}
+		pruned++
+	}
+	return pruned, remaining, nil
+}
+
 // inspectHookSpoolFilesystemMetadata builds a doctor check from directory
 // metadata only (entry counts + byte sizes). Safe on the large-store early
 // path: no SQLite open. Fix reads last_error envelope fields only.
@@ -1152,8 +1217,8 @@ func inspectHookSpoolFilesystemMetadata() doctorCheck {
 			formatByteSize(stats.DeadBytes),
 		),
 		Hint: Localize(
-			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations. `traceary doctor --fix` requeues transient dead letters and prunes files older than 14 days without opening SQLite.",
-			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook で drain されます。`traceary doctor --fix` は SQLite を開かず transient dead-letter を再キューし、14 日より古いファイルを prune します。",
+			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations. `traceary doctor --fix` requeues transient dead letters and prunes dead-letter files and orphan *.tmp leftovers older than 14 days without opening SQLite.",
+			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook で drain されます。`traceary doctor --fix` は SQLite を開かず transient dead-letter を再キューし、14 日より古い dead-letter と orphan *.tmp を prune します。",
 		),
 	}
 	if status == doctorStatusWarn {
@@ -1179,29 +1244,36 @@ func fixHookSpoolDeadLettersFilesystem(ctx context.Context, now time.Time, dryRu
 	if err != nil {
 		return doctorFixResult{}, err
 	}
+	prunedTmp, _, err := pruneHookSpoolOrphanTmpFiles(now, dryRun)
+	if err != nil {
+		return doctorFixResult{}, err
+	}
 	if dryRun {
 		return doctorFixResult{Action: localizef(
-			"would requeue %d transient dead-letter(s), skip %d non-transient, and prune %d aged dead-letter file(s)",
-			"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、古い dead-letter %d 件を prune します",
+			"would requeue %d transient dead-letter(s), skip %d non-transient, prune %d aged dead-letter file(s), and prune %d orphan tmp file(s)",
+			"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、古い dead-letter %d 件と orphan tmp %d 件を prune します",
 			requeued,
 			skippedNontransient,
 			pruned,
+			prunedTmp,
 		)}, nil
 	}
 	return doctorFixResult{
 		Action: localizef(
-			"requeued=%d skipped_nontransient=%d pruned_dead=%d dead_remaining=%d",
-			"requeued=%d skipped_nontransient=%d pruned_dead=%d dead_remaining=%d",
+			"requeued=%d skipped_nontransient=%d pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
+			"requeued=%d skipped_nontransient=%d pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
 			requeued,
 			skippedNontransient,
 			pruned,
 			deadRemaining,
+			prunedTmp,
 		),
 		Metrics: map[string]int{
 			"requeued":             requeued,
 			"skipped_nontransient": skippedNontransient,
 			"pruned_dead":          pruned,
 			"dead_remaining":       deadRemaining,
+			"pruned_tmp":           prunedTmp,
 		},
 	}, nil
 }
@@ -1289,7 +1361,7 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 	if statsErr != nil {
 		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect hook spool metadata: %v", "hook spool メタデータの検査に失敗しました: %v", statsErr)}
 	}
-	if len(records) == 0 && len(unreadable) == 0 && stats.DeadCount == 0 {
+	if len(records) == 0 && len(unreadable) == 0 && stats.DeadCount == 0 && stats.StaleInflightCount == 0 {
 		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending hook spool records found", "未処理の hook spool record はありません")}
 	}
 	structuredFix := func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
@@ -1306,14 +1378,19 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		if err != nil {
 			return doctorFixResult{}, err
 		}
+		prunedTmp, _, err := pruneHookSpoolOrphanTmpFiles(now, dryRun)
+		if err != nil {
+			return doctorFixResult{}, err
+		}
 		if dryRun {
 			return doctorFixResult{Action: localizef(
-				"would requeue %d transient dead-letter(s), skip %d non-transient, drain up to %d pending hook spool record(s), and prune %d aged dead-letter file(s)",
-				"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、未処理 hook spool record 最大 %d 件を drain し、古い dead-letter %d 件を prune します",
+				"would requeue %d transient dead-letter(s), skip %d non-transient, drain up to %d pending hook spool record(s), prune %d aged dead-letter file(s), and prune %d orphan tmp file(s)",
+				"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、未処理 hook spool record 最大 %d 件を drain し、古い dead-letter %d 件と orphan tmp %d 件を prune します",
 				requeued,
 				skippedNontransient,
 				min(pending+requeued, 200),
 				pruned,
+				prunedTmp,
 			)}, nil
 		}
 		limit := min(pending+requeued, 200)
@@ -1323,8 +1400,8 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		}
 		return doctorFixResult{
 			Action: localizef(
-				"drained hook spool: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d",
-				"hook spool を drain しました: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d",
+				"drained hook spool: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
+				"hook spool を drain しました: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
 				requeued,
 				skippedNontransient,
 				result.Replayed,
@@ -1333,6 +1410,7 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 				result.Remaining,
 				pruned,
 				deadRemaining,
+				prunedTmp,
 			),
 			Metrics: map[string]int{
 				"requeued":             requeued,
@@ -1343,6 +1421,7 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 				"unreadable":           result.Unreadable,
 				"pruned_dead":          pruned,
 				"dead_remaining":       deadRemaining,
+				"pruned_tmp":           prunedTmp,
 			},
 		}, nil
 	}
@@ -1351,21 +1430,21 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		latest = fmt.Sprintf("client=%s command=%s action=%s created_at=%s path=%s", emptyAsDash(records[0].Client), emptyAsDash(records[0].Command), emptyAsDash(records[0].Action), records[0].CreatedAt.Format(time.RFC3339Nano), records[0].Path)
 	}
 	status := doctorStatusPass
-	if len(records) > 0 || len(unreadable) > 0 || hookSpoolDeadOverThreshold(stats) {
+	if len(records) > 0 || len(unreadable) > 0 || hookSpoolDeadOverThreshold(stats) || stats.StaleInflightCount > 0 {
 		status = doctorStatusWarn
 	}
 	message := localizef(
-		"found %d pending hook spool record(s), %d terminal dead-letter record(s), and %d unreadable record(s); latest %s",
-		"未処理の hook spool record が %d 件、terminal dead-letter が %d 件、読めない record が %d 件あります。latest %s",
-		len(records), stats.DeadCount, len(unreadable), latest,
+		"found %d pending hook spool record(s), %d terminal dead-letter record(s), %d unreadable record(s), and %d stale inflight file(s); latest %s",
+		"未処理の hook spool record が %d 件、terminal dead-letter が %d 件、読めない record が %d 件、stale inflight が %d 件あります。latest %s",
+		len(records), stats.DeadCount, len(unreadable), stats.StaleInflightCount, latest,
 	)
 	check := doctorCheck{
 		Name:    name,
 		Status:  status,
 		Message: message,
 		Hint: Localize(
-			"records are drained automatically on later hook invocations (bounded batch). After 3 failed attempts a record is retained under spool/dead/. Run `traceary doctor --fix` to requeue transient dead letters, drain pending records, and prune dead-letter files older than 14 days. Doctor never deletes dead-letter files without --fix.",
-			"record は後続 hook 呼び出し時に bounded batch で自動 drain されます。3 回失敗すると spool/dead/ に保持されます。`traceary doctor --fix` で transient dead-letter を再キューし、未処理を drain し、14 日より古い dead-letter を prune します。--fix なしでは dead-letter を削除しません。",
+			"records are drained automatically on later hook invocations (bounded batch). After 3 failed attempts a record is retained under spool/dead/. Run `traceary doctor --fix` to requeue transient dead letters, drain pending records, and prune dead-letter files and orphan *.tmp leftovers older than 14 days. Doctor never deletes those files without --fix.",
+			"record は後続 hook 呼び出し時に bounded batch で自動 drain されます。3 回失敗すると spool/dead/ に保持されます。`traceary doctor --fix` で transient dead-letter を再キューし、未処理を drain し、14 日より古い dead-letter と orphan *.tmp を prune します。--fix なしではそれらを削除しません。",
 		),
 	}
 	if status == doctorStatusWarn {

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1021,6 +1021,7 @@ func TestInspectHookSpoolDiagnostics_FixReportsUnreadableRemaining(t *testing.T)
 		"unreadable":           1,
 		"pruned_dead":          0,
 		"dead_remaining":       0,
+		"pruned_tmp":           0,
 	}
 	if !reflect.DeepEqual(result.Metrics, wantMetrics) {
 		t.Fatalf("metrics=%v, want %v", result.Metrics, wantMetrics)
@@ -2292,5 +2293,176 @@ func TestRequeueHookSpoolRecord_ClassifiedUnreplayableErrorsIncrementTowardDeadL
 				t.Fatalf("dead-lettered poison still in batch: %#v", batch)
 			}
 		})
+	}
+}
+
+func writeHookSpoolTmp(t *testing.T, spoolDir, name, body string, age time.Duration) string {
+	t.Helper()
+	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(spoolDir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", name, err)
+	}
+	if age > 0 {
+		at := time.Now().Add(-age)
+		if err := os.Chtimes(path, at, at); err != nil {
+			t.Fatalf("Chtimes %s: %v", name, err)
+		}
+	}
+	return path
+}
+
+type disappearedSpoolEntry struct{ name string }
+
+func (e disappearedSpoolEntry) Name() string               { return e.name }
+func (e disappearedSpoolEntry) IsDir() bool                { return false }
+func (e disappearedSpoolEntry) Type() os.FileMode          { return 0 }
+func (e disappearedSpoolEntry) Info() (os.FileInfo, error) { return nil, os.ErrNotExist }
+
+func TestInspectHookSpoolFilesystemStats_CountsAgedTmpAsStaleInflight(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+	fresh := writeHookSpoolTmp(t, spoolDir, "fresh.json.tmp", "fresh-tmp\n", 0)
+	aged := writeHookSpoolTmp(t, spoolDir, "aged.json.tmp", "aged-tmp-body\n", hookSpoolTmpStaleAge+time.Minute)
+
+	stats, err := inspectHookSpoolFilesystemStats(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("inspectHookSpoolFilesystemStats: %v", err)
+	}
+	if stats.StaleInflightCount != 1 || stats.PendingCount != 0 {
+		t.Fatalf("stats=%+v, want stale_inflight=1 pending=0", stats)
+	}
+	if stats.StaleInflightBytes != int64(len("aged-tmp-body\n")) {
+		t.Fatalf("stale bytes=%d, want aged tmp size", stats.StaleInflightBytes)
+	}
+
+	check := inspectHookSpoolFilesystemMetadata()
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q, want warn", check.Status)
+	}
+	if !strings.Contains(check.Message, "stale_inflight=1") {
+		t.Fatalf("message=%q, want stale_inflight=1", check.Message)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh tmp must remain: %v", err)
+	}
+	if _, err := os.Stat(aged); err != nil {
+		t.Fatalf("aged-but-under-retention tmp must remain until 14d prune: %v", err)
+	}
+}
+
+func TestPruneHookSpoolOrphanTmpFiles_RemovesAgedFilesOnlyOnFix(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+	fresh := writeHookSpoolTmp(t, spoolDir, "fresh.json.tmp", "fresh\n", time.Second)
+	stale := writeHookSpoolTmp(t, spoolDir, "hour-old.json.tmp", "hour\n", hookSpoolTmpStaleAge+time.Minute)
+	prunable := writeHookSpoolTmp(t, spoolDir, "july.json.tmp", "july-orphan\n", hookSpoolDeadRetention+24*time.Hour)
+
+	dryPruned, _, err := pruneHookSpoolOrphanTmpFiles(time.Now().UTC(), true)
+	if err != nil {
+		t.Fatalf("dry-run prune: %v", err)
+	}
+	if dryPruned != 1 {
+		t.Fatalf("dry-run pruned=%d, want 1", dryPruned)
+	}
+	for _, path := range []string{fresh, stale, prunable} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("dry-run must not delete %s: %v", path, err)
+		}
+	}
+
+	pruned, remaining, err := pruneHookSpoolOrphanTmpFiles(time.Now().UTC(), false)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 1 || remaining != 0 {
+		t.Fatalf("pruned=%d remaining=%d, want 1 and 0", pruned, remaining)
+	}
+	if _, err := os.Stat(prunable); !os.IsNotExist(err) {
+		t.Fatalf("14d tmp must be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh tmp must be kept: %v", err)
+	}
+	if _, err := os.Stat(stale); err != nil {
+		t.Fatalf("1h tmp must be kept until 14d: %v", err)
+	}
+
+	check := inspectHookSpoolFilesystemMetadata()
+	if !check.AutoFixAvailable || check.StructuredFixFunc == nil {
+		t.Fatal("stale tmp must expose doctor --fix")
+	}
+	result, err := check.StructuredFixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("StructuredFixFunc: %v", err)
+	}
+	if result.Metrics["pruned_tmp"] != 0 {
+		t.Fatalf("second fix pruned_tmp=%d, want 0", result.Metrics["pruned_tmp"])
+	}
+}
+
+func TestFixHookSpoolDeadLettersFilesystem_PrunesRetentionAgedTmp(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	spoolDir := filepath.Join(stateDir, "spool")
+	july := writeHookSpoolTmp(t, spoolDir, "20260716T000000.000000000Z-grok.json.tmp", "grok-orphan\n", hookSpoolDeadRetention+time.Hour)
+	july2 := writeHookSpoolTmp(t, spoolDir, "20260722T000000.000000000Z-kimi.json.tmp", "kimi-orphan\n", hookSpoolDeadRetention+2*time.Hour)
+	fresh := writeHookSpoolTmp(t, spoolDir, "now.json.tmp", "now\n", 0)
+
+	stats, err := inspectHookSpoolFilesystemStats(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("inspectHookSpoolFilesystemStats: %v", err)
+	}
+	if stats.StaleInflightCount != 2 {
+		t.Fatalf("stats=%+v, want stale_inflight=2", stats)
+	}
+
+	result, err := fixHookSpoolDeadLettersFilesystem(context.Background(), time.Now().UTC(), true)
+	if err != nil {
+		t.Fatalf("dry-run fix: %v", err)
+	}
+	if !strings.Contains(result.Action, "orphan tmp") {
+		t.Fatalf("dry-run action=%q, want orphan tmp preview", result.Action)
+	}
+	if _, err := os.Stat(july); err != nil {
+		t.Fatalf("dry-run must keep july tmp: %v", err)
+	}
+
+	result, err = fixHookSpoolDeadLettersFilesystem(context.Background(), time.Now().UTC(), false)
+	if err != nil {
+		t.Fatalf("fix: %v", err)
+	}
+	if result.Metrics["pruned_tmp"] != 2 {
+		t.Fatalf("metrics=%v, want pruned_tmp=2", result.Metrics)
+	}
+	if !strings.Contains(result.Action, "pruned_tmp=2") {
+		t.Fatalf("action=%q, want pruned_tmp=2", result.Action)
+	}
+	if _, err := os.Stat(july); !os.IsNotExist(err) {
+		t.Fatalf("july tmp must be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(july2); !os.IsNotExist(err) {
+		t.Fatalf("july2 tmp must be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh tmp must remain: %v", err)
+	}
+}
+
+func TestAddHookSpoolFilesystemEntry_ToleratesDisappearedTmp(t *testing.T) {
+	t.Parallel()
+	var stats hookSpoolFilesystemStats
+	if err := addHookSpoolFilesystemEntry(&stats, t.TempDir(), disappearedSpoolEntry{name: "gone.json.tmp"}, time.Now().UTC()); err != nil {
+		t.Fatalf("disappeared tmp must be skipped: %v", err)
+	}
+	if stats != (hookSpoolFilesystemStats{}) {
+		t.Fatalf("stats=%+v, want zero", stats)
+	}
+	if err := addHookSpoolFilesystemEntry(&stats, t.TempDir(), disappearedSpoolEntry{name: "gone.json"}, time.Now().UTC()); err == nil {
+		t.Fatal("disappeared non-tmp must fail")
 	}
 }


### PR DESCRIPTION
Closes #2115

Leaves parent #2108 open.

Doctor counts spool-root *.tmp older than 1h in stale_inflight. doctor --fix / --dry-run prune those older than the 14-day dead-letter bar and report pruned_tmp=. Fresh write-rename temps are neither counted nor deleted. A tmp that disappears between list and stat is skipped.