### PR TITLE
fix: back off extract workers while compact waits for exclusive

### DIFF
--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -87,6 +87,8 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 		return application.CompactResult{}, fmt.Errorf("stat compaction source: %w", beforeErr)
 	}
 	u.reportWindow("exclusive_lease")
+	ctx, stopExclusiveWait := bindCompactExclusiveWait(ctx)
+	defer stopExclusiveWait()
 	release, err := u.lease.AcquireExclusive(ctx, u.expectedStore)
 	if err != nil {
 		return application.CompactResult{}, err
@@ -336,6 +338,17 @@ func (u *storeCompactionUsecase) reportWindow(name string) {
 	if w, ok := u.progress.(compactionWindowProgress); ok {
 		w.OnWindow(name)
 	}
+}
+
+// compactExclusiveWait outlives one in-flight extract job so workers that
+// honor the compact-pending marker can finish the current job and back off.
+const compactExclusiveWait = 5 * time.Minute
+
+func bindCompactExclusiveWait(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, compactExclusiveWait)
 }
 
 func (u *storeCompactionUsecase) Apply(ctx context.Context, id string) (domain.CompactionRun, error) {

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -39,6 +39,15 @@ run中にopenerが現れたことを意味し、runは中止されます。
 
 このsidecar recoveryは`store compact`に限られます。
 
+`hook memory-extract-worker` は Extract job のあいだ shared store lease を保持します。
+次の job を始める前に、lease file の隣にある内部 compact-pending marker を見ます。
+marker があるときは新しい job を始めません。実行中の job は最後まで走り、worker は
+残ジョブを spool に残して終了します。compact は exclusive lease 待ちの前にこの
+marker を書き、lease 解放時に消します。exclusive timeout のエラーは、`lsof` が
+見えるとき holder の pid と command を含みます。extract worker を kill しないで
+ください。backoff で空きができます。spool を空にしたいときだけ `doctor --fix` です。
+
+
 退役済み検索インデックスは work copy 上で DROP します。source に残っていても
 compact は拒否しません。詳細は
 [`search-retirement.ja.md`](../operations/search-retirement.ja.md) を参照して

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -48,6 +48,17 @@ arrived mid-run and the run aborts.
 
 This sidecar recovery is specific to `store compact`.
 
+`hook memory-extract-worker` holds a shared store lease for each Extract job.
+Before starting a job it checks an internal compact-pending marker next to the
+store lease file. If the marker is present it finishes nothing new: the current
+job (if already running) completes, then the worker exits and leaves remaining
+jobs on the spool. Compact writes that marker before waiting for the exclusive
+lease and removes it when the lease is released. Exclusive-timeout errors name
+the lock holder pid and command when `lsof` can see them. Do not kill extract
+workers by hand; drain happens by this backoff, or by `doctor --fix` if you
+need the spool empty for another reason.
+
+
 The retired search index family is dropped on the work copy. Compact no longer
 refuses a source that still carries it. See
 [`search-retirement.md`](../operations/search-retirement.md).

--- a/infrastructure/sqlite/store_lease.go
+++ b/infrastructure/sqlite/store_lease.go
@@ -103,13 +103,19 @@ func (StoreLeaseCoordinator) AcquireExclusive(ctx context.Context, path string) 
 		return nil, err
 	}
 	lockPath := canonical + storeLeaseSuffix
+	_ = writeCompactPendingMarker(canonical)
 	ctx, cancel := bindExclusiveLeaseDeadline(ctx)
 	defer cancel()
 	lease, err := acquireAdvisoryLease(ctx, lockPath, true)
 	if err != nil {
+		clearCompactPendingMarker(canonical)
+		if holders := describeStoreLeaseHolders(lockPath); holders != "" {
+			return nil, fmt.Errorf("wait for exclusive store lease on %s: %w; held by %s", lockPath, err, holders)
+		}
 		return nil, fmt.Errorf("wait for exclusive store lease on %s: %w; inspect holders with lsof %s", lockPath, err, lockPath)
 	}
 	if err := validateStoreLinkIdentity(canonical); err != nil {
+		clearCompactPendingMarker(canonical)
 		_ = lease.Close()
 		return nil, err
 	}
@@ -118,6 +124,7 @@ func (StoreLeaseCoordinator) AcquireExclusive(ctx context.Context, path string) 
 	return func() {
 		once.Do(func() {
 			exclusiveHeldByProcess.Delete(lockPath)
+			clearCompactPendingMarker(canonical)
 			_ = lease.Close()
 		})
 	}, nil

