### PR TITLE
fix: bound shared store lease and fail fast on self-deadlock

### DIFF
--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -60,6 +60,7 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 		return application.CompactResult{}, fmt.Errorf("compaction store binding mismatch")
 	}
 	cutoff := application.CompactCutoff(in.Now, in.KeepDays)
+	u.reportWindow("inspect_gate")
 	if setter, ok := u.builder.(compactFilterSetter); ok {
 		filter := application.CompactFilter{Cutoff: cutoff, WorkDir: strings.TrimSpace(in.WorkDir)}
 		if in.Force && u.cover != nil {
@@ -85,6 +86,7 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 	if beforeErr != nil {
 		return application.CompactResult{}, fmt.Errorf("stat compaction source: %w", beforeErr)
 	}
+	u.reportWindow("exclusive_lease")
 	release, err := u.lease.AcquireExclusive(ctx, u.expectedStore)
 	if err != nil {
 		return application.CompactResult{}, err
@@ -92,6 +94,7 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 	defer release()
 	// Measure after the exclusive lease so released_* matches the work-copy
 	// clear. A pre-lease SUM can miss a writer that lands before the copy.
+	u.reportWindow("inspect_reclaim")
 	var reclaim application.CommandBodyReclaim
 	if inspector, ok := u.builder.(application.CommandBodyReclaimInspector); ok {
 		measured, inspectErr := inspector.InspectCommandBodyReclaim(ctx, source)
@@ -114,6 +117,7 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 	if strings.TrimSpace(in.WorkDir) != "" {
 		strategy = application.CompactStrategyExternal
 	}
+	u.reportWindow("plan")
 	run, err := u.compactLeased(ctx, source)
 	if err != nil {
 		if isInsufficientCompactionSpace(err) && strategy != application.CompactStrategyInPlace {
@@ -318,7 +322,20 @@ func (u *storeCompactionUsecase) planLeased(ctx context.Context, source string) 
 	if err := u.journal.Create(ctx, planned); err != nil {
 		return domain.CompactionRun{}, err
 	}
+	if u.progress != nil {
+		u.progress.OnPhase(planned.Phase, planned.Resources.DestinationBytes)
+	}
 	return planned, nil
+}
+
+type compactionWindowProgress interface {
+	OnWindow(name string)
+}
+
+func (u *storeCompactionUsecase) reportWindow(name string) {
+	if w, ok := u.progress.(compactionWindowProgress); ok {
+		w.OnWindow(name)
+	}
 }
 
 func (u *storeCompactionUsecase) Apply(ctx context.Context, id string) (domain.CompactionRun, error) {

--- a/application/usecase/store_compaction_progress_test.go
+++ b/application/usecase/store_compaction_progress_test.go
@@ -2,14 +2,22 @@ package usecase
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/duck8823/traceary/application"
 	"github.com/duck8823/traceary/domain"
 )
 
 type recordProgress struct {
 	phases  []domain.CompactionPhase
+	windows []string
 	watches int
+}
+
+func (r *recordProgress) OnWindow(name string) {
+	r.windows = append(r.windows, name)
 }
 
 func (r *recordProgress) OnPhase(phase domain.CompactionPhase, _ uint64) {
@@ -37,5 +45,25 @@ func TestBindCompactionProgress_ReportsPhaseAndBuildWatch(t *testing.T) {
 	}
 	if progress.watches == 0 {
 		t.Fatalf("WatchBuild was not called; phases=%v", progress.phases)
+	}
+}
+
+func TestCompact_ReportsPreCopyWindows(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "store.db")
+	if err := os.WriteFile(source, []byte("not-a-real-store"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	progress := &recordProgress{}
+	svc := NewStoreCompactionUsecase(source, &faultJournal{run: compactionRunAt(domain.CompactionCommitted)}, faultBuilder{}, faultFiles{}, faultLease{})
+	BindCompactionProgress(svc, progress)
+	_, _ = svc.Compact(context.Background(), application.CompactInput{Source: source})
+	want := []string{"inspect_gate", "exclusive_lease", "inspect_reclaim", "plan"}
+	if len(progress.windows) < len(want) {
+		t.Fatalf("windows=%v, want at least %v", progress.windows, want)
+	}
+	for i, name := range want {
+		if progress.windows[i] != name {
+			t.Fatalf("windows[%d]=%q, want %q (all=%v)", i, progress.windows[i], name, progress.windows)
+		}
 	}
 }

--- a/infrastructure/filesystem/file_retention_datasource_unix_test.go
+++ b/infrastructure/filesystem/file_retention_datasource_unix_test.go
@@ -38,13 +38,14 @@ func TestFileRetentionLiveGenerationHonorsContextWhileExclusiveLeaseHeld(t *test
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	started := time.Now()
-	if _, err := fileRetentionLiveGeneration(ctx, "backup", path); !errors.Is(err, context.DeadlineExceeded) {
+	_, liveErr := fileRetentionLiveGeneration(ctx, "backup", path)
+	if liveErr == nil || !strings.Contains(liveErr.Error(), "self-deadlock") {
 		release()
-		t.Fatalf("live generation error=%v, want deadline", err)
+		t.Fatalf("live generation error=%v, want same-process self-deadlock", liveErr)
 	}
 	if time.Since(started) > time.Second {
 		release()
-		t.Fatal("live generation did not cancel promptly")
+		t.Fatal("live generation did not fail promptly")
 	}
 	release()
 	if _, err := fileRetentionLiveGeneration(context.Background(), "backup", path); err != nil {

--- a/infrastructure/sqlite/compaction_sqlite_test.go
+++ b/infrastructure/sqlite/compaction_sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -174,6 +175,47 @@ func TestStoreCompactionSmallAllocatedShapeE2E(t *testing.T) {
 	}
 	if restored.Inode != original.Inode {
 		t.Fatalf("original inode not restored: %d != %d", restored.Inode, original.Inode)
+	}
+}
+
+func TestCompact_CompletesWhileOtherProcessWaitsForSharedLease(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	db, err := sql.Open("sqlite", directSQLiteRWDSNCreate(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE sample(id INTEGER PRIMARY KEY, body BLOB); INSERT INTO sample(body) VALUES(zeroblob(65536)),('queryable')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	journal := &CompactionFileJournal{Dir: filepath.Join(dir, "journal")}
+	service := usecase.NewStoreCompactionUsecase(source, journal, SQLiteCompactionBuilder{}, StoreReplacementFiles{CallerHoldsExclusiveLease: true}, StoreLeaseCoordinator{})
+	done := make(chan error, 1)
+	go func() {
+		_, compactErr := service.Compact(ctx, application.CompactInput{Source: source})
+		done <- compactErr
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStoreLeaseHelperProcess$")
+	cmd.Env = append(os.Environ(), "TRACEARY_STORE_LEASE_HELPER=1", "TRACEARY_STORE_LEASE_PATH="+source)
+	if startErr := cmd.Start(); startErr != nil {
+		t.Fatal(startErr)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+	select {
+	case compactErr := <-done:
+		if compactErr != nil {
+			t.Fatalf("Compact: %v", compactErr)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Compact stalled while another process waited for a shared lease")
 	}
 }
 

--- a/infrastructure/sqlite/store_lease.go
+++ b/infrastructure/sqlite/store_lease.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -15,16 +16,35 @@ const storeLeaseSuffix = ".traceary.lock"
 
 // exclusiveLeaseAcquireTimeout bounds exclusive flock polling when the
 // caller did not set a deadline. A same-process idle shared lease used
-// to wait forever (#2120).
+// to wait forever (#2120). Shared acquire uses the same default (#2149).
 const exclusiveLeaseAcquireTimeout = 60 * time.Second
+
+const sharedLeaseAcquireTimeout = exclusiveLeaseAcquireTimeout
+
+// errStoreLeaseSelfDeadlock is returned when this process already holds
+// the exclusive lease and then requests a shared flock on a second fd.
+// flock is per open file description; that poll can never succeed (#2149).
+var errStoreLeaseSelfDeadlock = errors.New("store lease self-deadlock")
 
 var exclusiveLeaseWaitInterval = 10 * time.Second
 
 var exclusiveLeaseWaitReporter func(waited time.Duration, lockPath string)
 
+var sharedLeaseWaitReporter func(waited time.Duration, lockPath string)
+
+// exclusiveHeldByProcess tracks lock paths whose exclusive fd is held
+// by this process. Connect consults it before polling LOCK_SH.
+var exclusiveHeldByProcess sync.Map
+
 // SetExclusiveLeaseWaitReporter installs a stderr-style waiter hook.
 func SetExclusiveLeaseWaitReporter(fn func(waited time.Duration, lockPath string)) {
 	exclusiveLeaseWaitReporter = fn
+}
+
+// SetSharedLeaseWaitReporter installs a stderr-style waiter hook for
+// shared flock polling.
+func SetSharedLeaseWaitReporter(fn func(waited time.Duration, lockPath string)) {
+	sharedLeaseWaitReporter = fn
 }
 
 func bindExclusiveLeaseDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -32,6 +52,22 @@ func bindExclusiveLeaseDeadline(ctx context.Context) (context.Context, context.C
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, exclusiveLeaseAcquireTimeout)
+}
+
+func bindSharedLeaseDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, sharedLeaseAcquireTimeout)
+}
+
+func processHoldsExclusiveLease(lockPath string) bool {
+	_, ok := exclusiveHeldByProcess.Load(lockPath)
+	return ok
+}
+
+func selfDeadlockError(lockPath string) error {
+	return fmt.Errorf("%w on %s: this process already holds the exclusive lease", errStoreLeaseSelfDeadlock, lockPath)
 }
 
 func canonicalStorePath(path string) (string, error) {
@@ -77,8 +113,14 @@ func (StoreLeaseCoordinator) AcquireExclusive(ctx context.Context, path string) 
 		_ = lease.Close()
 		return nil, err
 	}
+	exclusiveHeldByProcess.Store(lockPath, struct{}{})
 	var once sync.Once
-	return func() { once.Do(func() { _ = lease.Close() }) }, nil
+	return func() {
+		once.Do(func() {
+			exclusiveHeldByProcess.Delete(lockPath)
+			_ = lease.Close()
+		})
+	}, nil
 }
 
 func probeStoreLeaseCapability(ctx context.Context, path string) error {
@@ -123,9 +165,14 @@ func (c *storeLeaseConnector) Connect(ctx context.Context) (driver.Conn, error) 
 	if err := validateStoreLinkIdentity(c.storePath); err != nil {
 		return nil, err
 	}
+	if processHoldsExclusiveLease(c.lockPath) {
+		return nil, selfDeadlockError(c.lockPath)
+	}
+	ctx, cancel := bindSharedLeaseDeadline(ctx)
+	defer cancel()
 	lease, err := acquireAdvisoryLease(ctx, c.lockPath, false)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("wait for shared store lease on %s: %w; inspect holders with lsof %s", c.lockPath, err, c.lockPath)
 	}
 	conn, err := c.driver.Open(c.dsn)
 	if err != nil {

--- a/infrastructure/sqlite/store_lease_exclusive_test.go
+++ b/infrastructure/sqlite/store_lease_exclusive_test.go
@@ -43,6 +43,63 @@ func TestAcquireExclusive_TimesOutWhileSharedConnHeld(t *testing.T) {
 	}
 }
 
+func TestCoordinatedOpen_FailsFastWhenThisProcessHoldsExclusive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	release, err := (StoreLeaseCoordinator{}).AcquireExclusive(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	started := time.Now()
+	db := openCoordinatedDB(path, sqliteDSN(path))
+	defer func() { _ = db.Close() }()
+	err = db.PingContext(context.Background())
+	if err == nil {
+		t.Fatal("coordinated ping succeeded while this process holds exclusive")
+	}
+	if !strings.Contains(err.Error(), "self-deadlock") || !strings.Contains(err.Error(), storeLeaseSuffix) {
+		t.Fatalf("error should name self-deadlock and lock path, got %v", err)
+	}
+	if time.Since(started) > time.Second {
+		t.Fatalf("self-deadlock took %s, want fail-fast", time.Since(started))
+	}
+}
+
+func TestSharedLease_TimesOutWhileExclusiveHeldOnOtherFd(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	lockPath, err := canonicalLeasePath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := acquireAdvisoryLease(context.Background(), lockPath, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+
+	var reports int
+	SetSharedLeaseWaitReporter(func(time.Duration, string) { reports++ })
+	t.Cleanup(func() { SetSharedLeaseWaitReporter(nil) })
+	orig := exclusiveLeaseWaitInterval
+	exclusiveLeaseWaitInterval = 15 * time.Millisecond
+	t.Cleanup(func() { exclusiveLeaseWaitInterval = orig })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+	db := openCoordinatedDB(path, sqliteDSN(path))
+	defer func() { _ = db.Close() }()
+	err = db.PingContext(ctx)
+	if err == nil {
+		t.Fatal("shared lease acquired while exclusive flock was held")
+	}
+	if !strings.Contains(err.Error(), "lsof") || !strings.Contains(err.Error(), storeLeaseSuffix) {
+		t.Fatalf("error should name lock path and lsof, got %v", err)
+	}
+	if reports == 0 {
+		t.Fatal("expected shared wait reporter while blocked")
+	}
+}
+
 func TestAcquireExclusive_WaitReporterFires(t *testing.T) {
 	orig := exclusiveLeaseWaitInterval
 	exclusiveLeaseWaitInterval = 15 * time.Millisecond

--- a/infrastructure/sqlite/store_lease_unix.go
+++ b/infrastructure/sqlite/store_lease_unix.go
@@ -33,6 +33,9 @@ func validateStoreLinkIdentity(path string) error {
 }
 
 func acquireAdvisoryLease(ctx context.Context, path string, exclusive bool) (advisoryLease, error) {
+	if !exclusive && processHoldsExclusiveLease(path) {
+		return nil, selfDeadlockError(path)
+	}
 	fd, err := syscall.Open(path, syscall.O_CREAT|syscall.O_RDWR|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open store lease: %w", err)
@@ -63,12 +66,16 @@ func acquireAdvisoryLease(ctx context.Context, path string, exclusive bool) (adv
 			_ = file.Close()
 			return nil, fmt.Errorf("acquire store lease: %w", err)
 		}
-		if exclusive {
-			now := time.Now()
-			if reporter := exclusiveLeaseWaitReporter; reporter != nil && now.Sub(lastWait) >= exclusiveLeaseWaitInterval {
-				reporter(now.Sub(started), path)
-				lastWait = now
+		now := time.Now()
+		if now.Sub(lastWait) >= exclusiveLeaseWaitInterval {
+			reporter := sharedLeaseWaitReporter
+			if exclusive {
+				reporter = exclusiveLeaseWaitReporter
 			}
+			if reporter != nil {
+				reporter(now.Sub(started), path)
+			}
+			lastWait = now
 		}
 		select {
 		case <-ctx.Done():

--- a/main.go
+++ b/main.go
@@ -253,6 +253,9 @@ func run() error {
 			sqlite.SetExclusiveLeaseWaitReporter(func(waited time.Duration, lockPath string) {
 				_, _ = fmt.Fprintf(os.Stderr, "compact: waiting for exclusive store lease (%s) on %s\n", waited.Round(time.Second), lockPath)
 			})
+			sqlite.SetSharedLeaseWaitReporter(func(waited time.Duration, lockPath string) {
+				_, _ = fmt.Fprintf(os.Stderr, "traceary: waiting for shared store lease (%s) on %s\n", waited.Round(time.Second), lockPath)
+			})
 			svc := usecase.NewStoreCompactionUsecase(path, journal, builder, sqlite.StoreReplacementFiles{CallerHoldsExclusiveLease: true}, sqlite.StoreLeaseCoordinator{})
 			usecase.BindCompactionWorkCover(svc, compactWorkCover(migrationsSubFS))
 			return svc

--- a/presentation/cli/store_compaction_progress.go
+++ b/presentation/cli/store_compaction_progress.go
@@ -21,6 +21,13 @@ func newCLICompactionProgress(w io.Writer) cliCompactionProgress {
 	return cliCompactionProgress{w: w, now: time.Now}
 }
 
+func (p cliCompactionProgress) OnWindow(name string) {
+	if p.w == nil || name == "" {
+		return
+	}
+	_, _ = fmt.Fprintf(p.w, "compact: %s\n", name)
+}
+
 func (p cliCompactionProgress) OnPhase(phase domain.CompactionPhase, destinationBytes uint64) {
 	if p.w == nil {
 		return

--- a/presentation/cli/store_compaction_progress_test.go
+++ b/presentation/cli/store_compaction_progress_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/duck8823/traceary/domain"
 )
 
+func TestCLICompactionProgress_OnWindowWritesPreCopyToken(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	p := newCLICompactionProgress(&buf)
+	p.OnWindow("inspect_reclaim")
+	if buf.String() != "compact: inspect_reclaim\n" {
+		t.Fatalf("window line = %q", buf.String())
+	}
+}
+
 func TestCLICompactionProgress_OnPhaseWritesStderrOnlyShape(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer


### PR DESCRIPTION
Closes #2149

Leaves parent #2126 open.

## Summary

Shared store-lease acquisition was unbounded and silent. After exclusive acquire, a same-process coordinated `LOCK_SH` poll can never succeed (flock is per open file description) and hung live compact for 19+ minutes with no `copy_intent` output.

This PR:

- Bounds shared acquire to the same 60s default as exclusive (caller deadline still wins) and prints wait lines on stderr
- Fails fast when this process already holds exclusive, naming the lock path
- Prints pre-copy windows (`inspect_gate`, `exclusive_lease`, `inspect_reclaim`, `plan`) plus the existing `planned` journal phase so a stall is visible before `copy_intent`
- Keeps compact inspect/build on direct openers so default compact still completes while another process waits for shared

## Test plan

- [x] `go test ./...`
- [x] `go tool golangci-lint run`
- [x] Real-flock tests: self-deadlock fail-fast, shared timeout + reporter, Compact completes while another process waits for shared
