### PR TITLE
fix: drive filterable search from fingerprints plus fail-open tail

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **フィルタ可能な `search` が fingerprint 適用のためにイベント全履歴を歩かない (#2127)** — 候補は `literal_search_fingerprints`（`idx_literal_search_fingerprints_by_fp`）と cutover 後 / 未 inventory の tail。decode が match 権威のまま。pre-filter は fail-open。短い unfilterable クエリは events walk のまま。検索 JSON 形は不変。親 #2126 は open のまま。
 - **`report` の期間ロードがフィルタ列を `ts_norm` で包まず、OFFSET 再走査もしない (#2128)** — sessions / usage に `started_at_norm` / `observed_at_norm` を永続化（`events.created_at_norm` と同じ語彙形）。ページは `LIMIT/OFFSET` ではなく keyset `(norm, id)`。usage workspace tally は usage ページと同じ期間を数える（JSON 形は不変。窓外の行は値が減ることがある）。空の norm はストア open 時のバッチ catch-up で埋める。親 #2126 は open のまま。
 
 ## [v0.43.0] - 2026-08-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Filterable `search` no longer walks total event history to apply fingerprints (#2127)** — candidates come from `literal_search_fingerprints` (index `idx_literal_search_fingerprints_by_fp`) plus the post-cutover / never-inventoried tail. Decode remains the match authority; the pre-filter stays fail-open; unfilterable short queries keep the events walk. Search JSON shape is unchanged. Leaves parent #2126 open.
 - **`report` window loads no longer wrap filter columns in `ts_norm` or re-scan with OFFSET (#2128)** — sessions and usage persist `started_at_norm` / `observed_at_norm` (same lexical form as `events.created_at_norm`); pages use keyset `(norm, id)` instead of `LIMIT/OFFSET`. Usage workspace tally counts the same interval as the usage page (JSON shape unchanged; values may drop rows outside the window). Empty norms are stamped in batched store-open catch-up. Leaves parent #2126 open.
 
 ## [v0.43.0] - 2026-08-18

--- a/infrastructure/sqlite/event_search_authority.go
+++ b/infrastructure/sqlite/event_search_authority.go
@@ -223,31 +223,20 @@ func (d *EventDatasource) searchTieredTopKMetadataTx(ctx context.Context, tx *sq
 func buildTieredSearchCandidateQuery(criteria apptypes.EventSearchCriteria, generation string) (string, []any) {
 	query := apptypes.CharacterizeLiteralQuery(criteria.Query())
 	var builder strings.Builder
-	// The candidate set is events, not search_projection_source_sequence.
-	// That table is the projection's own checkpoint ledger: it is populated by
-	// the migration-038 insert trigger and, for rows that predate it, only by
-	// the rebuild's inventory phase (search_projection_rebuild.go:271). An
-	// upgraded store that has never completed a generation therefore has no
-	// sequence row for any of its history, and joining through it would drop
-	// that history from every search. It also outlives deleted events, since
-	// nothing removes a row when its event goes away.
-	//
-	// There is no sequence bound either: post-completion rows form the live
-	// tail and must participate in the same ordered walk as projected events.
-	// The fingerprint pre-filter below is fail-open for events with no rows
-	// for the generation, so tail rows are decided on their decoded content.
-	builder.WriteString(`SELECT e.id,COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0) FROM events e LEFT JOIN command_audits a ON a.event_id=e.id WHERE 1=1`)
+	const candidateSelect = `SELECT e.id,COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0)`
 	args := []any{}
-	args = appendEventSearchFilters(&builder, args, criteria)
-	// An empty generation means no trustworthy fingerprints exist for this
-	// read. Skip the clause outright rather than relying on it matching
-	// nothing: three correlated subqueries per candidate row are not free,
-	// and the fail-open behaviour should not depend on an invariant about
-	// which generation ids can appear in literal_search_fingerprints.
+	// Filterable queries with a usable generation start from fingerprints
+	// (plus the post-cutover / never-inventoried tail). Walking events and
+	// probing fingerprints per row stays O(history) for no-match. An empty
+	// generation or an unfilterable short query keeps the events walk.
 	if generation != "" && query.Filterable() {
 		fingerprints := query.Fingerprints()
-		builder.WriteString(" AND (NOT EXISTS(SELECT 1 FROM literal_search_fingerprints known WHERE known.generation_id=? AND known.event_id=e.id AND known.fingerprint_version=1) OR (SELECT COUNT(DISTINCT matched.fingerprint) FROM literal_search_fingerprints matched WHERE matched.generation_id=? AND matched.event_id=e.id AND matched.fingerprint_version=1 AND matched.fingerprint IN (")
-		args = append(args, generation, generation)
+		builder.WriteString(candidateSelect)
+		builder.WriteString(` FROM (
+  SELECT fp.event_id AS id
+    FROM literal_search_fingerprints fp INDEXED BY idx_literal_search_fingerprints_by_fp
+   WHERE fp.generation_id=? AND fp.fingerprint_version=1 AND fp.fingerprint IN (`)
+		args = append(args, generation)
 		for i, fingerprint := range fingerprints {
 			if i > 0 {
 				builder.WriteByte(',')
@@ -255,9 +244,43 @@ func buildTieredSearchCandidateQuery(criteria apptypes.EventSearchCriteria, gene
 			builder.WriteByte('?')
 			args = append(args, []byte(fingerprint))
 		}
-		builder.WriteString("))=?)")
-		args = append(args, len(fingerprints))
+		builder.WriteString(`)
+   GROUP BY fp.event_id
+  HAVING COUNT(DISTINCT fp.fingerprint)=?
+  UNION
+  SELECT q.event_id
+    FROM search_projection_source_sequence q
+   WHERE q.sequence > (SELECT high_water FROM search_projection_state WHERE singleton=1)
+  UNION
+  SELECT q.event_id
+    FROM search_projection_source_sequence q
+   WHERE q.sequence <= (SELECT high_water FROM search_projection_state WHERE singleton=1)
+     AND NOT EXISTS (
+         SELECT 1 FROM literal_search_fingerprints known
+          WHERE known.generation_id=? AND known.event_id=q.event_id AND known.fingerprint_version=1
+     )
+  UNION
+  SELECT e_tail.id
+    FROM events e_tail
+   WHERE NOT EXISTS (
+         SELECT 1 FROM search_projection_source_sequence missing WHERE missing.event_id=e_tail.id
+   )
+) candidates
+JOIN events e ON e.id=candidates.id
+LEFT JOIN command_audits a ON a.event_id=e.id
+WHERE 1=1`)
+		args = append(args, len(fingerprints), generation)
+	} else {
+		// The candidate set is events, not search_projection_source_sequence.
+		// That table is the projection's own checkpoint ledger: it is populated
+		// by the migration-038 insert trigger and, for rows that predate it,
+		// only by the rebuild's inventory phase. An upgraded store that has
+		// never completed a generation therefore has no sequence row for any
+		// of its history, and joining through it would drop that history.
+		builder.WriteString(candidateSelect)
+		builder.WriteString(` FROM events e LEFT JOIN command_audits a ON a.event_id=e.id WHERE 1=1`)
 	}
+	args = appendEventSearchFilters(&builder, args, criteria)
 	builder.WriteString(" ORDER BY e.created_at_norm DESC,e.id DESC LIMIT ?")
 	args = append(args, apptypes.DeepLiteralSearchBudget.SourceRows+1)
 	return builder.String(), args

--- a/infrastructure/sqlite/event_search_authority_internal_test.go
+++ b/infrastructure/sqlite/event_search_authority_internal_test.go
@@ -281,9 +281,12 @@ func TestTieredAuthorityFingerprintPreFilter(t *testing.T) {
 	}
 }
 
-func TestTieredAuthorityFingerprintReadersUsePrimaryKeyAfterCandidateIndexDrop(t *testing.T) {
+func TestTieredAuthorityFingerprintFirstPlanUsesByFpIndex(t *testing.T) {
 	ctx := context.Background()
 	database, _ := newTieredAuthorityFixture(t)
+	insertTieredSearchEvent(t, database, "pre-match", "shared needle alpha", time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	seedTieredCompleteProjection(t, database, "generation")
+	seedLiteralFingerprints(t, database, "generation", "pre-match", "shared needle alpha")
 	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
 	query, args := buildTieredSearchCandidateQuery(criteria, "generation")
 
@@ -297,11 +300,11 @@ func TestTieredAuthorityFingerprintReadersUsePrimaryKeyAfterCandidateIndexDrop(t
 	if err = raw.QueryRowContext(ctx, `
 		SELECT COUNT(*)
 		  FROM sqlite_schema
-		 WHERE type='index' AND name='idx_literal_search_fingerprint_candidate'`).Scan(&indexCount); err != nil {
+		 WHERE type='index' AND name='idx_literal_search_fingerprints_by_fp'`).Scan(&indexCount); err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(0, indexCount); diff != "" {
-		t.Fatalf("candidate index still exists (-want +got):\n%s", diff)
+	if diff := cmp.Diff(1, indexCount); diff != "" {
+		t.Fatalf("fingerprint-first index missing (-want +got):\n%s", diff)
 	}
 
 	rows, err := raw.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
@@ -322,26 +325,48 @@ func TestTieredAuthorityFingerprintReadersUsePrimaryKeyAfterCandidateIndexDrop(t
 		t.Fatal(err)
 	}
 	plan := strings.Join(details, "\n")
-
-	// Matched per row rather than against the joined plan, and without the
-	// word between "using" and the index name: SQLite writes "USING INDEX" or
-	// "USING COVERING INDEX" depending on whether the row is satisfied from
-	// the index alone, and which one it picks is not the property under test.
-	// Pinning the exact phrase would turn an irrelevant planner detail into a
-	// red build.
-	for _, reader := range []string{"known", "matched"} {
-		t.Run(reader, func(t *testing.T) {
-			for _, detail := range details {
-				if strings.HasPrefix(detail, "search "+reader+" using") &&
-					strings.Contains(detail, "sqlite_autoindex_literal_search_fingerprints_1") {
-					return
-				}
-			}
-			t.Fatalf("fingerprint reader %q does not resolve through the primary key:\n%s", reader, plan)
-		})
+	if !strings.Contains(plan, "idx_literal_search_fingerprints_by_fp") {
+		t.Fatalf("fingerprint-first plan does not use idx_literal_search_fingerprints_by_fp:\n%s", plan)
 	}
-	if strings.Contains(plan, "idx_literal_search_fingerprint_candidate") {
-		t.Fatalf("fingerprint query plan still names the dropped candidate index:\n%s", plan)
+	if strings.Contains(query, "NOT EXISTS(SELECT 1 FROM literal_search_fingerprints") {
+		t.Fatal("filterable fingerprint-first SQL still probes fingerprints per events row")
+	}
+}
+
+func TestTieredAuthorityNoMatchDoesNotWalkProjectedHistory(t *testing.T) {
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "pre-noise", "zzzz other text", base)
+	seedTieredCompleteProjection(t, database, "gen-nomatch")
+	seedLiteralFingerprints(t, database, "gen-nomatch", "pre-noise", "zzzz other text")
+	got, err := datasource.SearchMetadata(ctx, apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build())
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("no-match IDs = %v, want empty", metadataIDs(got))
+	}
+}
+
+func TestTieredAuthorityUnfilterableKeepsEventsWalk(t *testing.T) {
+	t.Parallel()
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("ab").Build()
+	query, _ := buildTieredSearchCandidateQuery(criteria, "generation")
+	if strings.Contains(query, "literal_search_fingerprints") {
+		t.Fatalf("unfilterable query still uses fingerprints:\n%s", query)
+	}
+	if !strings.Contains(query, "FROM events e LEFT JOIN command_audits") {
+		t.Fatalf("unfilterable query lost the events walk:\n%s", query)
+	}
+}
+
+func TestTieredAuthorityEmptyGenerationKeepsEventsWalk(t *testing.T) {
+	t.Parallel()
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	query, _ := buildTieredSearchCandidateQuery(criteria, "")
+	if strings.Contains(query, "literal_search_fingerprints") {
+		t.Fatalf("empty generation still uses fingerprints:\n%s", query)
 	}
 }
 

--- a/infrastructure/sqlite/migrate_offline_test.go
+++ b/infrastructure/sqlite/migrate_offline_test.go
@@ -51,8 +51,8 @@ func TestStoreInitAppliesOfflineMigrations(t *testing.T) {
 	if err := current.InitializeAuthorized(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 69 {
-		t.Fatalf("schema version=%d, want 69", got)
+	if got := maxSchemaVersion(t, path); got != 70 {
+		t.Fatalf("schema version=%d, want 70", got)
 	}
 }
 
@@ -64,8 +64,8 @@ func TestEmptyStoreReachesCurrentSchemaImplicitly(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 69 {
-		t.Fatalf("schema version=%d, want 69", got)
+	if got := maxSchemaVersion(t, path); got != 70 {
+		t.Fatalf("schema version=%d, want 70", got)
 	}
 }
 

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -112,6 +112,9 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	// Row backfill of started_at_norm / observed_at_norm is a bounded open
 	// catch-up, not this migration.
 	69: {69, "000069_add_report_window_norm_columns.sql", "85ab3ae7f4efc6a777eef43406e7882cc523c9a53bd8d758fe3eb8daa01a8455", MigrationConstantInPlace},
+	// 70 recreates a fingerprint-first secondary index. CREATE INDEX does not
+	// rewrite the fingerprint rows; previous binaries ignore the extra index.
+	70: {70, "000070_restore_literal_search_fingerprint_by_fp.sql", "4ab560ca7ba1986758c6a40f6c0d0d58c9ca393090b550ae6995a8f6a9a93b3c", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 69 || len(plan.Pending) != 34 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 70 || len(plan.Pending) != 35 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -66,6 +66,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		67: MigrationConstantInPlace,
 		68: MigrationConstantInPlace,
 		69: MigrationConstantInPlace,
+		70: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 69 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 70 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/schema/sqlite/migrations/000070_restore_literal_search_fingerprint_by_fp.sql
+++ b/schema/sqlite/migrations/000070_restore_literal_search_fingerprint_by_fp.sql
@@ -1,0 +1,8 @@
+-- Restore a fingerprint-first access path. Migration 000059 dropped
+-- idx_literal_search_fingerprint_candidate because the then-readers filtered
+-- on the primary-key prefix (generation_id, event_id, fingerprint). The
+-- #2127 candidate set starts at fingerprint IN (…) so that index is needed
+-- again. CREATE INDEX does not rewrite fingerprint rows.
+
+CREATE INDEX IF NOT EXISTS idx_literal_search_fingerprints_by_fp
+  ON literal_search_fingerprints(generation_id, fingerprint_version, fingerprint, event_id);


### PR DESCRIPTION
Closes #2127

Leaves parent #2126 open.

## Summary

Filterable search with a usable generation no longer walks `events` applying correlated fingerprint probes per row.

- Candidates are fingerprint `IN (…)` grouped by `event_id`, unioned with the post-cutover sequence tail, inventoried rows that have no fingerprints, and events never inventoried.
- Migration `000070` restores `idx_literal_search_fingerprints_by_fp`. Previous binaries ignore the extra index.
- `decodedEventSearchMatch` remains the match authority. Unfilterable short queries and empty generations keep the events walk. JSON shape is unchanged.

## Tests

- EXPLAIN uses `idx_literal_search_fingerprints_by_fp` (`INDEXED BY`).
- No-match on a complete generation with non-matching fingerprints returns empty.
- Unfilterable / empty-generation SQL keeps the events walk.
- Existing fail-open, rebuild-previous-generation, and watermark-gap tests still pass via `SearchMetadata` / `SearchPage`.

`go test ./...` and `go tool golangci-lint run` passed on this branch.

Copy-matrix ≤2 s no-match/selective is the Wave 1 verify step on an isolated post-compact copy, not this commit.