--- a/infrastructure/sqlite/store_lease_exclusive_test.go
+++ b/infrastructure/sqlite/store_lease_exclusive_test.go
@@ -38,8 +38,12 @@ func TestAcquireExclusive_TimesOutWhileSharedConnHeld(t *testing.T) {
 	defer cancel()
 	if _, err := (StoreLeaseCoordinator{}).AcquireExclusive(ctx, path); err == nil {
 		t.Fatal("exclusive lease acquired while a shared conn was held")
-	} else if !strings.Contains(err.Error(), "lsof") || !strings.Contains(err.Error(), storeLeaseSuffix) {
-		t.Fatalf("error should name lock path and lsof, got %v", err)
+	} else if !strings.Contains(err.Error(), storeLeaseSuffix) {
+		t.Fatalf("error should name lock path, got %v", err)
+	} else if !strings.Contains(err.Error(), "held by") && !strings.Contains(err.Error(), "lsof") {
+		t.Fatalf("error should name holder or lsof, got %v", err)
+	} else if strings.Contains(err.Error(), "held by") && !strings.Contains(err.Error(), "pid=") {
+		t.Fatalf("named holder should include pid, got %v", err)
 	}
 }
 

--- a/infrastructure/sqlite/store_lease_holders_unix.go
+++ b/infrastructure/sqlite/store_lease_holders_unix.go
@@ -1,0 +1,53 @@
+//go:build darwin || linux
+
+package sqlite
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func describeStoreLeaseHolders(lockPath string) string {
+	cmd := exec.Command("lsof", "-F", "pcn", "--", lockPath)
+	out, err := cmd.Output()
+	if err != nil || len(out) == 0 {
+		return ""
+	}
+	var holders []string
+	var pid, command string
+	for _, line := range bytes.Split(out, []byte("\n")) {
+		if len(line) < 2 {
+			continue
+		}
+		switch line[0] {
+		case 'p':
+			if pid != "" {
+				holders = append(holders, formatLeaseHolder(pid, command))
+			}
+			pid = string(line[1:])
+			command = ""
+		case 'c':
+			command = string(line[1:])
+		}
+	}
+	if pid != "" {
+		holders = append(holders, formatLeaseHolder(pid, command))
+	}
+	if len(holders) == 0 {
+		return ""
+	}
+	return strings.Join(holders, "; ")
+}
+
+func formatLeaseHolder(pid, command string) string {
+	if _, err := strconv.Atoi(pid); err != nil {
+		return strings.TrimSpace(command + " " + pid)
+	}
+	if command == "" {
+		return "pid=" + pid
+	}
+	return fmt.Sprintf("pid=%s command=%s", pid, command)
+}

--- a/infrastructure/sqlite/store_lease_holders_unsupported.go
+++ b/infrastructure/sqlite/store_lease_holders_unsupported.go
@@ -1,0 +1,5 @@
+//go:build !darwin && !linux
+
+package sqlite
+
+func describeStoreLeaseHolders(string) string { return "" }

--- a/infrastructure/sqlite/store_lease_pending.go
+++ b/infrastructure/sqlite/store_lease_pending.go
@@ -1,0 +1,74 @@
+//nolint:wrapcheck // Marker helpers preserve path-level errors for lease callers.
+package sqlite
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const compactPendingSuffix = ".traceary.compact-pending"
+
+// CompactPendingMarkerPath is the internal file adjacent to the store lease.
+func CompactPendingMarkerPath(storePath string) (string, error) {
+	canonical, err := canonicalStorePath(storePath)
+	if err != nil {
+		return "", err
+	}
+	return canonical + compactPendingSuffix, nil
+}
+
+// CompactPendingActive reports whether compact (or another exclusive waiter)
+// asked extract workers to finish the current job and not start another.
+// A marker whose pid is not alive is treated as stale and removed.
+func CompactPendingActive(storePath string) bool {
+	path, err := CompactPendingMarkerPath(storePath)
+	if err != nil {
+		return false
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	pid, convErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if convErr != nil || pid <= 0 {
+		return true
+	}
+	if !pidAlive(pid) {
+		_ = os.Remove(path)
+		return false
+	}
+	return true
+}
+
+func writeCompactPendingMarker(storePath string) error {
+	path, err := CompactPendingMarkerPath(storePath)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600)
+}
+
+func clearCompactPendingMarker(storePath string) {
+	path, err := CompactPendingMarkerPath(storePath)
+	if err != nil {
+		return
+	}
+	raw, readErr := os.ReadFile(path)
+	if readErr != nil {
+		return
+	}
+	if strings.TrimSpace(string(raw)) != strconv.Itoa(os.Getpid()) {
+		return
+	}
+	_ = os.Remove(path)
+}
+
+func pidAlive(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
+}

