### PR TITLE
fix: drop superseded events indexes and name keyword exemption

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **compact 後の非 payload 増幅: 置き換え済み events index を落とし、session-keyword の evict 免除を名指しする (#2129)** — migration `000071` が `idx_events_created_at` など生 `created_at` 系 5 本を DROP（読者は `created_at_norm` 系のまま）。`search_projection_session_keywords` は index-family 予算に計上し evict しない。`doctor` の `search-projection-budget` WARN がそのファミリを名指しする。親 #2126 は open のまま。
 - **フィルタ可能な `search` が fingerprint 適用のためにイベント全履歴を歩かない (#2127)** — 候補は `literal_search_fingerprints`（`idx_literal_search_fingerprints_by_fp`）と cutover 後 / 未 inventory の tail。decode が match 権威のまま。pre-filter は fail-open。短い unfilterable クエリは events walk のまま。検索 JSON 形は不変。親 #2126 は open のまま。
 - **`report` の期間ロードがフィルタ列を `ts_norm` で包まず、OFFSET 再走査もしない (#2128)** — sessions / usage に `started_at_norm` / `observed_at_norm` を永続化（`events.created_at_norm` と同じ語彙形）。ページは `LIMIT/OFFSET` ではなく keyset `(norm, id)`。usage workspace tally は usage ページと同じ期間を数える（JSON 形は不変。窓外の行は値が減ることがある）。空の norm はストア open 時のバッチ catch-up で埋める。親 #2126 は open のまま。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Post-compact non-payload amplification: drop superseded events indexes and name the session-keyword exemption (#2129)** — migration `000071` drops `idx_events_created_at`, `idx_events_session_created_at`, `idx_events_session_created_at_id_desc`, `idx_events_workspace_created_at`, and `idx_events_source_hook_time` (readers stay on the `created_at_norm` family). `search_projection_session_keywords` remains counted in the index-family budget and is not evictable; `doctor` `search-projection-budget` WARN names that family. Leaves parent #2126 open.
 - **Filterable `search` no longer walks total event history to apply fingerprints (#2127)** — candidates come from `literal_search_fingerprints` (index `idx_literal_search_fingerprints_by_fp`) plus the post-cutover / never-inventoried tail. Decode remains the match authority; the pre-filter stays fail-open; unfilterable short queries keep the events walk. Search JSON shape is unchanged. Leaves parent #2126 open.
 - **`report` window loads no longer wrap filter columns in `ts_norm` or re-scan with OFFSET (#2128)** — sessions and usage persist `started_at_norm` / `observed_at_norm` (same lexical form as `events.created_at_norm`); pages use keyset `(norm, id)` instead of `LIMIT/OFFSET`. Usage workspace tally counts the same interval as the usage page (JSON shape unchanged; values may drop rows outside the window). Empty norms are stamped in batched store-open catch-up. Leaves parent #2126 open.
 

--- a/docs/search-projection-rebuild.ja.md
+++ b/docs/search-projection-rebuild.ja.md
@@ -75,7 +75,7 @@ b-tree 割当であり、ソーステキストではありません。デフォ�
 
 | ティア | 比例する対象 | evict できない理由 |
 |---|---|---|
-| `search_projection_session_summaries` / `_session_keywords` / `_command_aggregates` | セッション数 | セッション一致を返す追加の面。落とすとその一致を失う |
+| `search_projection_session_summaries` / `_session_keywords` / `_command_aggregates` | セッション数 | **evict しない**: セッション一致を返す追加の面。落とすとその一致を失う。`index_family_within_budget` には計上する。成長上限は complete な 1 世代分の session-tier keywords で、世代が置き換わると掃除される |
 | `literal_search_fingerprints` | イベント数 | pre-filter が fail open するのは、その event の行が 1 件も無い場合だけ。行がある状態でクエリの要求する fingerprint が揃っていないと復号前に除外され、遅くなるのではなく偽陰性になる |
 | `search_projection_source_sequence` / `_exclusions` | イベント数 | 再構築自体の台帳 |
 

--- a/docs/search-projection-rebuild.md
+++ b/docs/search-projection-rebuild.md
@@ -111,7 +111,7 @@ it:
 
 | tier | grows with | why it cannot be evicted |
 |---|---|---|
-| `search_projection_session_summaries`, `_session_keywords`, `_command_aggregates` | number of sessions | it is an additional session-match surface; dropping it loses those matches |
+| `search_projection_session_summaries`, `_session_keywords`, `_command_aggregates` | number of sessions | **eviction-exempt**: additional session-match surface; dropping it loses those matches. Still counted in `index_family_within_budget`. Growth bound is one complete generation's session-tier keywords, cleaned when that generation is replaced |
 | `literal_search_fingerprints` | number of events | the pre-filter fails open only for an event with *no* rows at all; once it has rows, a query whose fingerprints are not all present excludes it before decoding — a false negative, not a slower answer |
 | `search_projection_source_sequence`, `_exclusions` | number of events | they are the rebuild's own bookkeeping |
 

--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -33,12 +33,12 @@ Traceary は、ローカル状態を 1 つの SQLite DB ファイルに保存し
 - `client`: `cli`、`claude`、`codex`、`gemini`、`mcp` などの ingestion path
 - `workspace`: 利用可能な場合の補助的な work-context identifier
 
-主な index:
+主な index（語彙順の `created_at_norm` 系。生の `created_at` 重複 index は migration 000071 で削除）:
 
-- `idx_events_session_created_at` on `(session_id, created_at)`
-- `idx_events_session_created_at_id_desc` on `(session_id, created_at DESC, id DESC)`
-- `idx_events_created_at` on `(created_at DESC, id DESC)`
-- `idx_events_workspace_created_at` on `(workspace, created_at)`
+- `idx_events_created_at_norm_id_desc` on `(created_at_norm DESC, id DESC)`
+- `idx_events_session_created_at_norm_id_desc` on `(session_id, created_at_norm DESC, id DESC)`
+- `idx_events_workspace_created_at_norm_id_desc` on `(workspace, created_at_norm DESC, id DESC)`
+- `idx_events_source_hook_created_at_norm_id_desc` on `(source_hook, created_at_norm DESC, id DESC)`
 
 ### `command_audits`
 

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -33,12 +33,12 @@ Key columns:
 - `client`: ingestion path such as `cli`, `claude`, `codex`, `gemini`, or `mcp`
 - `workspace`: auxiliary work-context identifier when available
 
-Important indexes:
+Important indexes (lexical `created_at_norm` family; raw `created_at` duplicates were dropped in migration 000071):
 
-- `idx_events_session_created_at` on `(session_id, created_at)`
-- `idx_events_session_created_at_id_desc` on `(session_id, created_at DESC, id DESC)`
-- `idx_events_created_at` on `(created_at DESC, id DESC)`
-- `idx_events_workspace_created_at` on `(workspace, created_at)`
+- `idx_events_created_at_norm_id_desc` on `(created_at_norm DESC, id DESC)`
+- `idx_events_session_created_at_norm_id_desc` on `(session_id, created_at_norm DESC, id DESC)`
+- `idx_events_workspace_created_at_norm_id_desc` on `(workspace, created_at_norm DESC, id DESC)`
+- `idx_events_source_hook_created_at_norm_id_desc` on `(source_hook, created_at_norm DESC, id DESC)`
 
 ### `command_audits`
 

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -1149,18 +1149,16 @@ func sourceHookHasLegacyPrefix(sourceHook string) bool {
 }
 
 // queryRecentEvents dispatches between three SQL queries:
-//   - sourceHook == "": no filter — use the plain query that planners
-//     already serve via idx_events_created_at.
+//   - sourceHook == "": no filter — period bounds still go through
+//     ts_norm(created_at); the created_at_norm family serves other readers.
 //   - sourceHook in {subagent_stop, pre_compact}: UNION ALL form that
 //     includes a legacy-body-prefix branch so pre-#672 rows stay
 //     reachable during the migration window.
-//   - other sourceHook: primary-only query covered by the compound
-//     partial index idx_events_source_hook_time.
+//   - other sourceHook: primary-only query on e.source_hook.
 //
 // The legacy UNION ALL branch is NOT used for other hook names because
-// SQLite would still scan the right branch via idx_events_created_at
-// even when its WHERE filters returned zero rows, negating the index
-// gain from #683.
+// SQLite would still scan the right branch even when its WHERE filters
+// returned zero rows, negating the index gain from #683.
 func queryRecentEvents(
 	ctx context.Context,
 	db *sql.DB,

--- a/infrastructure/sqlite/events_legacy_index_drop_internal_test.go
+++ b/infrastructure/sqlite/events_legacy_index_drop_internal_test.go
@@ -1,0 +1,87 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestShippedEventPlansDoNotUseDroppedCreatedAtIndexes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	from := "2026-01-01T00:00:00.000000000Z"
+	to := "2026-01-02T00:00:00.000000000Z"
+	searchSQL, searchArgs := buildTieredSearchCandidateQuery(
+		apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build(),
+		"generation",
+	)
+	plans := []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{
+			name:  "list recent events",
+			query: selectRecentEventsQuery,
+			args:  []any{"", "", "", "", "", "", "", "", "", "", 0, "", "", "", "", 10, 0},
+		},
+		{
+			name:  "search fingerprint-first",
+			query: searchSQL,
+			args:  searchArgs,
+		},
+		{
+			name:  "report sessions",
+			query: listReportSessionsQuery,
+			args: []any{
+				"", "", "", "", from, from, to, to, "", "", "", 10,
+				"", "", "", "", from, from, to, to,
+			},
+		},
+	}
+	dropped := []string{
+		"idx_events_created_at",
+		"idx_events_session_created_at",
+		"idx_events_session_created_at_id_desc",
+		"idx_events_workspace_created_at",
+		"idx_events_source_hook_time",
+	}
+	for _, plan := range plans {
+		rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+plan.query, plan.args...)
+		if err != nil {
+			t.Fatalf("%s EXPLAIN: %v", plan.name, err)
+		}
+		joined := strings.ToLower(joinQueryPlan(t, rows))
+		_ = rows.Close()
+		masked := joined
+		for _, keep := range []string{
+			"idx_events_created_at_norm",
+			"idx_events_session_created_at_norm",
+			"idx_events_workspace_created_at_norm",
+			"idx_events_source_hook_created_at_norm",
+		} {
+			masked = strings.ReplaceAll(masked, keep, "kept_norm")
+		}
+		for _, name := range dropped {
+			if strings.Contains(masked, strings.ToLower(name)) {
+				t.Fatalf("%s plan still names %s:\n%s", plan.name, name, joined)
+			}
+		}
+	}
+}

--- a/infrastructure/sqlite/events_legacy_index_drop_test.go
+++ b/infrastructure/sqlite/events_legacy_index_drop_test.go
@@ -1,0 +1,56 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+var supersededEventsCreatedAtIndexes = []string{
+	"idx_events_created_at",
+	"idx_events_session_created_at",
+	"idx_events_session_created_at_id_desc",
+	"idx_events_workspace_created_at",
+	"idx_events_source_hook_time",
+}
+
+func TestMigration071DropsSupersededEventsCreatedAtIndexes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	before := sqlite.NewStoreManagementDatasource(sqlite.NewDatabase(path, onDiskSQLiteMigrationsBefore(t, 71)))
+	if err := before.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	conn, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	for _, name := range supersededEventsCreatedAtIndexes {
+		var n int
+		if err := conn.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE type='index' AND name=?`, name).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 1 {
+			t.Fatalf("pre-071 missing %s", name)
+		}
+	}
+
+	current := sqlite.NewStoreManagementDatasource(sqlite.NewDatabase(path, onDiskSQLiteMigrations(t)))
+	if err := current.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range supersededEventsCreatedAtIndexes {
+		var n int
+		if err := conn.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE type='index' AND name=?`, name).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Fatalf("post-071 still has %s", name)
+		}
+	}
+}

