### PR TITLE
fix: index report windows without ts_norm wrapping or OFFSET

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Fixed
+- **`report` の期間ロードがフィルタ列を `ts_norm` で包まず、OFFSET 再走査もしない (#2128)** — sessions / usage に `started_at_norm` / `observed_at_norm` を永続化（`events.created_at_norm` と同じ語彙形）。ページは `LIMIT/OFFSET` ではなく keyset `(norm, id)`。usage workspace tally は usage ページと同じ期間を数える（JSON 形は不変。窓外の行は値が減ることがある）。空の norm はストア open 時のバッチ catch-up で埋める。親 #2126 は open のまま。
+
 ## [v0.43.0] - 2026-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Fixed
+- **`report` window loads no longer wrap filter columns in `ts_norm` or re-scan with OFFSET (#2128)** — sessions and usage persist `started_at_norm` / `observed_at_norm` (same lexical form as `events.created_at_norm`); pages use keyset `(norm, id)` instead of `LIMIT/OFFSET`. Usage workspace tally counts the same interval as the usage page (JSON shape unchanged; values may drop rows outside the window). Empty norms are stamped in batched store-open catch-up. Leaves parent #2126 open.
+
 ## [v0.43.0] - 2026-08-18
 
 ### Fixed

--- a/application/types/report.go
+++ b/application/types/report.go
@@ -102,6 +102,7 @@ func (c ReportCriteria) ResultCap() int { return c.resultCap }
 // ReportSessionRecord is the body-free session projection required by report
 // aggregation.
 type ReportSessionRecord struct {
+	SessionID    domtypes.SessionID
 	Client       domtypes.Client
 	StartedAt    time.Time
 	TotalEvents  int
@@ -209,8 +210,8 @@ type ReportWindow struct {
 	Usage    []ReportUsageRecord
 	Extents  ReportSourceExtents
 	// UsageWorkspaceTally is a metadata-only count of finalized observations
-	// for the workspace/client filter (no time bound). Text output uses it
-	// when the windowed usage page is empty.
+	// for the same workspace/client/interval as the usage page. Text output
+	// uses it when the windowed usage page is empty.
 	UsageWorkspaceTally ReportUsageWorkspaceTally
 }
 

--- a/infrastructure/sqlite/command_audit_query.go
+++ b/infrastructure/sqlite/command_audit_query.go
@@ -57,13 +57,18 @@ func (d *EventDatasource) ListReportWindow(ctx context.Context, criteria apptype
 		to = formatTimestamp(criteria.To())
 	}
 	records := make([]apptypes.ReportCommandRecord, 0, batch)
-	for offset := 0; ; {
+	var after *apptypes.ReportCommandRecord
+	for {
+		afterFlag, afterNorm, afterID := "", "", ""
+		if after != nil {
+			afterFlag, afterNorm, afterID = reportKeysetArgs(formatReportNorm(after.CreatedAt), after.EventID.String())
+		}
 		rows, err := tx.QueryContext(ctx, listReportCommandAuditsQuery,
 			criteria.Client().String(), criteria.Client().String(),
 			criteria.Agent().String(), criteria.Agent().String(),
 			criteria.SessionID().String(), criteria.SessionID().String(),
 			criteria.Workspace().String(), criteria.Workspace().String(),
-			from, from, to, to, batch, offset,
+			from, from, to, to, afterFlag, afterNorm, afterID, batch,
 		)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to query report command audit page: %w", err)
@@ -86,7 +91,8 @@ func (d *EventDatasource) ListReportWindow(ctx context.Context, criteria apptype
 		if pageCount < batch {
 			break
 		}
-		offset += pageCount
+		last := records[len(records)-1]
+		after = &last
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, xerrors.Errorf("failed to commit report command audit read transaction: %w", err)

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -495,6 +495,8 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string, allowOffli
 	}
 	usageRepairResult, usageRepairErr := catchUpEpochZeroHookUsage(ctx, db, epochZeroHookUsageRepairBatchSize)
 	logEpochZeroHookUsageRepair(usageRepairResult, usageRepairErr)
+	normCatchUp, normCatchUpErr := catchUpReportWindowNorm(ctx, db, reportWindowNormCatchUpBatchSize)
+	logReportWindowNormCatchUp(normCatchUp, normCatchUpErr)
 	catchUpResult, catchUpErr := catchUpWorkspaceObservations(ctx, db, workspaceObservationCatchUpBatchSize)
 	if catchUpErr != nil {
 		// Catch-up is additive diagnostic coverage. A malformed historical row

--- a/infrastructure/sqlite/migrate_offline_test.go
+++ b/infrastructure/sqlite/migrate_offline_test.go
@@ -51,8 +51,8 @@ func TestStoreInitAppliesOfflineMigrations(t *testing.T) {
 	if err := current.InitializeAuthorized(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 68 {
-		t.Fatalf("schema version=%d, want 68", got)
+	if got := maxSchemaVersion(t, path); got != 69 {
+		t.Fatalf("schema version=%d, want 69", got)
 	}
 }
 
@@ -64,8 +64,8 @@ func TestEmptyStoreReachesCurrentSchemaImplicitly(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 68 {
-		t.Fatalf("schema version=%d, want 68", got)
+	if got := maxSchemaVersion(t, path); got != 69 {
+		t.Fatalf("schema version=%d, want 69", got)
 	}
 }
 

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -108,6 +108,10 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	// 68 adds cleanup_no_progress_attempts to the singleton
 	// search_projection_state row. No store-sized scan.
 	68: {68, "000068_add_search_projection_cleanup_no_progress_attempts.sql", "21d36ae2a63af21c8bfd4688c362aeb555ddcbdb0555e5703ccdf01aa877a526", MigrationConstantInPlace},
+	// 69 adds two empty TEXT columns, two indexes, and four stamp triggers.
+	// Row backfill of started_at_norm / observed_at_norm is a bounded open
+	// catch-up, not this migration.
+	69: {69, "000069_add_report_window_norm_columns.sql", "85ab3ae7f4efc6a777eef43406e7882cc523c9a53bd8d758fe3eb8daa01a8455", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 68 || len(plan.Pending) != 33 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 69 || len(plan.Pending) != 34 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -65,6 +65,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		66: MigrationConstantInPlace,
 		67: MigrationConstantInPlace,
 		68: MigrationConstantInPlace,
+		69: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 68 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 69 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/report_query.go
+++ b/infrastructure/sqlite/report_query.go
@@ -66,18 +66,32 @@ func (d *ReportDatasource) LoadReportWindow(ctx context.Context, criteria apptyp
 		}
 	}()
 
-	sessions, sessionsTruncated, err := loadCappedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit, offset int) ([]apptypes.ReportSessionRecord, error) {
-		return queryReportSessionPage(ctx, tx, criteria, limit, offset)
+	sessions, sessionsTruncated, err := loadKeyedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit int, after *apptypes.ReportSessionRecord) ([]apptypes.ReportSessionRecord, error) {
+		return queryReportSessionPage(ctx, tx, criteria, limit, after)
 	})
 	if err != nil {
 		return apptypes.ReportWindow{}, xerrors.Errorf("failed to load report sessions: %w", err)
 	}
-	events, eventsTruncated, err := loadCappedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit, offset int) ([]apptypes.EventMetadata, error) {
+	events, eventsTruncated, err := loadKeyedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit int, after *apptypes.EventMetadata) ([]apptypes.EventMetadata, error) {
+		eventCriteria := reportEventCriteria(criteria)
+		if after != nil {
+			anchor, anchorErr := apptypes.EventPageAnchorOf(after.CreatedAt(), after.EventID())
+			if anchorErr != nil {
+				return nil, xerrors.Errorf("failed to build report event page anchor: %w", anchorErr)
+			}
+			eventCriteria = apptypes.NewEventListCriteriaBuilder(criteria.PageSize()).
+				Workspace(criteria.Workspace()).
+				Client(criteria.Client()).
+				From(criteria.Interval().EffectiveFromInclusive()).
+				To(criteria.Interval().EffectiveToExclusive()).
+				PageAnchor(anchor).
+				Build()
+		}
 		rows, err := queryRecentEventMetadataTx(
-			ctx, tx, reportEventCriteria(criteria),
+			ctx, tx, eventCriteria,
 			formatMetadataOptionalTimestamp(criteria.Interval().EffectiveFromInclusive()),
 			formatMetadataOptionalTimestamp(criteria.Interval().EffectiveToExclusive()),
-			limit, offset,
+			limit, 0,
 		)
 		if err != nil {
 			return nil, err
@@ -87,14 +101,14 @@ func (d *ReportDatasource) LoadReportWindow(ctx context.Context, criteria apptyp
 	if err != nil {
 		return apptypes.ReportWindow{}, xerrors.Errorf("failed to load report events: %w", err)
 	}
-	commands, commandsTruncated, err := loadCappedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit, offset int) ([]apptypes.ReportCommandRecord, error) {
-		return queryReportCommandPage(ctx, tx, criteria, limit, offset)
+	commands, commandsTruncated, err := loadKeyedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit int, after *apptypes.ReportCommandRecord) ([]apptypes.ReportCommandRecord, error) {
+		return queryReportCommandPage(ctx, tx, criteria, limit, after)
 	})
 	if err != nil {
 		return apptypes.ReportWindow{}, xerrors.Errorf("failed to load report commands: %w", err)
 	}
-	usage, usageTruncated, err := loadCappedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit, offset int) ([]apptypes.ReportUsageRecord, error) {
-		return queryReportUsagePage(ctx, tx, criteria, limit, offset)
+	usage, usageTruncated, err := loadKeyedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit int, after *apptypes.ReportUsageRecord) ([]apptypes.ReportUsageRecord, error) {
+		return queryReportUsagePage(ctx, tx, criteria, limit, after)
 	})
 	if err != nil {
 		return apptypes.ReportWindow{}, xerrors.Errorf("failed to load report usage: %w", err)
@@ -123,18 +137,19 @@ func (d *ReportDatasource) LoadReportWindow(ctx context.Context, criteria apptyp
 	}, nil
 }
 
-func loadCappedReportRows[T any](pageSize, resultCap int, loadPage func(limit, offset int) ([]T, error)) ([]T, bool, error) {
+func loadKeyedReportRows[T any](pageSize, resultCap int, loadPage func(limit int, after *T) ([]T, error)) ([]T, bool, error) {
 	target := 0
 	if resultCap > 0 {
 		target = resultCap + 1
 	}
 	rows := make([]T, 0, pageSize)
-	for offset := 0; ; {
+	var after *T
+	for {
 		limit := pageSize
 		if target > 0 && target-len(rows) < limit {
 			limit = target - len(rows)
 		}
-		page, err := loadPage(limit, offset)
+		page, err := loadPage(limit, after)
 		if err != nil {
 			return nil, false, err
 		}
@@ -145,7 +160,8 @@ func loadCappedReportRows[T any](pageSize, resultCap int, loadPage func(limit, o
 		if len(page) < limit {
 			break
 		}
-		offset += len(page)
+		last := page[len(page)-1]
+		after = &last
 	}
 	truncated := resultCap > 0 && len(rows) > resultCap
 	if truncated {
@@ -154,14 +170,34 @@ func loadCappedReportRows[T any](pageSize, resultCap int, loadPage func(limit, o
 	return rows, truncated, nil
 }
 
-func queryReportSessionPage(ctx context.Context, tx *sql.Tx, criteria apptypes.ReportCriteria, limit, offset int) ([]apptypes.ReportSessionRecord, error) {
+func reportKeysetArgs(afterNorm, afterID string) (string, string, string) {
+	if afterNorm == "" || afterID == "" {
+		return "", "", ""
+	}
+	return "1", afterNorm, afterID
+}
+
+// formatReportNorm matches persisted started_at_norm / observed_at_norm /
+// created_at_norm so keyset after-keys compare equal to the indexed columns.
+func formatReportNorm(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return formatMemoryValidityTimestamp(value)
+}
+
+func queryReportSessionPage(ctx context.Context, tx *sql.Tx, criteria apptypes.ReportCriteria, limit int, after *apptypes.ReportSessionRecord) ([]apptypes.ReportSessionRecord, error) {
 	from := formatOptionalTimestamp(criteria.Interval().EffectiveFromInclusive())
 	to := formatOptionalTimestamp(criteria.Interval().EffectiveToExclusive())
+	afterFlag, afterNorm, afterID := "", "", ""
+	if after != nil {
+		afterFlag, afterNorm, afterID = reportKeysetArgs(formatReportNorm(after.StartedAt), after.SessionID.String())
+	}
 	rows, err := tx.QueryContext(
 		ctx, listReportSessionsQuery,
 		criteria.Workspace().String(), criteria.Workspace().String(),
 		criteria.Client().String(), criteria.Client().String(),
-		from, from, to, to, limit, offset,
+		from, from, to, to, afterFlag, afterNorm, afterID, limit,
 		criteria.Workspace().String(), criteria.Workspace().String(),
 		criteria.Client().String(), criteria.Client().String(),
 		from, from, to, to,
@@ -176,9 +212,9 @@ func queryReportSessionPage(ctx context.Context, tx *sql.Tx, criteria apptypes.R
 	}()
 	result := make([]apptypes.ReportSessionRecord, 0, limit)
 	for rows.Next() {
-		var client, startedAtValue string
+		var sessionID, client, startedAtValue string
 		var totalEvents, commandCount int
-		if err := rows.Scan(&client, &startedAtValue, &totalEvents, &commandCount); err != nil {
+		if err := rows.Scan(&sessionID, &client, &startedAtValue, &totalEvents, &commandCount); err != nil {
 			return nil, xerrors.Errorf("failed to scan report session row: %w", err)
 		}
 		startedAt, err := time.Parse(time.RFC3339Nano, startedAtValue)
@@ -186,7 +222,7 @@ func queryReportSessionPage(ctx context.Context, tx *sql.Tx, criteria apptypes.R
 			return nil, xerrors.Errorf("failed to restore report session timestamp: %w", err)
 		}
 		result = append(result, apptypes.ReportSessionRecord{
-			Client: types.Client(client), StartedAt: startedAt,
+			SessionID: types.SessionID(sessionID), Client: types.Client(client), StartedAt: startedAt,
 			TotalEvents: totalEvents, CommandCount: commandCount,
 		})
 	}
@@ -196,15 +232,19 @@ func queryReportSessionPage(ctx context.Context, tx *sql.Tx, criteria apptypes.R
 	return result, nil
 }
 
-func queryReportCommandPage(ctx context.Context, tx *sql.Tx, criteria apptypes.ReportCriteria, limit, offset int) ([]apptypes.ReportCommandRecord, error) {
+func queryReportCommandPage(ctx context.Context, tx *sql.Tx, criteria apptypes.ReportCriteria, limit int, after *apptypes.ReportCommandRecord) ([]apptypes.ReportCommandRecord, error) {
 	from := formatOptionalTimestamp(criteria.Interval().EffectiveFromInclusive())
 	to := formatOptionalTimestamp(criteria.Interval().EffectiveToExclusive())
+	afterFlag, afterNorm, afterID := "", "", ""
+	if after != nil {
+		afterFlag, afterNorm, afterID = reportKeysetArgs(formatReportNorm(after.CreatedAt), after.EventID.String())
+	}
 	rows, err := tx.QueryContext(
 		ctx, listReportCommandAuditsQuery,
 		criteria.Client().String(), criteria.Client().String(),
 		"", "", "", "",
 		criteria.Workspace().String(), criteria.Workspace().String(),
-		from, from, to, to, limit, offset,
+		from, from, to, to, afterFlag, afterNorm, afterID, limit,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query report command page: %w", err)
@@ -232,15 +272,20 @@ func queryReportUsagePage(
 	ctx context.Context,
 	tx *sql.Tx,
 	criteria apptypes.ReportCriteria,
-	limit, offset int,
+	limit int,
+	after *apptypes.ReportUsageRecord,
 ) ([]apptypes.ReportUsageRecord, error) {
 	from := formatOptionalTimestamp(criteria.Interval().EffectiveFromInclusive())
 	to := formatOptionalTimestamp(criteria.Interval().EffectiveToExclusive())
+	afterFlag, afterNorm, afterID := "", "", ""
+	if after != nil {
+		afterFlag, afterNorm, afterID = reportKeysetArgs(formatReportNorm(after.ObservedAt), after.ObservationID)
+	}
 	rows, err := tx.QueryContext(
 		ctx, listReportUsageQuery,
 		criteria.Workspace().String(), criteria.Workspace().String(),
 		criteria.Client().String(), criteria.Client().String(),
-		from, from, to, to, limit, offset,
+		from, from, to, to, afterFlag, afterNorm, afterID, limit,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query report usage page: %w", err)
@@ -269,12 +314,15 @@ func queryReportUsageWorkspaceTally(
 	tx *sql.Tx,
 	criteria apptypes.ReportCriteria,
 ) (apptypes.ReportUsageWorkspaceTally, error) {
+	from := formatOptionalTimestamp(criteria.Interval().EffectiveFromInclusive())
+	to := formatOptionalTimestamp(criteria.Interval().EffectiveToExclusive())
 	var tally apptypes.ReportUsageWorkspaceTally
 	err := tx.QueryRowContext(
 		ctx,
 		countReportUsageWorkspaceQuery,
 		criteria.Workspace().String(), criteria.Workspace().String(),
 		criteria.Client().String(), criteria.Client().String(),
+		from, from, to, to,
 	).Scan(&tally.Excluded, &tally.Unavailable, &tally.KimiMainWireKnown)
 	if err != nil {
 		return apptypes.ReportUsageWorkspaceTally{}, xerrors.Errorf("failed to count workspace usage observations: %w", err)

--- a/infrastructure/sqlite/report_query_plan_internal_test.go
+++ b/infrastructure/sqlite/report_query_plan_internal_test.go
@@ -1,0 +1,177 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestReportWindowSQLDoesNotUseOffset(t *testing.T) {
+	t.Parallel()
+	for name, query := range map[string]string{
+		"sessions": listReportSessionsQuery,
+		"usage":    listReportUsageQuery,
+		"commands": listReportCommandAuditsQuery,
+	} {
+		if strings.Contains(strings.ToUpper(query), "OFFSET") {
+			t.Errorf("%s report SQL still uses OFFSET", name)
+		}
+		if strings.Contains(query, "ts_norm(s.started_at)") ||
+			strings.Contains(query, "ts_norm(started_at)") ||
+			strings.Contains(query, "ts_norm(observation.observed_at)") ||
+			strings.Contains(query, "ts_norm(e.created_at)") {
+			t.Errorf("%s report SQL still wraps a stored column in ts_norm", name)
+		}
+	}
+}
+
+func TestReportSessionQueryPlanUsesStartedAtNormIndex(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	from := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	to := time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	rows, err := db.QueryContext(
+		ctx,
+		"EXPLAIN QUERY PLAN "+listReportSessionsQuery,
+		"workspace", "workspace",
+		"codex", "codex",
+		from, from, to, to, "", "", "", 10,
+		"workspace", "workspace",
+		"codex", "codex",
+		from, from, to, to,
+	)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	t.Cleanup(func() { _ = rows.Close() })
+	joined := strings.ToLower(joinQueryPlan(t, rows))
+	if !strings.Contains(joined, "idx_sessions_started_at_norm_id_desc") &&
+		!strings.Contains(joined, "started_at_norm") {
+		t.Fatalf("session report plan does not mention started_at_norm:\n%s", joined)
+	}
+}
+
+func TestReportUsageQueryPlanUsesObservedAtNormIndex(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	from := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	to := time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	rows, err := db.QueryContext(
+		ctx,
+		"EXPLAIN QUERY PLAN "+listReportUsageQuery,
+		"workspace", "workspace",
+		"codex", "codex",
+		from, from, to, to, "", "", "", 10,
+	)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	t.Cleanup(func() { _ = rows.Close() })
+	joined := strings.ToLower(joinQueryPlan(t, rows))
+	if !strings.Contains(joined, "idx_usage_observations_status_observed_at_norm_id_desc") &&
+		!strings.Contains(joined, "observed_at_norm") {
+		t.Fatalf("usage report plan does not mention observed_at_norm:\n%s", joined)
+	}
+}
+
+func TestCatchUpReportWindowNormStampsEmptyColumns(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	startedAt := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO sessions (session_id, started_at, client, agent, workspace, started_at_norm)
+		VALUES ('catchup-session', ?, 'codex', 'codex', 'workspace', '')
+	`, startedAt); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE sessions SET started_at_norm = '' WHERE session_id = 'catchup-session'`); err != nil {
+		t.Fatalf("clear started_at_norm: %v", err)
+	}
+
+	result, err := catchUpReportWindowNorm(ctx, db, 10)
+	if err != nil {
+		t.Fatalf("catchUpReportWindowNorm() error = %v", err)
+	}
+	if result.SessionsUpdated != 1 {
+		t.Fatalf("sessions updated = %d, want 1", result.SessionsUpdated)
+	}
+	var stored string
+	if err := db.QueryRowContext(ctx, `SELECT started_at_norm FROM sessions WHERE session_id = 'catchup-session'`).Scan(&stored); err != nil {
+		t.Fatalf("select started_at_norm: %v", err)
+	}
+	want := formatMemoryValidityTimestamp(time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC))
+	if stored != want {
+		t.Fatalf("started_at_norm = %q, want %q", stored, want)
+	}
+
+	criteria, err := apptypes.ReportCriteriaFrom(
+		"2026-07-23T00:00:00Z", "2026-07-24T00:00:00Z", "UTC",
+		time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC),
+		"workspace", "codex", 10, 0,
+	)
+	if err != nil {
+		t.Fatalf("ReportCriteriaFrom() error = %v", err)
+	}
+	window, err := NewReportDatasource(database).LoadReportWindow(ctx, criteria)
+	if err != nil {
+		t.Fatalf("LoadReportWindow() error = %v", err)
+	}
+	if len(window.Sessions) != 1 || window.Sessions[0].SessionID != "catchup-session" {
+		t.Fatalf("sessions after catch-up = %+v", window.Sessions)
+	}
+}
+
+func joinQueryPlan(t *testing.T, rows *sql.Rows) string {
+	t.Helper()
+	var plan []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+	return strings.Join(plan, "\n")
+}

--- a/infrastructure/sqlite/report_query_test.go
+++ b/infrastructure/sqlite/report_query_test.go
@@ -240,3 +240,168 @@ func TestReportDatasource_UsageSelectsCurrentSnapshotAndExposesCapAndFilters(t *
 		t.Fatalf("filtered usage extent = %+v", filtered.Extents.Usage)
 	}
 }
+
+func TestReportDatasource_UsageWorkspaceTallyUsesTheSameInterval(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	store := sqlite.NewStoreManagementDatasource(db)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	events := sqlite.NewEventDatasource(db)
+	sessions := sqlite.NewSessionDatasource(db)
+	sessionUsecase := usecase.NewSessionUsecase(events, sessions, sessions, events)
+	if _, err := sessionUsecase.Start(ctx, "codex", "codex", types.SessionID("session-1"), "workspace", ""); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	usage := sqlite.NewUsageObservationDatasource(db)
+	from := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
+	to := from.Add(20 * time.Hour)
+	inside := sqliteExcludedUsageAt(t, "tally-inside", from.Add(time.Hour))
+	outside := sqliteExcludedUsageAt(t, "tally-outside", to.Add(time.Hour))
+	for _, observation := range []*model.UsageObservation{inside, outside} {
+		if _, err := usage.Record(ctx, observation); err != nil {
+			t.Fatalf("Record(%s) error = %v", observation.Descriptor().ObservationID(), err)
+		}
+	}
+
+	windowed, err := apptypes.ReportCriteriaFrom(
+		from.Format(time.RFC3339Nano), to.Format(time.RFC3339Nano), "UTC", to,
+		"workspace", "codex", 100, 0,
+	)
+	if err != nil {
+		t.Fatalf("ReportCriteriaFrom(windowed) error = %v", err)
+	}
+	got, err := sqlite.NewReportDatasource(db).LoadReportWindow(ctx, windowed)
+	if err != nil {
+		t.Fatalf("LoadReportWindow(windowed) error = %v", err)
+	}
+	if got.UsageWorkspaceTally.Excluded != 1 {
+		t.Fatalf("windowed tally = %+v, want excluded=1 (in-window only)", got.UsageWorkspaceTally)
+	}
+	if len(got.Usage) != 1 || got.Usage[0].ObservationID != "tally-inside" {
+		t.Fatalf("windowed usage = %+v, want in-window excluded row", got.Usage)
+	}
+
+	unbounded, err := apptypes.ReportCriteriaFrom(
+		"2000-01-01T00:00:00Z", "2100-01-01T00:00:00Z", "UTC", to,
+		"workspace", "codex", 100, 0,
+	)
+	if err != nil {
+		t.Fatalf("ReportCriteriaFrom(unbounded) error = %v", err)
+	}
+	wide, err := sqlite.NewReportDatasource(db).LoadReportWindow(ctx, unbounded)
+	if err != nil {
+		t.Fatalf("LoadReportWindow(unbounded) error = %v", err)
+	}
+	if wide.UsageWorkspaceTally.Excluded != 2 {
+		t.Fatalf("unbounded tally = %+v, want excluded=2", wide.UsageWorkspaceTally)
+	}
+}
+
+func sqliteExcludedUsageAt(t *testing.T, id string, observedAt time.Time) *model.UsageObservation {
+	t.Helper()
+	source, err := types.UsageSourceOf("codex", "headless_stream", "0.145.0", "openai", "model-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	observationID, err := types.UsageObservationIDFrom(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := model.NewUsageObservationDescriptor(
+		observationID, types.SessionID("session-1"), source, types.UsageScopeCall,
+		types.UsageAccountingExcluded, observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := types.KnownUsageValue(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero, err := types.KnownUsageValue(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counters, err := types.UsageCountersOf(input, zero, zero, zero, zero, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, types.UnavailableUsageCost(), types.UsageTerminalSuccess, observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}
+
+func TestReportDatasource_KeysetPagesMatchASingleLargeLimit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	events := sqlite.NewEventDatasource(db)
+	sessions := sqlite.NewSessionDatasource(db)
+	store := sqlite.NewStoreManagementDatasource(db)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	sessionUsecase := usecase.NewSessionUsecase(events, sessions, sessions, events)
+	eventUsecase := usecase.NewEventUsecase(events, events)
+	for i := 1; i <= 5; i++ {
+		sessionID := types.SessionID(fmt.Sprintf("keyset-session-%d", i))
+		if _, err := sessionUsecase.Start(ctx, "codex", "codex", sessionID, "workspace", ""); err != nil {
+			t.Fatalf("Start(%d) error = %v", i, err)
+		}
+		if _, _, err := eventUsecase.Audit(ctx, apptypes.AuditInput{
+			Command: "go test ./...", Client: "codex", Agent: "codex",
+			SessionID: sessionID, Workspace: "workspace", ExitCode: types.Some(0),
+			FailureReason: types.CommandFailureReasonNone,
+		}, apptypes.NewAuditRedactionBuilder().Build()); err != nil {
+			t.Fatalf("Audit(%d) error = %v", i, err)
+		}
+	}
+
+	paged, err := apptypes.ReportCriteriaFrom(
+		"2000-01-01T00:00:00Z", "2100-01-01T00:00:00Z", "UTC", time.Now().UTC(),
+		"workspace", "codex", 1, 0,
+	)
+	if err != nil {
+		t.Fatalf("ReportCriteriaFrom(paged) error = %v", err)
+	}
+	got, err := sqlite.NewReportDatasource(db).LoadReportWindow(ctx, paged)
+	if err != nil {
+		t.Fatalf("LoadReportWindow(paged) error = %v", err)
+	}
+	single, err := apptypes.ReportCriteriaFrom(
+		"2000-01-01T00:00:00Z", "2100-01-01T00:00:00Z", "UTC", time.Now().UTC(),
+		"workspace", "codex", 100, 0,
+	)
+	if err != nil {
+		t.Fatalf("ReportCriteriaFrom(single) error = %v", err)
+	}
+	want, err := sqlite.NewReportDatasource(db).LoadReportWindow(ctx, single)
+	if err != nil {
+		t.Fatalf("LoadReportWindow(single) error = %v", err)
+	}
+	if len(got.Sessions) != 5 || len(want.Sessions) != 5 {
+		t.Fatalf("session counts paged=%d single=%d", len(got.Sessions), len(want.Sessions))
+	}
+	for i := range want.Sessions {
+		if got.Sessions[i].SessionID != want.Sessions[i].SessionID {
+			t.Fatalf("session[%d] paged=%s single=%s", i, got.Sessions[i].SessionID, want.Sessions[i].SessionID)
+		}
+	}
+	if len(got.Commands) != 5 || len(want.Commands) != 5 {
+		t.Fatalf("command counts paged=%d single=%d", len(got.Commands), len(want.Commands))
+	}
+	for i := range want.Commands {
+		if got.Commands[i].EventID != want.Commands[i].EventID {
+			t.Fatalf("command[%d] paged=%s single=%s", i, got.Commands[i].EventID, want.Commands[i].EventID)
+		}
+	}
+}

--- a/infrastructure/sqlite/report_window_norm_catchup.go
+++ b/infrastructure/sqlite/report_window_norm_catchup.go
@@ -1,0 +1,119 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+
+	"golang.org/x/xerrors"
+)
+
+// reportWindowNormCatchUpBatchSize bounds one UPDATE of empty started_at_norm
+// / observed_at_norm values. Initialize loops until the columns are full or
+// the attempt cap is hit so a 16 GiB events store does not rewrite a
+// store-sized table in one transaction, while sessions and usage still finish
+// in a typical open.
+const reportWindowNormCatchUpBatchSize = 2000
+const reportWindowNormCatchUpMaxBatches = 50
+
+type reportWindowNormCatchUpResult struct {
+	SessionsUpdated int
+	UsageUpdated    int
+	MorePending     bool
+}
+
+func catchUpReportWindowNorm(ctx context.Context, db *sql.DB, batchSize int) (reportWindowNormCatchUpResult, error) {
+	if batchSize <= 0 {
+		return reportWindowNormCatchUpResult{}, xerrors.Errorf("report window norm catch-up batch size must be positive")
+	}
+	sessionsReady, err := databaseColumnExists(ctx, db, "sessions", "started_at_norm")
+	if err != nil {
+		return reportWindowNormCatchUpResult{}, err
+	}
+	usageReady, err := databaseColumnExists(ctx, db, "usage_observations", "observed_at_norm")
+	if err != nil {
+		return reportWindowNormCatchUpResult{}, err
+	}
+	if !sessionsReady && !usageReady {
+		return reportWindowNormCatchUpResult{}, nil
+	}
+
+	var result reportWindowNormCatchUpResult
+	if sessionsReady {
+		updated, more, err := catchUpReportWindowNormTable(
+			ctx, db, batchSize,
+			`UPDATE sessions SET started_at_norm = ts_norm(started_at)
+			  WHERE rowid IN (
+			        SELECT rowid FROM sessions WHERE started_at_norm = '' LIMIT ?
+			  )`,
+		)
+		result.SessionsUpdated = updated
+		result.MorePending = result.MorePending || more
+		if err != nil {
+			return result, err
+		}
+	}
+	if usageReady {
+		updated, more, err := catchUpReportWindowNormTable(
+			ctx, db, batchSize,
+			`UPDATE usage_observations SET observed_at_norm = ts_norm(observed_at)
+			  WHERE rowid IN (
+			        SELECT rowid FROM usage_observations WHERE observed_at_norm = '' LIMIT ?
+			  )`,
+		)
+		result.UsageUpdated = updated
+		result.MorePending = result.MorePending || more
+		if err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func catchUpReportWindowNormTable(ctx context.Context, db *sql.DB, batchSize int, query string) (int, bool, error) {
+	updated := 0
+	for batch := 0; batch < reportWindowNormCatchUpMaxBatches; batch++ {
+		result, err := db.ExecContext(ctx, query, batchSize)
+		if err != nil {
+			return updated, false, xerrors.Errorf("failed to stamp report window norm column: %w", err)
+		}
+		n, err := result.RowsAffected()
+		if err != nil {
+			return updated, false, xerrors.Errorf("failed to count report window norm stamps: %w", err)
+		}
+		updated += int(n)
+		if n == 0 {
+			return updated, false, nil
+		}
+		if n < int64(batchSize) {
+			return updated, false, nil
+		}
+	}
+	return updated, true, nil
+}
+
+func logReportWindowNormCatchUp(result reportWindowNormCatchUpResult, err error) {
+	if err != nil {
+		slog.Error("report window norm catch-up incomplete; retrying on next initialization",
+			"sessions_updated", result.SessionsUpdated,
+			"usage_updated", result.UsageUpdated,
+			"more_pending", result.MorePending,
+			"error", err,
+		)
+		return
+	}
+	if result.SessionsUpdated == 0 && result.UsageUpdated == 0 && !result.MorePending {
+		return
+	}
+	if result.MorePending {
+		slog.Info("report window norm catch-up paused; remaining empty norms retry on next initialization",
+			"sessions_updated", result.SessionsUpdated,
+			"usage_updated", result.UsageUpdated,
+		)
+		return
+	}
+	slog.Debug("report window norm catch-up completed",
+		"sessions_updated", result.SessionsUpdated,
+		"usage_updated", result.UsageUpdated,
+	)
+}

--- a/infrastructure/sqlite/sql/count_report_usage_workspace.sql
+++ b/infrastructure/sqlite/sql/count_report_usage_workspace.sql
@@ -8,3 +8,5 @@ SELECT
  WHERE observation.status = 'finalized'
    AND (? = '' OR session.workspace = ?)
    AND (? = '' OR session.client = ?)
+   AND (? = '' OR observation.observed_at_norm >= ts_norm(?))
+   AND (? = '' OR observation.observed_at_norm < ts_norm(?))

--- a/infrastructure/sqlite/sql/list_report_command_audits.sql
+++ b/infrastructure/sqlite/sql/list_report_command_audits.sql
@@ -7,7 +7,8 @@ SELECT e.id, e.client, e.agent, e.session_id, e.workspace,
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
-   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
- LIMIT ? OFFSET ?
+   AND (? = '' OR e.created_at_norm >= ts_norm(?))
+   AND (? = '' OR e.created_at_norm < ts_norm(?))
+   AND (? = '' OR (e.created_at_norm, e.id) < (?, ?))
+ ORDER BY e.created_at_norm DESC, e.id DESC
+ LIMIT ?

--- a/infrastructure/sqlite/sql/list_report_sessions.sql
+++ b/infrastructure/sqlite/sql/list_report_sessions.sql
@@ -1,12 +1,13 @@
 WITH filtered_sessions AS (
-    SELECT s.session_id, s.client, s.started_at
+    SELECT s.session_id, s.client, s.started_at, s.started_at_norm
       FROM sessions s
      WHERE (? = '' OR s.workspace = ?)
        AND (? = '' OR s.client = ?)
-       AND (? = '' OR ts_norm(s.started_at) >= ts_norm(?))
-       AND (? = '' OR ts_norm(s.started_at) < ts_norm(?))
-     ORDER BY ts_norm(s.started_at) DESC, s.session_id DESC
-     LIMIT ? OFFSET ?
+       AND (? = '' OR s.started_at_norm >= ts_norm(?))
+       AND (? = '' OR s.started_at_norm < ts_norm(?))
+       AND (? = '' OR (s.started_at_norm, s.session_id) < (?, ?))
+     ORDER BY s.started_at_norm DESC, s.session_id DESC
+     LIMIT ?
 ), event_agg AS (
     SELECT e.session_id,
            COUNT(*) AS total_events,
@@ -15,14 +16,15 @@ WITH filtered_sessions AS (
       JOIN filtered_sessions fs ON fs.session_id = e.session_id
      WHERE (? = '' OR e.workspace = ?)
        AND (? = '' OR e.client = ?)
-       AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-       AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+       AND (? = '' OR e.created_at_norm >= ts_norm(?))
+       AND (? = '' OR e.created_at_norm < ts_norm(?))
      GROUP BY e.session_id
 )
-SELECT fs.client,
+SELECT fs.session_id,
+       fs.client,
        fs.started_at,
        COALESCE(agg.total_events, 0),
        COALESCE(agg.command_count, 0)
   FROM filtered_sessions fs
   LEFT JOIN event_agg agg ON agg.session_id = fs.session_id
- ORDER BY ts_norm(fs.started_at) DESC, fs.session_id DESC
+ ORDER BY fs.started_at_norm DESC, fs.session_id DESC

--- a/infrastructure/sqlite/sql/list_report_usage.sql
+++ b/infrastructure/sqlite/sql/list_report_usage.sql
@@ -50,7 +50,8 @@ SELECT observation.observation_id,
    )
    AND (? = '' OR session.workspace = ?)
    AND (? = '' OR session.client = ?)
-   AND (? = '' OR ts_norm(observation.observed_at) >= ts_norm(?))
-   AND (? = '' OR ts_norm(observation.observed_at) < ts_norm(?))
- ORDER BY ts_norm(observation.observed_at) DESC, observation.observation_id DESC
- LIMIT ? OFFSET ?
+   AND (? = '' OR observation.observed_at_norm >= ts_norm(?))
+   AND (? = '' OR observation.observed_at_norm < ts_norm(?))
+   AND (? = '' OR (observation.observed_at_norm, observation.observation_id) < (?, ?))
+ ORDER BY observation.observed_at_norm DESC, observation.observation_id DESC
+ LIMIT ?

--- a/schema/sqlite/migrations/000069_add_report_window_norm_columns.sql
+++ b/schema/sqlite/migrations/000069_add_report_window_norm_columns.sql
@@ -1,0 +1,37 @@
+-- Additive report-window indexes. Function wrappers on stored columns
+-- (`ts_norm(started_at)`) cannot use an index; persist the same lexical form
+-- as events.created_at_norm. Previous binaries ignore the new columns
+-- (DEFAULT ''). Row backfill is batched at store open, not in this file.
+
+ALTER TABLE sessions ADD COLUMN started_at_norm TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_observations ADD COLUMN observed_at_norm TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX idx_sessions_started_at_norm_id_desc
+  ON sessions(started_at_norm DESC, session_id DESC);
+
+-- status equality plus the window/keyset order. A time-only index loses to
+-- idx_usage_observations_aggregate (status) and then sorts.
+CREATE INDEX idx_usage_observations_status_observed_at_norm_id_desc
+  ON usage_observations(status, observed_at_norm DESC, observation_id DESC);
+
+CREATE TRIGGER sessions_started_at_norm_ai AFTER INSERT ON sessions
+WHEN NEW.started_at_norm = ''
+BEGIN
+  UPDATE sessions SET started_at_norm = ts_norm(NEW.started_at) WHERE session_id = NEW.session_id;
+END;
+
+CREATE TRIGGER sessions_started_at_norm_au AFTER UPDATE OF started_at ON sessions
+BEGIN
+  UPDATE sessions SET started_at_norm = ts_norm(NEW.started_at) WHERE session_id = NEW.session_id;
+END;
+
+CREATE TRIGGER usage_observations_observed_at_norm_ai AFTER INSERT ON usage_observations
+WHEN NEW.observed_at_norm = ''
+BEGIN
+  UPDATE usage_observations SET observed_at_norm = ts_norm(NEW.observed_at) WHERE observation_id = NEW.observation_id;
+END;
+
+CREATE TRIGGER usage_observations_observed_at_norm_au AFTER UPDATE OF observed_at ON usage_observations
+BEGIN
+  UPDATE usage_observations SET observed_at_norm = ts_norm(NEW.observed_at) WHERE observation_id = NEW.observation_id;
+END;


### PR DESCRIPTION
Closes #2128

Leaves parent #2126 open.

## Summary

Report window loads no longer wrap `sessions.started_at` / `usage_observations.observed_at` in `ts_norm`, and they no longer page with `LIMIT/OFFSET`.

- Migration `000069` adds `started_at_norm` / `observed_at_norm` (DEFAULT `''`), indexes, and insert/update stamp triggers. Previous binaries still open the store.
- `LoadReportWindow` (and `ListReportWindow` command pages) use keyset `(norm, id)`.
- Usage workspace tally uses the same interval as the usage page. JSON **shape** is unchanged; **values** may drop rows outside the window (changelog records this).
- Empty norms are stamped in batched store-open catch-up (2_000 rows × 50 batches per table).

## Tests

- Windowed tally ≠ unbounded tally on `LoadReportWindow`.
- Keyset pages (`pageSize=1`) match a single large LIMIT.
- EXPLAIN mentions `started_at_norm` / `observed_at_norm`; report SQL has no `OFFSET` and does not wrap stored columns in `ts_norm`.
- Catch-up fills a cleared `started_at_norm` and the row appears in the window.

`go test ./...` and `go tool golangci-lint run` passed on this branch.

## Copy matrix (Wave 1 verify, not this commit)

20 h `coverage=complete` ≤15 s and the {1 h, 20 h, 7 d, unbounded} × {workspace, client} matrix will be recorded on the isolated post-compact copy after the remaining v0.44 children land. This PR does not point a repo binary at the live home store.