### PR TITLE
fix: do not apply exclusive-wait timeout to compact rewrite

### DIFF
--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -87,9 +87,9 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 		return application.CompactResult{}, fmt.Errorf("stat compaction source: %w", beforeErr)
 	}
 	u.reportWindow("exclusive_lease")
-	ctx, stopExclusiveWait := bindCompactExclusiveWait(ctx)
-	defer stopExclusiveWait()
-	release, err := u.lease.AcquireExclusive(ctx, u.expectedStore)
+	waitCtx, stopExclusiveWait := bindCompactExclusiveWait(ctx)
+	release, err := u.lease.AcquireExclusive(waitCtx, u.expectedStore)
+	stopExclusiveWait()
 	if err != nil {
 		return application.CompactResult{}, err
 	}

--- a/application/usecase/store_compaction_fault_test.go
+++ b/application/usecase/store_compaction_fault_test.go
@@ -138,23 +138,31 @@ func compactionRunAt(phase domain.CompactionPhase) domain.CompactionRun {
 
 type reclaimOrderRecorder struct {
 	faultBuilder
-	leased            *bool
-	inspected         bool
-	inspectedUnleased bool
-	reclaim           application.CommandBodyReclaim
+	leased             *bool
+	inspected          bool
+	inspectedUnleased  bool
+	inspectHasDeadline bool
+	reclaim            application.CommandBodyReclaim
 }
 
-func (b *reclaimOrderRecorder) InspectCommandBodyReclaim(context.Context, string) (application.CommandBodyReclaim, error) {
+func (b *reclaimOrderRecorder) InspectCommandBodyReclaim(ctx context.Context, _ string) (application.CommandBodyReclaim, error) {
 	b.inspected = true
+	_, b.inspectHasDeadline = ctx.Deadline()
 	if b.leased == nil || !*b.leased {
 		b.inspectedUnleased = true
 	}
 	return b.reclaim, nil
 }
 
-type orderLease struct{ leased *bool }
+type orderLease struct {
+	leased          *bool
+	acquireDeadline *bool
+}
 
-func (l orderLease) AcquireExclusive(context.Context, string) (func(), error) {
+func (l orderLease) AcquireExclusive(ctx context.Context, _ string) (func(), error) {
+	if l.acquireDeadline != nil {
+		_, *l.acquireDeadline = ctx.Deadline()
+	}
 	if l.leased != nil {
 		*l.leased = true
 	}
@@ -182,6 +190,34 @@ func TestCompactMeasuresCommandBodyReclaimAfterExclusiveLease(t *testing.T) {
 	}
 	if !leased {
 		t.Fatal("AcquireExclusive was not called")
+	}
+}
+
+func TestCompact_ExclusiveWaitDeadlineDoesNotBoundRewrite(t *testing.T) {
+	dir := t.TempDir()
+	source := dir + "/store.db"
+	if err := os.WriteFile(source, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	leased := false
+	acquireDeadline := false
+	recorder := &reclaimOrderRecorder{
+		leased:  &leased,
+		reclaim: application.CommandBodyReclaim{Rows: 1, Bytes: 1},
+	}
+	svc := NewStoreCompactionUsecase(source, &faultJournal{run: compactionRunAt(domain.CompactionCommitted)}, recorder, faultFiles{}, orderLease{
+		leased:          &leased,
+		acquireDeadline: &acquireDeadline,
+	})
+	_, _ = svc.Compact(context.Background(), application.CompactInput{Source: source})
+	if !acquireDeadline {
+		t.Fatal("AcquireExclusive should see the exclusive-wait deadline")
+	}
+	if !recorder.inspected {
+		t.Fatal("InspectCommandBodyReclaim was not called")
+	}
+	if recorder.inspectHasDeadline {
+		t.Fatal("rewrite must not inherit the exclusive-wait deadline")
 	}
 }
 


### PR DESCRIPTION
Closes #2161

Leaves parent #2126 open.

## Summary

`bindCompactExclusiveWait` is only for exclusive acquire. `Compact()` used to replace the caller context with that 5-minute timeout for the rest of the rewrite. Live compact of a 52.7 GiB store acquired exclusive, then abandoned at `drop retired legacy search projection: context deadline exceeded`.

This PR uses the wait context only for `AcquireExclusive`, cancels it as soon as acquire returns, and keeps inspect/plan/copy/swap on the original context.

## Test plan

- [x] `go test ./application/usecase -run TestCompact_ExclusiveWaitDeadlineDoesNotBoundRewrite`
- [x] `go tool golangci-lint run ./application/usecase/...`
- Live store compact after this change reached `phase=committed` (56.6 GiB → 12.8 GiB, `run_id=a2a63c807050c977bff3351713279d6f`)