--- a/infrastructure/sqlite/migrate_offline_test.go
+++ b/infrastructure/sqlite/migrate_offline_test.go
@@ -51,8 +51,8 @@ func TestStoreInitAppliesOfflineMigrations(t *testing.T) {
 	if err := current.InitializeAuthorized(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 70 {
-		t.Fatalf("schema version=%d, want 70", got)
+	if got := maxSchemaVersion(t, path); got != 71 {
+		t.Fatalf("schema version=%d, want 71", got)
 	}
 }
 
@@ -64,8 +64,8 @@ func TestEmptyStoreReachesCurrentSchemaImplicitly(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 70 {
-		t.Fatalf("schema version=%d, want 70", got)
+	if got := maxSchemaVersion(t, path); got != 71 {
+		t.Fatalf("schema version=%d, want 71", got)
 	}
 }
 

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -115,6 +115,9 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	// 70 recreates a fingerprint-first secondary index. CREATE INDEX does not
 	// rewrite the fingerprint rows; previous binaries ignore the extra index.
 	70: {70, "000070_restore_literal_search_fingerprint_by_fp.sql", "4ab560ca7ba1986758c6a40f6c0d0d58c9ca393090b550ae6995a8f6a9a93b3c", MigrationConstantInPlace},
+	// 71 drops five unused raw-created_at events indexes. DROP INDEX moves
+	// pages to the freelist (000059); no row rewrite.
+	71: {71, "000071_drop_superseded_events_created_at_indexes.sql", "518555e257aa6f100713c370fafc45765449a8f875f1708438b139e0e7edb3f5", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 70 || len(plan.Pending) != 35 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 71 || len(plan.Pending) != 36 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -67,6 +67,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		68: MigrationConstantInPlace,
 		69: MigrationConstantInPlace,
 		70: MigrationConstantInPlace,
+		71: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 70 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 71 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/presentation/cli/doctor_search_projection.go
+++ b/presentation/cli/doctor_search_projection.go
@@ -96,10 +96,16 @@ func searchProjectionBudgetDoctorCheck(status apptypes.SearchProjectionControlSt
 		}
 	case 0:
 		return doctorCheck{
-			Name:    name,
-			Status:  doctorStatusWarn,
-			Message: Localize("completed search-projection family exceeds the configured index-family budget", "完了した search-projection ファミリが設定した index-family 予算を超えています"),
-			Hint:    Localize("run `traceary store compact --projection-rebuild` with a smaller --index-family-bytes; CatchUp will not correct a complete generation", "`--index-family-bytes` を小さくして `traceary store compact --projection-rebuild` を実行してください。CatchUp は complete 世代を直しません"),
+			Name:   name,
+			Status: doctorStatusWarn,
+			Message: Localize(
+				"completed search-projection family exceeds the configured index-family budget; search_projection_session_keywords (and its autoindex) is counted, corpus-proportional, and not evictable",
+				"完了した search-projection ファミリが設定した index-family 予算を超えています。search_projection_session_keywords（とその autoindex）は計上され、コーパス比例で evict できません",
+			),
+			Hint: Localize(
+				"session keywords bound is one complete generation, cleaned when that generation is replaced; run `traceary store compact --projection-rebuild` with a smaller --index-family-bytes to shrink the evictable recent tier. CatchUp will not correct a complete generation",
+				"session keywords の上限は complete な 1 世代分で、世代が置き換わると掃除されます。evict できる recent ティアを縮めるには `--index-family-bytes` を小さくして `traceary store compact --projection-rebuild` を実行してください。CatchUp は complete 世代を直しません",
+			),
 		}
 	default:
 		return doctorCheck{

--- a/presentation/cli/doctor_search_projection_test.go
+++ b/presentation/cli/doctor_search_projection_test.go
@@ -48,6 +48,9 @@ func TestSearchProjectionBudgetDoctorCheck(t *testing.T) {
 			if tt.want == doctorStatusWarn && got.Hint == "" {
 				t.Fatal("over-budget warning must name the operator lever")
 			}
+			if tt.want == doctorStatusWarn && !strings.Contains(got.Message, "search_projection_session_keywords") {
+				t.Fatalf("over-budget message=%q, want exempt family named", got.Message)
+			}
 		})
 	}
 }

--- a/schema/sqlite/migrations/000071_drop_superseded_events_created_at_indexes.sql
+++ b/schema/sqlite/migrations/000071_drop_superseded_events_created_at_indexes.sql
@@ -1,0 +1,10 @@
+-- Drop raw-created_at events indexes superseded by the created_at_norm
+-- family (migration 000031). Bounded: DROP INDEX moves pages to the freelist
+-- (000059 precedent). Older binaries still open; they already have the norm
+-- indexes for the same shapes.
+
+DROP INDEX IF EXISTS idx_events_created_at;
+DROP INDEX IF EXISTS idx_events_session_created_at;
+DROP INDEX IF EXISTS idx_events_session_created_at_id_desc;
+DROP INDEX IF EXISTS idx_events_workspace_created_at;
+DROP INDEX IF EXISTS idx_events_source_hook_time;


### PR DESCRIPTION
Closes #2129

Leaves parent #2126 open.

## Summary

- Migration `000071` drops `idx_events_created_at`, `idx_events_session_created_at`, `idx_events_session_created_at_id_desc`, `idx_events_workspace_created_at`, and `idx_events_source_hook_time`. Readers stay on the `created_at_norm` family (000031). DROP INDEX is bounded (000059).
- Keyword-family decision: **documented eviction exemption**, still counted in `index_family_within_budget`. Growth bound is one complete generation, cleaned on replace. `doctor` `search-projection-budget` WARN names `search_projection_session_keywords`.
- Docs: `docs/search-projection-rebuild.md` / `.ja.md` and storage README index lists.

## Tests

- Pre-071 store has the five indexes; after current Initialize they are gone.
- EXPLAIN of list / fingerprint-first search / report sessions does not name the dropped indexes (norm names masked).
- Doctor over-budget message contains `search_projection_session_keywords`.

`go test ./...` and `go tool golangci-lint run` passed.

Copy dbstat attribution and ~70% reclaim measurement remain the Wave 1 verify step on the isolated post-compact copy (never the live home store).