### PR TITLE
fix: abandon stale pre-publication compact journals

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **中断した `store compact` が次の実行を壊さない (#2118)** — publication 前 journal（`planned` / `copy_intent` / `copy_retry_intent` / `candidate_prepared`）で source identity が動いていれば abandon（candidate 削除）し、同じ呼び出しで新規 plan。`doctor` は進行中 journal を WARN、`--fix` は同じ abandon。`swap_intent` 以降は変えない。構築中の SIGINT は best-effort で `abandoned` を journal する。
 - **`doctor` が hook-spool の orphan `*.tmp` を `stale_inflight` に数え、14 日超を prune する (#2115)** — 1 時間超は既存カウンタへ。`doctor --fix` / `--dry-run` に `pruned_tmp=` を追加。直後の write-rename 一時ファイルは数えも消しもしない。
 - **`store compact --projection-rebuild` の JSON に `result_kind` を付ける (#2111)** — start/置き換えは `generation`、hash 一致 resume は `run`。既存フィールドはそのまま。分岐は `result_kind`。`--projection-abort` は変えない。
 - **既定の `doctor` が 2 GiB 以上のストアで O(1) の回収可能ページと projection generation を出す (#2110)** — `mode=ro` で `page_count` / `page_size` / `freelist_count` と `search_projection_state` singleton だけ読む。pragma が答えるとき `store-size` は growth unknown にしない。`store-capacity` は skip のまま。event body、dbstat、migration は読まない。不正な sparse fixture は fail-soft。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Interrupted `store compact` no longer bricks the next run (#2118)** — a pre-publication journal (`planned` / `copy_intent` / `copy_retry_intent` / `candidate_prepared`) whose source identity has moved is abandoned (candidate removed) and the same invocation plans fresh. `doctor` WARNs on in-flight journals; `--fix` applies the same abandon. `swap_intent` and later are unchanged. SIGINT during build best-effort journals `abandoned`.
 - **`doctor` counts orphan hook-spool `*.tmp` leftovers as `stale_inflight` and prunes them after 14 days (#2115)** — files older than 1h enter the existing counter; `doctor --fix` / `--dry-run` add `pruned_tmp=`. Fresh write-rename temps are neither counted nor deleted.
 - **`store compact --projection-rebuild` JSON carries `result_kind` (#2111)** — start/replace emit `generation`; matching-hash resume emits `run`. Existing fields stay. Branch on `result_kind`; do not sniff the shape. `--projection-abort` is unchanged.
 - **Default `doctor` reports O(1) reclaimable pages and projection generation on ≥2 GiB stores (#2110)** — `mode=ro` reads `page_count` / `page_size` / `freelist_count` plus the `search_projection_state` singleton. `store-size` no longer calls growth unknown when those pragmas answer it. `store-capacity` stays skip; event bodies, dbstat, and migrations stay unread. Invalid sparse fixtures fail-soft.

--- a/application/store_compaction.go
+++ b/application/store_compaction.go
@@ -83,9 +83,21 @@ type StoreCompactionUsecase interface {
 	Resume(context.Context, string) (domain.CompactionRun, error)
 	Status(context.Context, string) (domain.CompactionRun, error)
 	Rollback(context.Context, string) (domain.CompactionRun, error)
+	// AbandonStalePrePublication journals abandoned and removes the
+	// candidate when an in-flight run is strictly pre-publication and the
+	// live source identity no longer matches the journal fence.
+	AbandonStalePrePublication(context.Context, string) (domain.CompactionRun, error)
 }
 
 // CompactionInFlightFinder locates a non-terminal journal for a store.
 type CompactionInFlightFinder interface {
 	FindInFlight(context.Context, string) (domain.CompactionRun, error)
+}
+
+// CompactionPrePublicationCleanup inspects the live source and removes an
+// abandoned candidate without requiring the journaled source identity to
+// still match (the mismatch is why abandon is needed).
+type CompactionPrePublicationCleanup interface {
+	InspectStoreFile(context.Context, string) (domain.StoreFileIdentity, error)
+	RemoveAbandonedCandidate(context.Context, domain.CompactionRun) error
 }

--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -195,11 +195,17 @@ func isInsufficientCompactionSpace(err error) bool {
 func (u *storeCompactionUsecase) compactLeased(ctx context.Context, source string) (domain.CompactionRun, error) {
 	if finder, ok := u.journal.(application.CompactionInFlightFinder); ok {
 		existing, findErr := finder.FindInFlight(ctx, source)
-		if findErr == nil && existing.ID != "" && existing.Phase != domain.CompactionCommitted && existing.Phase != domain.CompactionRolledBack {
-			if err := u.validateBinding(existing); err != nil {
-				return existing, err
+		if findErr == nil && existing.ID != "" && !existing.Phase.IsTerminal() {
+			abandoned, abandonErr := u.abandonIfStalePrePublication(ctx, existing)
+			if abandonErr != nil {
+				return existing, abandonErr
 			}
-			return u.resumeLeased(ctx, existing)
+			if !abandoned {
+				if err := u.validateBinding(existing); err != nil {
+					return existing, err
+				}
+				return u.resumeLeased(ctx, existing)
+			}
 		}
 		if findErr != nil && !errors.Is(findErr, os.ErrNotExist) {
 			return domain.CompactionRun{}, findErr
@@ -210,6 +216,79 @@ func (u *storeCompactionUsecase) compactLeased(ctx context.Context, source strin
 		return planned, err
 	}
 	return u.applyLeased(ctx, planned)
+}
+
+func (u *storeCompactionUsecase) AbandonStalePrePublication(ctx context.Context, source string) (domain.CompactionRun, error) {
+	if filepath.Clean(source) != u.expectedStore {
+		return domain.CompactionRun{}, fmt.Errorf("compaction store binding mismatch")
+	}
+	release, err := u.lease.AcquireExclusive(ctx, u.expectedStore)
+	if err != nil {
+		return domain.CompactionRun{}, err
+	}
+	defer release()
+	finder, ok := u.journal.(application.CompactionInFlightFinder)
+	if !ok {
+		return domain.CompactionRun{}, nil
+	}
+	existing, findErr := finder.FindInFlight(ctx, source)
+	if findErr != nil {
+		if errors.Is(findErr, os.ErrNotExist) {
+			return domain.CompactionRun{}, nil
+		}
+		return domain.CompactionRun{}, findErr
+	}
+	if err := u.validateBinding(existing); err != nil {
+		return existing, err
+	}
+	abandoned, err := u.abandonIfStalePrePublication(ctx, existing)
+	if err != nil {
+		return existing, err
+	}
+	if !abandoned {
+		return domain.CompactionRun{}, nil
+	}
+	loaded, loadErr := u.journal.Load(ctx, existing.ID)
+	if loadErr != nil {
+		return existing, loadErr
+	}
+	return loaded, nil
+}
+
+func (u *storeCompactionUsecase) abandonIfStalePrePublication(ctx context.Context, existing domain.CompactionRun) (bool, error) {
+	if !existing.Phase.IsPrePublication() {
+		return false, nil
+	}
+	cleanup, ok := u.files.(application.CompactionPrePublicationCleanup)
+	if !ok {
+		return false, nil
+	}
+	current, err := cleanup.InspectStoreFile(ctx, existing.SourcePath)
+	if err != nil {
+		return false, err
+	}
+	if !existing.ShouldAbandonForStaleSource(current) {
+		return false, nil
+	}
+	if _, err := u.abandonPrePublication(ctx, existing); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (u *storeCompactionUsecase) abandonPrePublication(ctx context.Context, run domain.CompactionRun) (domain.CompactionRun, error) {
+	if !run.Phase.IsPrePublication() {
+		return run, fmt.Errorf("cannot abandon compaction in phase %q", run.Phase)
+	}
+	// SIGINT / deadline already cancelled ctx; journal append and unlink
+	// must still run so the next invocation does not resume this corpse.
+	abandonCtx := context.WithoutCancel(ctx)
+	if cleanup, ok := u.files.(application.CompactionPrePublicationCleanup); ok {
+		if err := cleanup.RemoveAbandonedCandidate(abandonCtx, run); err != nil {
+			return run, err
+		}
+	}
+	return u.advance(abandonCtx, run, domain.CompactionAbandoned)
 }
 
 func (u *storeCompactionUsecase) Plan(ctx context.Context, source string) (domain.CompactionRun, error) {
@@ -304,6 +383,11 @@ func (u *storeCompactionUsecase) applyLeased(ctx context.Context, run domain.Com
 				stop()
 			} else {
 				err = u.builder.Build(ctx, run.SourcePath, run.CandidatePath)
+			}
+			if err != nil && ctx.Err() != nil {
+				if _, abandonErr := u.abandonPrePublication(ctx, run); abandonErr != nil {
+					return run, fmt.Errorf("%w (also failed to abandon: %v)", err, abandonErr)
+				}
 			}
 			if err == nil {
 				run, err = u.advance(ctx, run, domain.CompactionCopyComplete)

--- a/application/usecase/store_compaction_abandon_test.go
+++ b/application/usecase/store_compaction_abandon_test.go
@@ -1,0 +1,164 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+type findingJournal struct {
+	faultJournal
+	inFlight domain.CompactionRun
+	missing  bool
+	phases   []domain.CompactionPhase
+}
+
+func (j *findingJournal) FindInFlight(context.Context, string) (domain.CompactionRun, error) {
+	if j.missing || j.inFlight.Phase.IsTerminal() {
+		return domain.CompactionRun{}, os.ErrNotExist
+	}
+	if j.inFlight.ID != "" {
+		return j.inFlight, nil
+	}
+	if j.run.ID != "" && !j.run.Phase.IsTerminal() {
+		return j.run, nil
+	}
+	return domain.CompactionRun{}, os.ErrNotExist
+}
+
+func (j *findingJournal) Append(ctx context.Context, r domain.CompactionRun) error {
+	j.phases = append(j.phases, r.Phase)
+	if r.ID == j.inFlight.ID {
+		j.inFlight = r
+	}
+	return j.faultJournal.Append(ctx, r)
+}
+
+type abandonFiles struct {
+	faultFiles
+	current      domain.StoreFileIdentity
+	removed      []string
+	inspectErr   error
+	removeErr    error
+	inspectCalls int
+	removeCalls  int
+}
+
+func (f *abandonFiles) InspectStoreFile(context.Context, string) (domain.StoreFileIdentity, error) {
+	f.inspectCalls++
+	if f.inspectErr != nil {
+		return domain.StoreFileIdentity{}, f.inspectErr
+	}
+	return f.current, nil
+}
+
+func (f *abandonFiles) RemoveAbandonedCandidate(_ context.Context, run domain.CompactionRun) error {
+	f.removeCalls++
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	f.removed = append(f.removed, run.CandidatePath)
+	return nil
+}
+
+func TestCompactLeasedDoesNotAbandonSwapIntent(t *testing.T) {
+	run := compactionRunAt(domain.CompactionSwapIntent)
+	run.SourcePath = "/store"
+	current := run.SourceIdentity
+	current.ModUnix++
+	journal := &findingJournal{inFlight: run}
+	files := &abandonFiles{
+		faultFiles: faultFiles{fail: "observe", observation: domain.CompactionObservation{}},
+		current:    current,
+	}
+	svc := NewStoreCompactionUsecase("/store", journal, faultBuilder{}, files, faultLease{})
+	if _, err := svc.Resume(context.Background(), run.ID); err == nil {
+		t.Fatal("swap_intent resume must still observe")
+	}
+	if files.removeCalls != 0 {
+		t.Fatalf("removeCalls=%d, want 0", files.removeCalls)
+	}
+}
+
+func TestAbandonStalePrePublicationNoopsWhenSourceMatches(t *testing.T) {
+	run := compactionRunAt(domain.CompactionCandidatePrepared)
+	run.SourcePath = "/store"
+	journal := &findingJournal{inFlight: run}
+	files := &abandonFiles{current: run.SourceIdentity}
+	svc := NewStoreCompactionUsecase("/store", journal, faultBuilder{}, files, faultLease{})
+	got, err := svc.AbandonStalePrePublication(context.Background(), "/store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "" {
+		t.Fatalf("got=%+v, want empty (source still matches)", got)
+	}
+	if files.removeCalls != 0 {
+		t.Fatalf("removeCalls=%d, want 0", files.removeCalls)
+	}
+}
+
+func TestBuildCancellationJournalsAbandoned(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	run := compactionRunAt(domain.CompactionCandidatePrepared)
+	run.SourcePath = "/store"
+	journal := &faultJournal{run: run}
+	files := &abandonFiles{current: run.SourceIdentity}
+	svc := NewStoreCompactionUsecase("/store", journal, cancelBuild{}, files, faultLease{}).(*storeCompactionUsecase)
+	got, err := svc.applyLeased(ctx, run)
+	if err == nil {
+		t.Fatal("expected canceled build error")
+	}
+	if got.Phase != domain.CompactionAbandoned && journal.run.Phase != domain.CompactionAbandoned {
+		t.Fatalf("phase got=%q journal=%q, want abandoned", got.Phase, journal.run.Phase)
+	}
+	if files.removeCalls != 1 {
+		t.Fatalf("removeCalls=%d, want 1", files.removeCalls)
+	}
+}
+
+type cancelBuild struct{ faultBuilder }
+
+func (cancelBuild) Build(ctx context.Context, _, _ string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("build canceled: %w", err)
+	}
+	return errors.New("build was not canceled")
+}
+
+func TestCompactLeasedAbandonUsesMovedSource(t *testing.T) {
+	stale := compactionRunAt(domain.CompactionCandidatePrepared)
+	stale.SourcePath = "/store"
+	stale.CandidatePath = "/store.compact-" + stale.ID
+	current := stale.SourceIdentity
+	current.ModUnix++
+	journal := &findingJournal{faultJournal: faultJournal{run: stale}, inFlight: stale}
+	files := &abandonFiles{current: current}
+	svc := NewStoreCompactionUsecase("/store", journal, faultBuilder{fail: "build"}, files, faultLease{}).(*storeCompactionUsecase)
+	_, err := svc.compactLeased(context.Background(), "/store")
+	if err == nil {
+		t.Fatal("fresh apply should fail at build")
+	}
+	if len(journal.phases) == 0 || journal.phases[0] != domain.CompactionAbandoned {
+		t.Fatalf("phases=%v, want abandoned first", journal.phases)
+	}
+	if journal.inFlight.Phase != domain.CompactionAbandoned {
+		t.Fatalf("in-flight phase=%q, want abandoned", journal.inFlight.Phase)
+	}
+	if files.removeCalls != 1 || files.removed[0] != stale.CandidatePath {
+		t.Fatalf("removed=%v", files.removed)
+	}
+}
+
+func TestAbandonPrePublicationRefusesSwapIntent(t *testing.T) {
+	run := compactionRunAt(domain.CompactionSwapIntent)
+	svc := NewStoreCompactionUsecase("/store", &faultJournal{run: run}, faultBuilder{}, &abandonFiles{}, faultLease{}).(*storeCompactionUsecase)
+	if _, err := svc.abandonPrePublication(context.Background(), run); err == nil {
+		t.Fatal("expected refuse")
+	}
+}

--- a/domain/compaction_run.go
+++ b/domain/compaction_run.go
@@ -30,4 +30,5 @@ const (
 	CompactionRollbackSwapIntent    = PreparedStoreUpgradeRollbackSwapIntent
 	CompactionRollbackSwapped       = PreparedStoreUpgradeRollbackSwapped
 	CompactionRolledBack            = PreparedStoreUpgradeRolledBack
+	CompactionAbandoned             = PreparedStoreUpgradeAbandoned
 )

--- a/domain/compaction_run_test.go
+++ b/domain/compaction_run_test.go
@@ -57,6 +57,34 @@ func TestCompactionRunRecoveryActionsRejectUnknownAndDecideCrashRecovery(t *test
 	}
 }
 
+func TestCompactionRunShouldAbandonForStaleSource(t *testing.T) {
+	t.Parallel()
+	source := StoreFileIdentity{Device: 1, Inode: 2, Size: 10, ModUnix: 100}
+	moved := source
+	moved.ModUnix = 200
+	run := CompactionRun{Phase: CompactionCandidatePrepared, SourceIdentity: source}
+	if !run.ShouldAbandonForStaleSource(moved) {
+		t.Fatal("pre-publication stale source must abandon")
+	}
+	if run.ShouldAbandonForStaleSource(source) {
+		t.Fatal("matching source must not abandon")
+	}
+	run.Phase = CompactionSwapIntent
+	if run.ShouldAbandonForStaleSource(moved) {
+		t.Fatal("swap_intent must never auto-abandon")
+	}
+	if !CompactionAbandoned.IsTerminal() || CompactionCandidatePrepared.IsTerminal() {
+		t.Fatal("abandoned is terminal; candidate_prepared is not")
+	}
+	got, err := (CompactionRun{Phase: CompactionCandidatePrepared}).Advance(CompactionAbandoned, time.Now())
+	if err != nil || got.Phase != CompactionAbandoned {
+		t.Fatalf("advance to abandoned: %q %v", got.Phase, err)
+	}
+	if _, err := (CompactionRun{Phase: CompactionSwapIntent}).Advance(CompactionAbandoned, time.Now()); err == nil {
+		t.Fatal("swap_intent must not advance to abandoned")
+	}
+}
+
 func TestCompactionRunNextActionOwnsNormalDecision(t *testing.T) {
 	action, err := (CompactionRun{Phase: CompactionScrubInProgress}).NextAction()
 	if err != nil {

--- a/domain/prepared_store_upgrade.go
+++ b/domain/prepared_store_upgrade.go
@@ -28,6 +28,9 @@ const (
 	PreparedStoreUpgradeRollbackSwapIntent    PreparedStoreUpgradePhase = "rollback_swap_intent"
 	PreparedStoreUpgradeRollbackSwapped       PreparedStoreUpgradePhase = "rollback_swapped"
 	PreparedStoreUpgradeRolledBack            PreparedStoreUpgradePhase = "rolled_back"
+	// PreparedStoreUpgradeAbandoned is a terminal pre-publication exit.
+	// The source inode was never swapped; the candidate may be removed.
+	PreparedStoreUpgradeAbandoned PreparedStoreUpgradePhase = "abandoned"
 )
 
 // StoreFileIdentity fences every destructive filesystem action.
@@ -284,10 +287,10 @@ type PreparedStoreUpgradeRun struct {
 }
 
 var preparedStoreUpgradeTransitions = map[PreparedStoreUpgradePhase][]PreparedStoreUpgradePhase{
-	PreparedStoreUpgradePlanned:               {PreparedStoreUpgradeCopyIntent},
-	PreparedStoreUpgradeCopyIntent:            {PreparedStoreUpgradeCandidatePrepared},
-	PreparedStoreUpgradeCopyRetryIntent:       {PreparedStoreUpgradeCandidatePrepared},
-	PreparedStoreUpgradeCandidatePrepared:     {PreparedStoreUpgradeCopyComplete, PreparedStoreUpgradeCopyRetryIntent},
+	PreparedStoreUpgradePlanned:               {PreparedStoreUpgradeCopyIntent, PreparedStoreUpgradeAbandoned},
+	PreparedStoreUpgradeCopyIntent:            {PreparedStoreUpgradeCandidatePrepared, PreparedStoreUpgradeAbandoned},
+	PreparedStoreUpgradeCopyRetryIntent:       {PreparedStoreUpgradeCandidatePrepared, PreparedStoreUpgradeAbandoned},
+	PreparedStoreUpgradeCandidatePrepared:     {PreparedStoreUpgradeCopyComplete, PreparedStoreUpgradeCopyRetryIntent, PreparedStoreUpgradeAbandoned},
 	PreparedStoreUpgradeCopyComplete:          {PreparedStoreUpgradeCandidateSyncIntent},
 	PreparedStoreUpgradeCandidateSyncIntent:   {PreparedStoreUpgradeCandidateSynced},
 	PreparedStoreUpgradeCandidateSynced:       {PreparedStoreUpgradeScrubInProgress},
@@ -300,6 +303,34 @@ var preparedStoreUpgradeTransitions = map[PreparedStoreUpgradePhase][]PreparedSt
 	PreparedStoreUpgradeCommitted:             {PreparedStoreUpgradeRollbackSwapIntent},
 	PreparedStoreUpgradeRollbackSwapIntent:    {PreparedStoreUpgradeRollbackSwapped},
 	PreparedStoreUpgradeRollbackSwapped:       {PreparedStoreUpgradeRolledBack},
+}
+
+// IsTerminal reports whether the journal no longer requires resume.
+func (p PreparedStoreUpgradePhase) IsTerminal() bool {
+	switch p {
+	case PreparedStoreUpgradeCommitted, PreparedStoreUpgradeRolledBack, PreparedStoreUpgradeAbandoned:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsPrePublication is the window where abandoning is unconditionally safe:
+// the rollback inode was never created and the source inode was never swapped.
+func (p PreparedStoreUpgradePhase) IsPrePublication() bool {
+	switch p {
+	case PreparedStoreUpgradePlanned, PreparedStoreUpgradeCopyIntent, PreparedStoreUpgradeCopyRetryIntent, PreparedStoreUpgradeCandidatePrepared:
+		return true
+	default:
+		return false
+	}
+}
+
+// ShouldAbandonForStaleSource is true when a pre-publication journal is fenced
+// to a source identity that no longer matches the live file (typically mtime
+// after a later writer). Publication phases must not take this exit.
+func (r PreparedStoreUpgradeRun) ShouldAbandonForStaleSource(current StoreFileIdentity) bool {
+	return r.Phase.IsPrePublication() && current != (StoreFileIdentity{}) && current != r.SourceIdentity
 }
 
 // Advance rejects skipped or backward protocol transitions.

--- a/infrastructure/sqlite/compaction_files.go
+++ b/infrastructure/sqlite/compaction_files.go
@@ -302,8 +302,7 @@ func (j *PreparedStoreUpgradeFileJournal) FindInFlight(ctx context.Context, sour
 		if run.Operation != "" && run.Operation != domain.PreparedStoreUpgradeOperationCompaction {
 			continue
 		}
-		switch run.Phase {
-		case domain.CompactionCommitted, domain.CompactionRolledBack:
+		if run.Phase.IsTerminal() {
 			continue
 		}
 		if match.ID != "" {
@@ -702,6 +701,34 @@ func (f PreparedStoreUpgradeFiles) RemoveOwnedPartialCandidate(ctx context.Conte
 		if err := f.recoveryHook("after_dir_sync"); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (f PreparedStoreUpgradeFiles) InspectStoreFile(ctx context.Context, path string) (domain.StoreFileIdentity, error) {
+	if err := ctx.Err(); err != nil {
+		return domain.StoreFileIdentity{}, err
+	}
+	return inspectRegularFile(path)
+}
+
+func (f PreparedStoreUpgradeFiles) RemoveAbandonedCandidate(ctx context.Context, run domain.CompactionRun) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !run.Phase.IsPrePublication() {
+		return errors.New("abandoned candidate cleanup is not authorized after publication")
+	}
+	if run.CandidatePath != ownedCandidatePath(run) {
+		return errors.New("candidate path is not owned by run")
+	}
+	if _, rollbackExists, err := inspectOptionalRegularFile(run.RollbackPath); err != nil {
+		return err
+	} else if rollbackExists {
+		return errors.New("rollback path exists during pre-publication abandon")
+	}
+	if err := os.Remove(run.CandidatePath); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	return nil
 }

--- a/infrastructure/sqlite/compaction_sqlite_test.go
+++ b/infrastructure/sqlite/compaction_sqlite_test.go
@@ -611,4 +611,95 @@ func prepareCompactionCandidateForResumeTest(ctx context.Context, t *testing.T, 
 	return run, journal
 }
 
+func TestStoreCompactionAbandonsStaleCandidatePreparedAndReplans(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	db, err := sql.Open("sqlite", directSQLiteRWDSNCreate(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE sample(id INTEGER PRIMARY KEY, body TEXT); INSERT INTO sample(body) VALUES('keep')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stale, journal := prepareCompactionCandidateForResumeTest(ctx, t, source, dir)
+	if _, err := os.Stat(stale.CandidatePath); err != nil {
+		t.Fatalf("expected leftover candidate marker: %v", err)
+	}
+	moved := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(source, moved, moved); err != nil {
+		t.Fatal(err)
+	}
+	svc := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
+	result, err := svc.Compact(ctx, application.CompactInput{Source: source, Now: time.Now()})
+	if err != nil {
+		t.Fatalf("Compact after stale candidate_prepared: %v", err)
+	}
+	if result.Run.Phase != domain.CompactionCommitted {
+		t.Fatalf("phase=%s, want committed", result.Run.Phase)
+	}
+	if result.Run.ID == stale.ID {
+		t.Fatal("fresh plan reused the abandoned run id")
+	}
+	abandoned, err := journal.Load(ctx, stale.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abandoned.Phase != domain.CompactionAbandoned {
+		t.Fatalf("stale journal phase=%s, want abandoned", abandoned.Phase)
+	}
+	if _, err := os.Stat(stale.CandidatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("abandoned candidate must be removed, stat err=%v", err)
+	}
+}
+
+func TestStoreCompactionDoesNotAbandonSwapIntent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run := domain.CompactionRun{
+		ID:             "0123456789abcdef0123456789abcdef",
+		SourcePath:     source,
+		CandidatePath:  source + ".compact-0123456789abcdef0123456789abcdef",
+		RollbackPath:   source + ".rollback-0123456789abcdef0123456789abcdef",
+		Phase:          domain.CompactionSwapIntent,
+		SourceIdentity: domain.StoreFileIdentity{Device: 1, Inode: 1, Size: 6},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	journal := &findingPhaseJournal{run: run}
+	svc := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
+	if _, err := svc.AbandonStalePrePublication(ctx, source); err != nil {
+		t.Fatal(err)
+	}
+	if journal.run.Phase != domain.CompactionSwapIntent {
+		t.Fatalf("phase=%s, swap_intent must stay", journal.run.Phase)
+	}
+}
+
+type findingPhaseJournal struct {
+	run domain.CompactionRun
+}
+
+func (j *findingPhaseJournal) Create(context.Context, domain.CompactionRun) error { return nil }
+func (j *findingPhaseJournal) Load(context.Context, string) (domain.CompactionRun, error) {
+	return j.run, nil
+}
+func (j *findingPhaseJournal) Append(_ context.Context, run domain.CompactionRun) error {
+	j.run = run
+	return nil
+}
+func (j *findingPhaseJournal) FindInFlight(context.Context, string) (domain.CompactionRun, error) {
+	if j.run.Phase.IsTerminal() {
+		return domain.CompactionRun{}, os.ErrNotExist
+	}
+	return j.run, nil
+}
+
 func directSQLiteRWDSNCreate(path string) string { return "file:" + path }

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -358,6 +358,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		// open SQLite. Large stores are the ones most likely to still hold
 		// a source-sized rollback inode (#1827).
 		report.Checks = append(report.Checks, inspectCompactRollbackCopies(resolvedDBPath))
+		report.Checks = append(report.Checks, c.inspectCompactInFlight(resolvedDBPath, time.Now()))
 		report.Checks = append(report.Checks, buildOperatorCostCheck(residentCost))
 		report.Checks = append(report.Checks, inspectTracearyOnPath())
 		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(snapshot, resolvedDBPath, pageErr == nil))

--- a/presentation/cli/doctor_compact_inflight.go
+++ b/presentation/cli/doctor_compact_inflight.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+const compactJournalDirName = ".traceary-compaction"
+
+type compactInFlightJournal struct {
+	ID        string                 `json:"id"`
+	Phase     domain.CompactionPhase `json:"phase"`
+	UpdatedAt time.Time              `json:"updated_at"`
+}
+
+func inspectCompactInFlightJournals(dbPath string, now time.Time) doctorCheck {
+	return inspectCompactInFlightJournalsWithFix(dbPath, now, nil)
+}
+
+func inspectCompactInFlightJournalsWithFix(dbPath string, now time.Time, fix func(context.Context, bool) (doctorFixResult, error)) doctorCheck {
+	const name = "compact-in-flight"
+	if strings.TrimSpace(dbPath) == "" {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusSkip,
+			Message: Localize("store path is empty, so compaction journals were not inspected", "store path が空のため compaction journal は検査しません"),
+		}
+	}
+	journals, err := listCompactInFlightJournals(filepath.Join(filepath.Dir(dbPath), compactJournalDirName))
+	if err != nil {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusWarn,
+			Message: localizef("failed to inspect compaction journals: %v", "compaction journal を検査できません: %v", err),
+		}
+	}
+	if len(journals) == 0 {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusPass,
+			Message: Localize("no in-flight compaction journal is present", "進行中の compaction journal はありません"),
+		}
+	}
+	parts := make([]string, 0, len(journals))
+	prePub := 0
+	for _, journal := range journals {
+		age := now.Sub(journal.UpdatedAt).Truncate(time.Second)
+		if age < 0 {
+			age = 0
+		}
+		parts = append(parts, localizef(
+			"id=%s phase=%s age=%s",
+			"id=%s phase=%s age=%s",
+			journal.ID,
+			journal.Phase,
+			age,
+		))
+		if journal.Phase.IsPrePublication() {
+			prePub++
+		}
+	}
+	check := doctorCheck{
+		Name:   name,
+		Status: doctorStatusWarn,
+		Message: localizef(
+			"in-flight compaction journal(s): %s",
+			"進行中の compaction journal: %s",
+			strings.Join(parts, "; "),
+		),
+		Hint: Localize(
+			"Pre-publication phases (planned / copy_intent / copy_retry_intent / candidate_prepared) can be abandoned by `traceary doctor --fix` or the next `store compact` when the source identity has moved. swap_intent and later keep today's resume/rollback semantics.",
+			"publication 前の phase（planned / copy_intent / copy_retry_intent / candidate_prepared）は、source identity が動いていれば `traceary doctor --fix` または次の `store compact` が abandon します。swap_intent 以降は従来の resume/rollback です。",
+		),
+	}
+	if prePub > 0 && fix != nil {
+		check.FixCommand = "traceary doctor --fix"
+		check.AutoFixAvailable = true
+		check.StructuredFixFunc = fix
+		check.FixFunc = func(ctx context.Context, dryRun bool) (string, error) {
+			result, err := fix(ctx, dryRun)
+			return result.Action, err
+		}
+	}
+	return check
+}
+
+func (c *RootCLI) inspectCompactInFlight(dbPath string, now time.Time) doctorCheck {
+	var fix func(context.Context, bool) (doctorFixResult, error)
+	if c != nil && c.storeCompactionFactory != nil {
+		fix = func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
+			if dryRun {
+				return doctorFixResult{Action: Localize(
+					"would abandon stale pre-publication compaction journals whose source identity has moved",
+					"source identity が動いた publication 前 compaction journal を abandon します",
+				)}, nil
+			}
+			_, usecase, err := c.compactionFor(dbPath)
+			if err != nil {
+				return doctorFixResult{}, err
+			}
+			abandoned, err := usecase.AbandonStalePrePublication(ctx, dbPath)
+			if err != nil {
+				return doctorFixResult{}, xerrors.Errorf("failed to abandon stale compaction journal: %w", err)
+			}
+			if abandoned.ID == "" {
+				return doctorFixResult{
+					Action:  Localize("no stale pre-publication compaction journal was abandoned", "abandon した publication 前 compaction journal はありません"),
+					Metrics: map[string]int{"abandoned": 0},
+				}, nil
+			}
+			return doctorFixResult{
+				Action: localizef(
+					"abandoned compact run id=%s phase=%s",
+					"compaction run を abandon しました id=%s phase=%s",
+					abandoned.ID,
+					abandoned.Phase,
+				),
+				Metrics: map[string]int{"abandoned": 1},
+			}, nil
+		}
+	}
+	return inspectCompactInFlightJournalsWithFix(dbPath, now, fix)
+}
+
+func listCompactInFlightJournals(dir string) ([]compactInFlightJournal, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read compaction journal directory: %w", err)
+	}
+	var out []compactInFlightJournal
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		journal, ok, loadErr := loadCompactJournalSnapshot(filepath.Join(dir, entry.Name()))
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		if !ok || journal.Phase.IsTerminal() {
+			continue
+		}
+		out = append(out, journal)
+	}
+	return out, nil
+}
+
+func loadCompactJournalSnapshot(path string) (compactInFlightJournal, bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return compactInFlightJournal{}, false, nil
+		}
+		return compactInFlightJournal{}, false, xerrors.Errorf("failed to open compaction journal: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 4096), 1<<20)
+	var last []byte
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		last = append(last[:0], line...)
+	}
+	if err := scanner.Err(); err != nil {
+		return compactInFlightJournal{}, false, xerrors.Errorf("failed to read compaction journal: %w", err)
+	}
+	if len(last) == 0 {
+		return compactInFlightJournal{}, false, nil
+	}
+	var journal compactInFlightJournal
+	if err := json.Unmarshal(last, &journal); err != nil {
+		return compactInFlightJournal{}, false, xerrors.Errorf("failed to decode compaction journal: %w", err)
+	}
+	if journal.ID == "" || journal.Phase == "" {
+		return compactInFlightJournal{}, false, nil
+	}
+	return journal, true, nil
+}

--- a/presentation/cli/doctor_compact_inflight_test.go
+++ b/presentation/cli/doctor_compact_inflight_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+func TestInspectCompactInFlightJournals_WarnsOnCandidatePrepared(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "traceary.db")
+	if err := os.WriteFile(dbPath, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, compactJournalDirName)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	updated := time.Now().UTC().Add(-2 * time.Hour)
+	run := domain.CompactionRun{
+		ID:        "cc172b5a0123456789abcdef01234567",
+		Phase:     domain.CompactionCandidatePrepared,
+		UpdatedAt: updated,
+	}
+	encoded, err := json.Marshal(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, run.ID+".jsonl"), append(encoded, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	check := inspectCompactInFlightJournals(dbPath, time.Now().UTC())
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q, want warn", check.Status)
+	}
+	if !strings.Contains(check.Message, run.ID) || !strings.Contains(check.Message, "candidate_prepared") {
+		t.Fatalf("message=%q", check.Message)
+	}
+}
+
+func TestInspectCompactInFlightJournals_IgnoresAbandonedAndCommitted(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "traceary.db")
+	if err := os.WriteFile(dbPath, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, compactJournalDirName)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, run := range []domain.CompactionRun{
+		{ID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Phase: domain.CompactionAbandoned, UpdatedAt: time.Now()},
+		{ID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Phase: domain.CompactionCommitted, UpdatedAt: time.Now()},
+	} {
+		encoded, err := json.Marshal(run)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, run.ID+".jsonl"), append(encoded, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	check := inspectCompactInFlightJournals(dbPath, time.Now().UTC())
+	if check.Status != doctorStatusPass {
+		t.Fatalf("status=%q message=%q, want pass", check.Status, check.Message)
+	}
+}
+
+func TestInspectCompactInFlightJournals_SwapIntentWarnsWithoutAutoFix(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "traceary.db")
+	dir := filepath.Join(root, compactJournalDirName)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	run := domain.CompactionRun{
+		ID:        "cccccccccccccccccccccccccccccccc",
+		Phase:     domain.CompactionSwapIntent,
+		UpdatedAt: time.Now().UTC(),
+	}
+	encoded, err := json.Marshal(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, run.ID+".jsonl"), append(encoded, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	check := inspectCompactInFlightJournals(dbPath, time.Now().UTC())
+	if check.Status != doctorStatusWarn || check.AutoFixAvailable {
+		t.Fatalf("check=%#v, want warn without autofix", check)
+	}
+}

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -55,7 +55,7 @@ func inspectStoreFileSnapshot(path string, stat func(string) (os.FileInfo, error
 
 func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string, snapshot storeFileSnapshot) []doctorCheck {
 	checks := c.inspectStoreGrowthBudgetWithClock(ctx, dbPath, snapshot, time.Now)
-	return append(checks, inspectCompactRollbackCopies(dbPath))
+	return append(checks, inspectCompactRollbackCopies(dbPath), c.inspectCompactInFlight(dbPath, time.Now()))
 }
 
 // inspectCompactRollbackCopies reports leftover <db>.rollback-<run> files.

--- a/presentation/cli/doctor_store_size_test.go
+++ b/presentation/cli/doctor_store_size_test.go
@@ -66,7 +66,7 @@ func TestInspectStoreGrowthBudgetSeparatesRetiredIndexFromProjection(t *testing.
 		},
 	}}}
 	checks := root.inspectStoreGrowthBudget(context.Background(), path, inspectStoreFileSnapshot(path, os.Stat))
-	if len(checks) != 4 {
+	if len(checks) != 5 {
 		t.Fatalf("checks=%#v", checks)
 	}
 	if checks[1].Name != "store-capacity" || !strings.Contains(checks[1].Message, "top=[") {
@@ -74,6 +74,9 @@ func TestInspectStoreGrowthBudgetSeparatesRetiredIndexFromProjection(t *testing.
 	}
 	if checks[3].Name != "compact-rollback-copy" || checks[3].Status != doctorStatusPass {
 		t.Fatalf("rollback check=%#v", checks[3])
+	}
+	if checks[4].Name != "compact-in-flight" || checks[4].Status != doctorStatusPass {
+		t.Fatalf("in-flight check=%#v", checks[4])
 	}
 	legacy := checks[2]
 	if legacy.Name != "legacy-search-index" || legacy.Status != doctorStatusWarn {

--- a/presentation/cli/store_compaction_test.go
+++ b/presentation/cli/store_compaction_test.go
@@ -39,6 +39,9 @@ func (*compactionCLIStub) Status(context.Context, string) (domain.CompactionRun,
 func (*compactionCLIStub) Rollback(context.Context, string) (domain.CompactionRun, error) {
 	return domain.CompactionRun{}, nil
 }
+func (*compactionCLIStub) AbandonStalePrePublication(context.Context, string) (domain.CompactionRun, error) {
+	return domain.CompactionRun{}, nil
+}
 
 func TestStoreCompactUsesDedicatedPathBoundComposition(t *testing.T) {
 	stub := &compactionCLIStub{}

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -45,6 +45,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "compact-in-flight",
+      "status": "pass",
+      "severity": "PASS",
+      "section": "Hooks",
+      "message": "no in-flight compaction journal is present",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "path",
       "status": "pass",
       "severity": "PASS",
@@ -484,6 +494,16 @@
           "auto_fix_available": false
         },
         {
+          "name": "compact-in-flight",
+          "status": "pass",
+          "severity": "PASS",
+          "section": "Hooks",
+          "message": "no in-flight compaction journal is present",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
           "name": "hook-spool",
           "status": "pass",
           "severity": "PASS",
@@ -567,7 +587,7 @@
     }
   ],
   "summary": {
-    "pass": 26,
+    "pass": 27,
     "warn": 1,
     "fail": 0
   },


### PR DESCRIPTION
Closes #2118

Leaves parent #2108 open.

Pre-publication compact journals (planned / copy_intent / copy_retry_intent / candidate_prepared) whose source identity has moved are abandoned: candidate marker/replica is removed, the journal records abandoned, and the same store compact invocation plans fresh. doctor WARNs on in-flight journals (id/phase/age); --fix applies the same abandon. swap_intent and later are never auto-abandoned. SIGINT during replica build best-effort journals abandoned via context.WithoutCancel.