### PR TITLE
docs: harden Gemini, Antigravity, and Codex update paths

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -20,6 +20,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 - **`doctor --fix` が transient dead-letter 再キューを 45 秒の壁時計内で続けて drain する (#2109)** — 1 バッチ 200 件の上限は残し、スプールが空になるか壁時計が尽きるまでループする。`--dry-run` は計画件数を全件出す。Fixes 行のカウンタ形式は変えない。
 
 ### Docs
+- Gemini / Antigravity / Codex の更新手順を v0.42 dogfood の実経路に揃える (#2116)。Gemini は `scripts/install-gemini-extension.sh`（tag pin、`--consent`、先に uninstall）。Antigravity は rsync / `agy plugin install`。Codex は headless の `codex plugin add` と local-path の `marketplace upgrade` 制限。
 - README の quickstart サンプルから削除済みの `timeline` / `tail` を外した (#2117)。代わりに `list --blocks` / `list --follow`。
 
 ## [v0.42.0] - 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 - **`doctor --fix` drains transient dead-letter requeue under the 45s wall (#2109)** — the 200-record batch cap remains, but batches loop until the spool is empty or the fixer wall clock is exhausted. `--dry-run` previews the full planned requeue count. Fixes-line counters are unchanged.
 
 ### Docs
+- Host update paths for Gemini, Antigravity, and Codex match the v0.42 dogfood workarounds (#2116). Gemini uses `scripts/install-gemini-extension.sh` (tag-pinned, `--consent`, uninstall-first). Antigravity documents rsync / `agy plugin install`. Codex documents headless `codex plugin add` and the local-path `marketplace upgrade` limitation.
 - README quickstart samples no longer show the removed `timeline` / `tail` commands (#2117). Use `list --blocks` / `list --follow`.
 
 ## [v0.42.0] - 2026-08-17

--- a/docs/integrations/antigravity.ja.md
+++ b/docs/integrations/antigravity.ja.md
@@ -179,6 +179,28 @@ alias `agy` と `antigravity-cli` は canonical な `antigravity` client に解�
 
 代わりに、同梱の plugin（[`integrations/antigravity-plugin/`](../../integrations/antigravity-plugin/)）を導入できます。同じ `traceary` hook グループに加え、公式 Antigravity スキーマに従う version 付き `plugin.json`、共有 skill 4 件（[skills](./skills.ja.md)）、任意適用の `permissions.example.json` fragment を同梱しています。workspace または user-level の Traceary hook 経路を同時に残さないでください。
 
+## Update
+
+Antigravity に `extensions update` 相当はありません。`brew upgrade traceary`（または CLI の更新）のあと、`traceary -v` と一致する checkout（`git checkout vX.Y.Z` またはその tag の clone）から packaged plugin を入れ直します。
+
+```sh
+# 現行 Antigravity が読む共有 plugin ディレクトリ
+rsync -a --delete integrations/antigravity-plugin/ ~/.gemini/config/plugins/traceary/
+
+# レガシーな CLI 専用コピーがあればそれも置き換える
+if [ -d ~/.gemini/antigravity-cli/plugins/traceary ]; then
+  rsync -a --delete integrations/antigravity-plugin/ ~/.gemini/antigravity-cli/plugins/traceary/
+fi
+```
+
+同じ checkout から次でもよいです。
+
+```sh
+agy plugin install integrations/antigravity-plugin
+```
+
+`doctor --client antigravity` がまだ stale な Gemini 形パッケージや version 不一致を出す場合は、[古い Gemini import の plugin を移行する](#古い-gemini-import-の-plugin-を移行する) と [post-upgrade plugin refresh](../release/post-upgrade-plugins.ja.md#antigravity-stale-dual-path-remediation) の dual-path 手順に従ってください。packaged plugin ではなく hooks だけの経路を使っているときだけ `traceary hooks install --client antigravity --upgrade` を再実行します。
+
 ## セットアップガイド
 
 ```sh

--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -182,6 +182,32 @@ Aliases `agy` and `antigravity-cli` resolve to the same canonical `antigravity` 
 
 Alternatively, install the packaged plugin under [`integrations/antigravity-plugin/`](../../integrations/antigravity-plugin/). It ships the same `traceary` hook group, a versioned `plugin.json` manifest following the official Antigravity schema, the four shared skills (see [skills](./skills.md)), and the opt-in `permissions.example.json` fragment. Do not also retain a direct workspace or user-level Traceary hook route.
 
+## Update
+
+Antigravity has no `extensions update` equivalent. After `brew upgrade
+traceary` (or any CLI bump), refresh the packaged plugin from the checkout
+that matches `traceary -v` (`git checkout vX.Y.Z` or a clone of that tag):
+
+```sh
+# Shared plugin directory used by current Antigravity
+rsync -a --delete integrations/antigravity-plugin/ ~/.gemini/config/plugins/traceary/
+
+# Also replace the legacy CLI-specific copy if it exists
+if [ -d ~/.gemini/antigravity-cli/plugins/traceary ]; then
+  rsync -a --delete integrations/antigravity-plugin/ ~/.gemini/antigravity-cli/plugins/traceary/
+fi
+```
+
+Or, from that same checkout:
+
+```sh
+agy plugin install integrations/antigravity-plugin
+```
+
+If `doctor --client antigravity` still reports a stale Gemini-shaped package
+or a version mismatch, follow [Migrating a stale Gemini-imported plugin](#migrating-a-stale-gemini-imported-plugin) and the dual-path notes in
+[post-upgrade plugin refresh](../release/post-upgrade-plugins.md#antigravity-stale-dual-path-remediation). Then rerun `traceary hooks install --client antigravity --upgrade` only if you use the hooks-only route instead of the packaged plugin.
+
 ## Setup guide
 
 ```sh

--- a/docs/integrations/codex-plugin.ja.md
+++ b/docs/integrations/codex-plugin.ja.md
@@ -182,14 +182,27 @@ apply path は必要に応じて target directory/file を作成し、管理ブ�
 
 ## 更新
 
-リポジトリを更新して、次回 Codex が `/plugins` をリフレッシュした時に新しいバージョンを取り込みます。
+対話更新: `traceary -v` と一致する checkout を pull したあと、Codex の `/plugins` で refresh / reinstall します。
+
+headless 更新（CLI 更新後に実際に通る経路）:
+
+```sh
+# marketplace clone — 実行中 CLI の tag と揃える
+cd ~/.codex/plugins/marketplaces/traceary-plugins   # または自分の marketplace root
+git fetch --tags
+git checkout "v$(traceary -v | awk '{print $2}')"
+codex plugin add traceary@traceary-marketplace
+```
+
+marketplace root が Git remote ではなく **local path** のとき、`codex plugin marketplace upgrade` は "No configured Git marketplaces" と返します。install 失敗ではありません。clone 内で `git pull` / `git checkout <tag>` したあと `codex plugin add traceary@traceary-marketplace` を使ってください。
+
+marketplace clone ではなく作業 tree から入れる場合:
 
 ```sh
 cd ~/src/traceary
 git pull --ff-only
+# 続けて同じ headless add、または対話セッションの /plugins
 ```
-
-plugin を一度外して入れ直したい場合は `/plugins` 画面から再インストールできます。
 
 ## Doctor と smoke test
 

--- a/docs/integrations/codex-plugin.md
+++ b/docs/integrations/codex-plugin.md
@@ -194,14 +194,31 @@ the cross-host strategy comparison and `invalid` recovery steps.
 
 ## Update
 
-Refresh the repository and let Codex pick up the new plugin version on the next `/plugins` refresh:
+Interactive refresh: pull the checkout that matches `traceary -v`, then use Codex `/plugins` to refresh or reinstall.
+
+Headless refresh (the path that actually works after a CLI upgrade):
+
+```sh
+# Marketplace clone — checkout that matches the running CLI tag
+cd ~/.codex/plugins/marketplaces/traceary-plugins   # or your marketplace root
+git fetch --tags
+git checkout "v$(traceary -v | awk '{print $2}')"
+codex plugin add traceary@traceary-marketplace
+```
+
+`codex plugin marketplace upgrade` answers "No configured Git marketplaces"
+when the marketplace root is a **local path** rather than a Git remote. That
+is expected; do not treat it as a missing install. Use `git pull` / `git
+checkout <tag>` in the clone plus `codex plugin add
+traceary@traceary-marketplace` instead.
+
+If you develop from a working tree instead of the marketplace clone:
 
 ```sh
 cd ~/src/traceary
 git pull --ff-only
+# then the same headless add, or /plugins in an interactive session
 ```
-
-If you need to bounce the plugin, `/plugins` also exposes a reinstall entry for the currently installed version.
 
 ## Doctor and smoke test
 

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -91,11 +91,20 @@ gemini extensions link integrations/gemini-extension
 
 ## Update
 
+ローカル install した Traceary extension に `gemini extensions update` を使わないでください。対話プロンプトで止まり、headless ではハングします。実行中 CLI の tag に pin して uninstall → reinstall します。
+
 ```sh
-gemini extensions update traceary
+./scripts/install-gemini-extension.sh
+# または明示的な ref:
+./scripts/install-gemini-extension.sh --ref v0.43.0
 ```
 
-特定の release に戻したい場合は、`--ref <tag>` を付けて再 install します。
+スクリプトはその tag を clone し（`main` ではない）、既存があれば `gemini extensions uninstall traceary` したあと `gemini extensions install --consent` で security prompt を避けます。スクリプトを使わず GitHub URL から入れる場合:
+
+```sh
+gemini extensions uninstall traceary
+gemini extensions install --consent https://github.com/duck8823/traceary --ref <tag>
+```
 
 ## Uninstall
 
@@ -120,8 +129,8 @@ traceary doctor --client gemini --json
 - `gemini-event-coverage`: recent Gemini session を見て、prompt/transcript が欠けた
   session 比率が `--coverage-threshold`（既定 `0.5`）を超えると警告します。audit のみの session も会話内容の coverage がないため警告対象です。
   settings.json ではなく Gemini extension package を使っている場合は、
-  `gemini extensions update traceary` で package 側の BeforeAgent /
-  AfterAgent hook を更新してください。
+  `./scripts/install-gemini-extension.sh` で CLI tag に合わせた
+  BeforeAgent / AfterAgent hook を入れ直してください。
 
 package 自体の validate は次です。
 

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -112,11 +112,26 @@ gemini extensions link integrations/gemini-extension
 
 ## Update
 
+Do not use `gemini extensions update` for a locally installed Traceary
+extension: that command waits on an interactive prompt and can hang in
+headless runs. Uninstall and reinstall instead, pinned to the running CLI
+tag:
+
 ```sh
-gemini extensions update traceary
+./scripts/install-gemini-extension.sh
+# or an explicit ref:
+./scripts/install-gemini-extension.sh --ref v0.43.0
 ```
 
-To pin a specific release again, reinstall with `--ref <tag>`.
+The script clones that tag (not `main`), runs `gemini extensions uninstall
+traceary` when a copy is already installed, then `gemini extensions install
+--consent` so the security prompt does not block. To pin a GitHub URL install
+without the script:
+
+```sh
+gemini extensions uninstall traceary
+gemini extensions install --consent https://github.com/duck8823/traceary --ref <tag>
+```
 
 ## Uninstall
 
@@ -140,9 +155,9 @@ traceary doctor --client gemini --json
   installs.
 - `gemini-event-coverage` scans recent Gemini sessions and warns when the
   prompt/transcript-missing session ratio is above `--coverage-threshold` (default `0.5`). Audit-only sessions still warn because they lack conversation coverage.
-  If you rely on the Gemini extension package instead of settings.json, update
-  it with `gemini extensions update traceary` so the packaged BeforeAgent /
-  AfterAgent hooks are refreshed.
+  If you rely on the Gemini extension package instead of settings.json, refresh
+  it with `./scripts/install-gemini-extension.sh` so the packaged BeforeAgent /
+  AfterAgent hooks are reinstalled from the matching CLI tag.
 
 Package validation:
 

--- a/docs/release/post-upgrade-plugins.ja.md
+++ b/docs/release/post-upgrade-plugins.ja.md
@@ -36,9 +36,9 @@ release 済みバイナリを更新するたびに、次を実行してくださ
 | Host | 更新 | 有効化 | version 検証 | 許可する skip |
 |---|---|---|---|---|
 | Claude Code | Claude Code 内で `claude plugins update <Traceary marketplace key>`。正確な key は `traceary doctor --client claude --json` の `FixCommand` を使います。 | 更新済み package を読み込むため、Claude Code を再起動するか新しい process を開始します。 | `traceary doctor --client claude --json` の `claude-plugin-version` が `pass`。 | Claude Code / Traceary package を意図的に導入していない場合だけ `--skip claude='理由'`。 |
-| Codex | `traceary -v` と一致する checkout の `plugins/traceary/` から再導入します。Codex plugin 文書も参照してください。 | `/plugins` で refresh / reinstall してから、新しい Codex session を開始します。 | `traceary doctor --client codex --json` の `codex-plugin-version` が `pass`。 | Codex / Traceary package を意図的に導入していない場合だけ `--skip codex='理由'`。 |
-| Gemini CLI（レガシー extension） | `gemini extensions update traceary`、その後 managed hook generation を更新（下記参照）。 | Gemini CLI を再起動します。 | `traceary doctor --client gemini --json` の `gemini-plugin-version` と `gemini-config` がどちらも `pass`。 | レガシー extension を意図的に導入していない場合だけ `--skip gemini='理由'`。 |
-| Antigravity | 下記の安全な dual path 手順を行ってから、`agy plugin install integrations/antigravity-plugin`。 | Antigravity を終了して開き直すか、新しい CLI session を開始します。 | `traceary doctor --client antigravity --json` のすべての `antigravity-plugin-version` が `pass`。一方が pass で、もう一方が version のない不完全 twin なら、後者の `skip` は許可されます。 | Antigravity / Traceary package を意図的に導入していない場合だけ `--skip antigravity='理由'`。 |
+| Codex | marketplace clone で `traceary -v` と一致する tag を `git checkout` し、`codex plugin add traceary@traceary-marketplace`。local-path marketplace では `codex plugin marketplace upgrade` は "No configured Git marketplaces" になるので使わない。対話の `/plugins` は従来どおり有効。 | add（または `/plugins` refresh）のあと新しい Codex session を開始します。 | `traceary doctor --client codex --json` の `codex-plugin-version` が `pass`。 | Codex / Traceary package を意図的に導入していない場合だけ `--skip codex='理由'`。 |
+| Gemini CLI（レガシー extension） | `./scripts/install-gemini-extension.sh`（uninstall + `install --consent`、tag pin）。その後 managed hook generation を更新（下記参照）。 | Gemini CLI を再起動します。 | `traceary doctor --client gemini --json` の `gemini-plugin-version` と `gemini-config` がどちらも `pass`。 | レガシー extension を意図的に導入していない場合だけ `--skip gemini='理由'`。 |
+| Antigravity | `traceary -v` と一致する checkout から `rsync -a --delete integrations/antigravity-plugin/` を `~/.gemini/config/plugins/traceary/`（と、あればレガシー `~/.gemini/antigravity-cli/plugins/traceary/`）へ、または `agy plugin install integrations/antigravity-plugin`。doctor がまだ stale twin を出す場合は下記の dual path 手順。 | Antigravity を終了して開き直すか、新しい CLI session を開始します。 | `traceary doctor --client antigravity --json` のすべての `antigravity-plugin-version` が `pass`。一方が pass で、もう一方が version のない不完全 twin なら、後者の `skip` は許可されます。 | Antigravity / Traceary package を意図的に導入していない場合だけ `--skip antigravity='理由'`。 |
 | Grok Build | `./scripts/install-grok-plugin.sh`。 | Grok Build を再起動するか、新しい session を開始します。 | `traceary doctor --client grok --json` の `grok-plugin` が `pass`。 | Grok Build / Traceary package を意図的に導入していない場合だけ `--skip grok='理由'`。 |
 | Kimi Code | `./scripts/install-kimi-plugin.sh`。installer は新しい generation を stage し、managed `traceary` symlink を atomic に切り替え、install record を保持します。 | `/plugins reload` を実行するか、**新しい Kimi session を開始**します。 | `traceary doctor --client kimi --json` の `kimi-plugin-version` と native `kimi-plugin` が健全。 | Kimi Code / Traceary package を意図的に導入していない場合だけ `--skip kimi='理由'`。 |
 
@@ -46,9 +46,9 @@ doctor が正確な非対話コマンドを `FixCommand` に出す場合は、�
 
 ## Gemini managed hook generation の更新
 
-`gemini extensions update traceary` は `~/.gemini/extensions/traceary/` 内の extension パッケージを更新しますが、`~/.gemini/settings.json` 内にすでに存在する Traceary 管理の hook エントリは**書き換えません**。それらのエントリは古い hook generation によって書かれたものであり、timeout が古い値のまま残ることがあります（例: 現行の 10000 ms に対して 5000 ms）。Doctor はこれを `gemini-config=warn` として `installed=…ms desired=…ms` のドリフトメッセージと共に報告します。
+`./scripts/install-gemini-extension.sh` は `~/.gemini/extensions/traceary/` 内の extension パッケージを入れ直します（uninstall のあと `install --consent`、実行中 CLI の tag に pin）。`~/.gemini/settings.json` 内にすでに存在する Traceary 管理の hook エントリは**書き換えません**。それらのエントリは古い hook generation によって書かれたものであり、timeout が古い値のまま残ることがあります（例: 現行の 10000 ms に対して 5000 ms）。Doctor はこれを `gemini-config=warn` として `installed=…ms desired=…ms` のドリフトメッセージと共に報告します。
 
-`gemini extensions update traceary` を実行したあと、次のコマンドを実行してください。
+ローカル install に `gemini extensions update traceary` を使わないでください。対話プロンプトで止まります。スクリプトのあと、次を実行してください。
 
 ```sh
 # プレビュー — Traceary 管理エントリへの変更内容だけを表示します。

--- a/docs/release/post-upgrade-plugins.md
+++ b/docs/release/post-upgrade-plugins.md
@@ -36,9 +36,9 @@ After every released binary upgrade:
 | Host | Refresh | Activation | Version verification | Supported skip |
 |---|---|---|---|---|
 | Claude Code | In Claude Code, run `claude plugins update <Traceary marketplace key>`; `traceary doctor --client claude --json` prints the exact key in `FixCommand`. | Restart Claude Code (or start a new process) so the updated package is loaded. | `traceary doctor --client claude --json` → `claude-plugin-version` is `pass`. | `--skip claude='reason'` only when Claude Code/its Traceary package is intentionally not installed. |
-| Codex | Reinstall the plugin from `plugins/traceary/` in the checkout that matches `traceary -v`; see the Codex plugin documentation. | Use `/plugins` to refresh/reinstall the package, then start a new Codex session. | `traceary doctor --client codex --json` → `codex-plugin-version` is `pass`. | `--skip codex='reason'` only when Codex/its Traceary package is intentionally not installed. |
-| Gemini CLI (legacy extension) | `gemini extensions update traceary`, then refresh managed hook generation (see below). | Restart Gemini CLI. | `traceary doctor --client gemini --json` → `gemini-plugin-version` is `pass` and `gemini-config` is `pass`. | `--skip gemini='reason'` only when the legacy extension is intentionally not installed. |
-| Antigravity | Use the safe dual-path procedure below, then `agy plugin install integrations/antigravity-plugin`. | Quit and reopen Antigravity (or start a new CLI session). | `traceary doctor --client antigravity --json` → every `antigravity-plugin-version` is `pass`, or an incomplete twin is the documented `skip` while another copy passes. | `--skip antigravity='reason'` only when Antigravity/its Traceary package is intentionally not installed. |
+| Codex | In the marketplace clone, `git checkout` the tag matching `traceary -v`, then `codex plugin add traceary@traceary-marketplace`. Do not use `codex plugin marketplace upgrade` on a local-path marketplace (it reports "No configured Git marketplaces"). Interactive `/plugins` remains valid. | Start a new Codex session after the add (or `/plugins` refresh). | `traceary doctor --client codex --json` → `codex-plugin-version` is `pass`. | `--skip codex='reason'` only when Codex/its Traceary package is intentionally not installed. |
+| Gemini CLI (legacy extension) | `./scripts/install-gemini-extension.sh` (uninstall + `install --consent`, tag-pinned). Then refresh managed hook generation (see below). | Restart Gemini CLI. | `traceary doctor --client gemini --json` → `gemini-plugin-version` is `pass` and `gemini-config` is `pass`. | `--skip gemini='reason'` only when the legacy extension is intentionally not installed. |
+| Antigravity | From the checkout matching `traceary -v`, `rsync -a --delete integrations/antigravity-plugin/` onto `~/.gemini/config/plugins/traceary/` (and the legacy `~/.gemini/antigravity-cli/plugins/traceary/` copy if present), or `agy plugin install integrations/antigravity-plugin`. If doctor still reports a stale twin, use the dual-path procedure below. | Quit and reopen Antigravity (or start a new CLI session). | `traceary doctor --client antigravity --json` → every `antigravity-plugin-version` is `pass`, or an incomplete twin is the documented `skip` while another copy passes. | `--skip antigravity='reason'` only when Antigravity/its Traceary package is intentionally not installed. |
 | Grok Build | `./scripts/install-grok-plugin.sh`. | Restart Grok Build or start a new session. | `traceary doctor --client grok --json` → `grok-plugin` is `pass`. | `--skip grok='reason'` only when Grok Build/its Traceary package is intentionally not installed. |
 | Kimi Code | `./scripts/install-kimi-plugin.sh`. The installer stages a new generation and atomically flips the managed `traceary` symlink while preserving the install record. | Run `/plugins reload` **or start a new Kimi session**. | `traceary doctor --client kimi --json` → `kimi-plugin-version` and native `kimi-plugin` are healthy. | `--skip kimi='reason'` only when Kimi Code/its Traceary package is intentionally not installed. |
 
@@ -46,14 +46,16 @@ Prefer the `FixCommand` printed by doctor when it provides an exact non-interact
 
 ## Gemini managed hook generation refresh
 
-`gemini extensions update traceary` updates the extension package in
-`~/.gemini/extensions/traceary/` but does **not** rewrite the Traceary-managed
-hook entries already present in `~/.gemini/settings.json`. Those entries were
+`./scripts/install-gemini-extension.sh` replaces the extension package in
+`~/.gemini/extensions/traceary/` (uninstall then `install --consent`, pinned
+to the running CLI tag). It does **not** rewrite the Traceary-managed hook
+entries already present in `~/.gemini/settings.json`. Those entries were
 written by an older hook generation and may have stale timeouts (for example,
 5000 ms instead of the current 10000 ms). Doctor reports this as
 `gemini-config=warn` with an `installed=…ms desired=…ms` drift message.
 
-After running `gemini extensions update traceary`, run:
+Do not run `gemini extensions update traceary` for a local install — that
+command prompts interactively. After the script, run:
 
 ```sh
 # Preview — shows only what would change in Traceary-managed entries.

--- a/scripts/install-gemini-extension.sh
+++ b/scripts/install-gemini-extension.sh
@@ -2,29 +2,75 @@
 
 set -euo pipefail
 
-# Check for Traceary CLI
+usage() {
+    cat >&2 <<'EOF'
+usage: scripts/install-gemini-extension.sh [--ref <git-ref>]
+
+Installs the Traceary Gemini extension from a clean clone, then installs
+project hooks. Existing installs are uninstalled first: `gemini extensions
+update` prompts interactively on local installs and is not used.
+
+--ref defaults to v$(traceary -v version), so a tagged CLI is not silently
+paired with main-branch hooks. Override with --ref or TRACEARY_GEMINI_REF.
+EOF
+}
+
+REF="${TRACEARY_GEMINI_REF:-}"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ref)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "error: --ref requires a git ref" >&2
+                exit 64
+            fi
+            REF="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 64
+            ;;
+    esac
+done
+
 if ! command -v traceary &> /dev/null; then
     echo "❌ traceary is not installed. Please install it first (e.g., brew install traceary or go install github.com/duck8823/traceary@latest)"
     exit 1
 fi
 
-# Check for Gemini CLI
 if ! command -v gemini &> /dev/null; then
     echo "❌ gemini is not installed. Please install it first (e.g., npm install -g @google/gemini-cli)"
     exit 1
 fi
 
-# Install extension from a clean clone to avoid path issues
-TMP_DIR=$(mktemp -d)
-echo "Cloning latest Traceary for extension assets..."
-git clone --depth 1 https://github.com/duck8823/traceary.git "$TMP_DIR"
-echo "Installing Gemini extension..."
-gemini extensions install "$TMP_DIR/integrations/gemini-extension"
-rm -rf "$TMP_DIR"
+if [[ -z "$REF" ]]; then
+    cli_version="$(traceary -v | awk '{print $2}')"
+    if [[ -z "$cli_version" ]]; then
+        echo "error: could not parse version from \`traceary -v\`" >&2
+        exit 1
+    fi
+    REF="v${cli_version#v}"
+fi
 
-# Install hooks to .gemini/settings.json in current project
+TMP_DIR=$(mktemp -d)
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+echo "Cloning Traceary ${REF} for extension assets..."
+git clone --depth 1 --branch "$REF" https://github.com/duck8823/traceary.git "$TMP_DIR"
+
+# Local installs hang on `gemini extensions update`. Uninstall-then-install is
+# the non-interactive refresh. --consent skips the security prompt.
+echo "Refreshing Gemini extension (uninstall existing, then install --consent)..."
+gemini extensions uninstall traceary >/dev/null 2>&1 || true
+gemini extensions install --consent "$TMP_DIR/integrations/gemini-extension"
+
 echo "Configuring Traceary hooks for Gemini CLI in current project..."
 traceary hooks install --client gemini --project-dir .
 
 echo "✅ Traceary Gemini extension installed and configured successfully!"
-echo "Run 'traceary doctor --client gemini' to verify."
+echo "Pinned to ${REF}. Run 'traceary doctor --client gemini' to verify."


### PR DESCRIPTION
Closes #2116

Leaves parent #2108 open.

Gemini installer pins the clone to the running CLI tag, uninstalls first, and uses install --consent. Docs stop recommending gemini extensions update for local installs. Antigravity gets an Update section (rsync / agy plugin install). Codex documents headless plugin add and the local-path marketplace upgrade limitation. post-upgrade-plugins matrix matches.

CLI doctor hints still mention gemini extensions update (issue scoped this PR to docs plus scripts only).