--- a/infrastructure/sqlite/store_lease_pending_test.go
+++ b/infrastructure/sqlite/store_lease_pending_test.go
@@ -1,0 +1,53 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestAcquireExclusive_WritesAndClearsCompactPendingMarker(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	release, err := (StoreLeaseCoordinator{}).AcquireExclusive(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !CompactPendingActive(path) {
+		t.Fatal("expected compact-pending marker while exclusive is held")
+	}
+	marker, err := CompactPendingMarkerPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(string(raw)), strconv.Itoa(os.Getpid())) {
+		t.Fatalf("marker pid = %q, want this process", raw)
+	}
+	release()
+	if CompactPendingActive(path) {
+		t.Fatal("marker should clear after exclusive release")
+	}
+}
+
+func TestCompactPendingActive_RemovesStalePID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	marker, err := CompactPendingMarkerPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, []byte("9999999\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if CompactPendingActive(path) {
+		t.Fatal("dead pid should not keep a compact-pending marker alive")
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("stale marker remained: %v", err)
+	}
+}

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -259,6 +259,14 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 			// Already exhausted the attempt ceiling; leave for retention GC.
 			return nil
 		}
+		resolvedDBPath, resolveErr := resolveDBPath(job.DBPath)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		if storeCompactPendingActive(resolvedDBPath) {
+			slog.Info("memory extract worker backing off; store compact pending", "job", resolvedJobPath)
+			return nil
+		}
 		if c.storeManagement == nil {
 			return xerrors.Errorf("initialize store usecase is not configured")
 		}
@@ -271,10 +279,6 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 		job.LastError = ""
 		if writeErr := writeHookMemoryExtractJob(resolvedJobPath, job); writeErr != nil {
 			return writeErr
-		}
-		resolvedDBPath, resolveErr := resolveDBPath(job.DBPath)
-		if resolveErr != nil {
-			return c.failHookMemoryExtractJob(resolvedJobPath, job, resolveErr)
 		}
 		c.applyDatabasePath(resolvedDBPath)
 		if initErr := c.storeManagement.Initialize(ctx); initErr != nil {

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -560,6 +561,39 @@ func TestInspectHookMemoryExtractDiagnostics_FixFuncDrains(t *testing.T) {
 	}
 	if launched != 1 {
 		t.Fatalf("launched = %d", launched)
+	}
+}
+
+func TestRunHookMemoryExtractWorker_BacksOffWhenCompactPending(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("backoff-pending"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         dbPath,
+		SourceBoundary: "session_end",
+	}
+	path, err := enqueueHookMemoryExtract(request, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	marker, err := storeCompactPendingMarkerPath(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := &RootCLI{}
+	if err := root.runHookMemoryExtractWorker(context.Background(), path); err != nil {
+		t.Fatalf("pending worker must no-op, got %v", err)
+	}
+	got, err := readHookMemoryExtractJob(path)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if got.Attempts != 0 {
+		t.Fatalf("backoff must not consume an attempt, attempts=%d", got.Attempts)
 	}
 }
 

--- a/presentation/cli/store_compact_pending.go
+++ b/presentation/cli/store_compact_pending.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/xerrors"
+)
+
+// Must stay aligned with infrastructure/sqlite compactPendingSuffix.
+const storeCompactPendingSuffix = ".traceary.compact-pending"
+
+func storeCompactPendingActive(dbPath string) bool {
+	path, err := storeCompactPendingMarkerPath(dbPath)
+	if err != nil {
+		return false
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	pid, convErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if convErr != nil || pid <= 0 {
+		return true
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return true
+	}
+	if process.Signal(syscall.Signal(0)) != nil {
+		_ = os.Remove(path)
+		return false
+	}
+	return true
+}
+
+func storeCompactPendingMarkerPath(dbPath string) (string, error) {
+	absolute, err := filepath.Abs(strings.TrimSpace(dbPath))
+	if err != nil {
+		return "", xerrors.Errorf("resolve compact-pending marker path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		return resolved + storeCompactPendingSuffix, nil
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(absolute))
+	if err != nil {
+		return "", xerrors.Errorf("resolve compact-pending marker directory: %w", err)
+	}
+	return filepath.Join(parent, filepath.Base(absolute)) + storeCompactPendingSuffix, nil
+}


### PR DESCRIPTION
Closes #2150

Leaves parent #2126 open.

## Summary

Memory-extract workers held the shared store lease for whole Extract jobs and starved exclusive compact. This PR writes an internal compact-pending marker (adjacent to the lease file) before exclusive wait. Workers finish the current job, then exit without starting the next. Exclusive timeout names lock holders (`pid=` / `command=`) via `lsof` when available. Default compact waits up to five minutes so one in-flight extract can finish.

Depends on #2159.

## Test plan

- [x] `go test ./...`
- [x] `go tool golangci-lint run`
- [x] Marker write/clear, stale-pid GC, extract worker backoff without consuming attempts
