### PR TITLE
fix: seek session-tier search from keywords, not summary LIKE

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **フィルタ可能な session 検索が全 summary を LIKE 走査しない (#2170)** — 候補は `search_projection_session_keywords`（`idx_search_projection_session_keywords_by_kw`）。フィルタ/ソートは `sessions.started_at_norm`。短い unfilterable クエリは summary LIKE のまま。検索 JSON 形は不変。親 #2126 は open のまま。
 - **ストア Initialize が workspace-observation catch-up でイベント履歴を歩かない (#2169)** — 0 行バッチ後は `workspace_observation_catchup_state.exhausted` で以降の open を飛ばす。残バッチは `created_at_norm DESC`（`ts_norm(created_at)` ではない）。親 #2126 は open のまま。
 - **フィルタ可能な no-match 検索が inventory 済みイベント履歴を歩かない (#2167)** — fail-open は cutover 後の `sequence > high_water` tail だけ。fingerprint の無い inventory 行は飛ばす。decode が match 権威のまま。親 #2126 は open のまま。
 - **compact 後の非 payload 増幅: 置き換え済み events index を落とし、session-keyword の evict 免除を名指しする (#2129)** — migration `000071` が `idx_events_created_at` など生 `created_at` 系 5 本を DROP（読者は `created_at_norm` 系のまま）。`search_projection_session_keywords` は index-family 予算に計上し evict しない。`doctor` の `search-projection-budget` WARN がそのファミリを名指しする。親 #2126 は open のまま。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Filterable session search no longer LIKE-scans every summary (#2170)** — candidates come from `search_projection_session_keywords` via `idx_search_projection_session_keywords_by_kw`. Filter/order use `sessions.started_at_norm`. Unfilterable short queries keep the summary LIKE walk. Search JSON shape is unchanged. Leaves parent #2126 open.
 - **Store Initialize no longer scans event history for workspace-observation catch-up (#2169)** — after a 0-row batch, `workspace_observation_catchup_state.exhausted` skips later opens. Remaining batches order by `created_at_norm DESC` (not `ts_norm(created_at)`). Leaves parent #2126 open.
 - **Filterable no-match search no longer walks inventoried event history (#2167)** — fail-open is only the post-cutover `sequence > high_water` tail. Inventoried rows without fingerprints are skipped. Decode remains the match authority. Leaves parent #2126 open.
 - **Post-compact non-payload amplification: drop superseded events indexes and name the session-keyword exemption (#2129)** — migration `000071` drops `idx_events_created_at`, `idx_events_session_created_at`, `idx_events_session_created_at_id_desc`, `idx_events_workspace_created_at`, and `idx_events_source_hook_time` (readers stay on the `created_at_norm` family). `search_projection_session_keywords` remains counted in the index-family budget and is not evictable; `doctor` `search-projection-budget` WARN names that family. Leaves parent #2126 open.

--- a/infrastructure/sqlite/migrate_offline_test.go
+++ b/infrastructure/sqlite/migrate_offline_test.go
@@ -51,8 +51,8 @@ func TestStoreInitAppliesOfflineMigrations(t *testing.T) {
 	if err := current.InitializeAuthorized(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 72 {
-		t.Fatalf("schema version=%d, want 72", got)
+	if got := maxSchemaVersion(t, path); got != 73 {
+		t.Fatalf("schema version=%d, want 73", got)
 	}
 }
 
@@ -64,8 +64,8 @@ func TestEmptyStoreReachesCurrentSchemaImplicitly(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if got := maxSchemaVersion(t, path); got != 72 {
-		t.Fatalf("schema version=%d, want 72", got)
+	if got := maxSchemaVersion(t, path); got != 73 {
+		t.Fatalf("schema version=%d, want 73", got)
 	}
 }
 

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -120,6 +120,9 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	71: {71, "000071_drop_superseded_events_created_at_indexes.sql", "518555e257aa6f100713c370fafc45765449a8f875f1708438b139e0e7edb3f5", MigrationConstantInPlace},
 	// 72 is a singleton bookkeeping table. No event scan.
 	72: {72, "000072_add_workspace_observation_catchup_state.sql", "943a7f54f976a6a4871fc8b80def19e6d3f2e11d4b755570728d7b5435a211a1", MigrationConstantInPlace},
+	// 73 adds a keyword-first secondary index. CREATE INDEX does not rewrite
+	// keyword rows; previous binaries ignore the extra index.
+	73: {73, "000073_add_session_keyword_by_kw_index.sql", "a171e67c6ffac43eb57c8cb0c2537cf42d7eb64b5654dc80a9665de992059a42", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 72 || len(plan.Pending) != 37 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 73 || len(plan.Pending) != 38 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -69,6 +69,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		70: MigrationConstantInPlace,
 		71: MigrationConstantInPlace,
 		72: MigrationConstantInPlace,
+		73: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 72 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 73 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/search_projection_read_path_test.go
+++ b/infrastructure/sqlite/search_projection_read_path_test.go
@@ -118,6 +118,7 @@ func TestSearchProjectionReadPath_SessionTierSummaryOnly(t *testing.T) {
 			workspace:  workspace.String(),
 			client:     "cli",
 			agent:      "codex",
+			keywords:   []string{"unique-session-marker"},
 		},
 	}, nil)
 
@@ -175,6 +176,7 @@ func TestSearchProjectionReadPath_SessionExcludedWhenEventHitExists(t *testing.T
 			workspace:  workspace.String(),
 			client:     "cli",
 			agent:      "codex",
+			keywords:   []string{"shared-marker"},
 		},
 		{
 			sessionID:  "sess-only-summary",
@@ -184,6 +186,7 @@ func TestSearchProjectionReadPath_SessionExcludedWhenEventHitExists(t *testing.T
 			workspace:  workspace.String(),
 			client:     "cli",
 			agent:      "codex",
+			keywords:   []string{"shared-marker"},
 		},
 	}, nil)
 
@@ -246,6 +249,7 @@ func TestSearchProjectionReadPath_FiltersApplyToBothTiers(t *testing.T) {
 			workspace:  wsA.String(),
 			client:     "cli",
 			agent:      "codex",
+			keywords:   []string{"filter-needle"},
 		},
 		{
 			sessionID:  "sess-old-b",
@@ -255,6 +259,7 @@ func TestSearchProjectionReadPath_FiltersApplyToBothTiers(t *testing.T) {
 			workspace:  wsB.String(),
 			client:     "cli",
 			agent:      "codex",
+			keywords:   []string{"filter-needle"},
 		},
 	}, nil)
 
@@ -450,9 +455,9 @@ func TestSearchProjectionReadPath_EventsAppendedAfterRebuildStayFindable(t *test
 	}
 }
 
-// sessions carries no persisted _norm column, so started_at comparisons must go
-// through ts_norm on both sides. Raw RFC3339Nano comparison drops a sub-second
-// timestamp out of range because '.' 0x2E sorts below 'Z' 0x5A (#1185).
+// started_at_norm is the persisted compare form (#2128 / #2170). Raw
+// RFC3339Nano comparison drops a sub-second timestamp out of range because
+// '.' 0x2E sorts below 'Z' 0x5A (#1185).
 func TestSearchProjectionReadPath_SessionFromFilterHandlesSubSecondStartedAt(t *testing.T) {
 	t.Parallel()
 
@@ -475,6 +480,7 @@ func TestSearchProjectionReadPath_SessionFromFilterHandlesSubSecondStartedAt(t *
 			workspace: workspace.String(),
 			client:    "cli",
 			agent:     "codex",
+			keywords:  []string{"subsecond-marker"},
 		},
 	}, nil)
 
@@ -671,6 +677,7 @@ func TestSearchSessionPageReportsStateFromTheSameSnapshot(t *testing.T) {
 			workspace:  workspace.String(),
 			client:     "cli",
 			agent:      "codex",
+			keywords:   []string{"unique-session-marker"},
 		},
 	}, nil)
 

--- a/infrastructure/sqlite/search_projection_session_keyword_test.go
+++ b/infrastructure/sqlite/search_projection_session_keyword_test.go
@@ -1,0 +1,100 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestSearchSessionPageFilterableMatchesKeywordNotSummarySubstring(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	workspace := types.Workspace("ws")
+	dbPath := t.TempDir() + "/store.db"
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	base := time.Date(2026, 6, 19, 10, 0, 0, 0, time.UTC)
+	seedCompleteProjection(t, dbPath, "gen-2170", nil, []projectionSessionSeed{
+		{
+			sessionID:  "sess-keyword",
+			summary:    "unrelated summary text",
+			eventCount: 2,
+			startedAt:  base,
+			workspace:  workspace.String(),
+			client:     "cli",
+			agent:      "codex",
+			keywords:   []string{"needle2170"},
+		},
+		{
+			sessionID:  "sess-substring",
+			summary:    "the needle2170token is only in the summary",
+			eventCount: 1,
+			startedAt:  base.Add(time.Minute),
+			workspace:  workspace.String(),
+			client:     "cli",
+			agent:      "codex",
+		},
+	}, nil)
+
+	got, err := sut.SearchSessionPage(ctx, apptypes.NewEventSearchCriteriaBuilder(10).Query("needle2170").Workspace(workspace).Build(), nil)
+	if err != nil {
+		t.Fatalf("SearchSessionPage() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"sess-keyword"}, sessionHitIDs(got.Hits())); diff != "" {
+		t.Fatalf("SearchSessionPage() IDs mismatch (-want +got):\n%s", diff)
+	}
+
+	empty, err := sut.SearchSessionPage(ctx, apptypes.NewEventSearchCriteriaBuilder(10).Query("xyzzy-nomatch-2170").Workspace(workspace).Build(), nil)
+	if err != nil {
+		t.Fatalf("SearchSessionPage(no-match) error = %v", err)
+	}
+	if len(empty.Hits()) != 0 {
+		t.Fatalf("no-match hits = %v, want empty", sessionHitIDs(empty.Hits()))
+	}
+
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		rows, err := db.Query(`EXPLAIN QUERY PLAN
+			SELECT sum.session_id, sum.summary_text, sum.event_count, s.started_at
+			  FROM search_projection_session_keywords k INDEXED BY idx_search_projection_session_keywords_by_kw
+			  JOIN search_projection_session_summaries sum
+			    ON sum.generation_id = k.generation_id AND sum.session_id = k.session_id
+			  JOIN sessions s ON s.session_id = sum.session_id
+			 WHERE k.generation_id = (SELECT active_generation_id FROM search_projection_state WHERE singleton = 1)
+			   AND k.keyword = ?
+			   AND s.workspace = ?
+			 ORDER BY s.started_at_norm DESC, s.session_id DESC LIMIT ?`,
+			"xyzzy-nomatch-2170", workspace.String(), 10)
+		if err != nil {
+			t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+		}
+		defer func() { _ = rows.Close() }()
+		var plan []string
+		for rows.Next() {
+			var id, parent, unused int
+			var detail string
+			if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+				t.Fatal(err)
+			}
+			plan = append(plan, strings.ToLower(detail))
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		joined := strings.Join(plan, "\n")
+		if !strings.Contains(joined, "idx_search_projection_session_keywords_by_kw") {
+			t.Fatalf("filterable plan does not use idx_search_projection_session_keywords_by_kw:\n%s", joined)
+		}
+		if strings.Contains(joined, "like") {
+			t.Fatalf("filterable plan still LIKE-scans summaries:\n%s", joined)
+		}
+	})
+}

--- a/infrastructure/sqlite/search_projection_session_query.go
+++ b/infrastructure/sqlite/search_projection_session_query.go
@@ -77,37 +77,8 @@ func queryProjectionSessionHits(
 	queryValue string,
 	excludeSessionIDs []types.SessionID,
 ) ([]apptypes.SearchSessionHit, error) {
-	var builder strings.Builder
-	builder.WriteString(`
-		SELECT sum.session_id, sum.summary_text, sum.event_count, s.started_at
-		  FROM search_projection_session_summaries sum
-		  JOIN sessions s ON s.session_id = sum.session_id
-		 WHERE sum.generation_id = (
-		         SELECT active_generation_id
-		           FROM search_projection_state
-		          WHERE singleton = 1
-		       )
-		   AND (
-		         EXISTS (
-		           SELECT 1
-		             FROM search_projection_session_keywords k
-		            WHERE k.generation_id = sum.generation_id
-		              AND k.session_id = sum.session_id
-		              AND k.keyword = ?
-		         )
-		         OR sum.summary_text LIKE ? ESCAPE '\'
-		       )`)
-	// Exact keyword + LIKE is the shipped session-tier match (#1756).
-	// A porter FTS was measured and not added: LIKE already matches
-	// stemming-as-substring, and the index would charge the family budget.
-	keyword := foldSearchASCII(queryValue)
-	likeQuery := "%" + escapeLikeQuery(queryValue) + "%"
-	args := []any{keyword, likeQuery}
-	args = appendSessionSearchFilters(&builder, args, criteria, excludeSessionIDs)
-	builder.WriteString(" ORDER BY ts_norm(s.started_at) DESC, s.session_id DESC LIMIT ?")
-	args = append(args, criteria.Limit())
-
-	rows, err := queryer.QueryContext(ctx, builder.String(), args...)
+	sqlText, args := buildProjectionSessionHitQuery(criteria, queryValue, excludeSessionIDs)
+	rows, err := queryer.QueryContext(ctx, sqlText, args...)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query projection session hits: %w", err)
 	}
@@ -140,6 +111,59 @@ func queryProjectionSessionHits(
 	return hits, nil
 }
 
+// buildProjectionSessionHitQuery is the SQL SearchSessionPage issues so EXPLAIN
+// tests measure the shipped statement. Filterable queries seek
+// idx_search_projection_session_keywords_by_kw; unfilterable short queries
+// keep the #1756 summary LIKE walk.
+func buildProjectionSessionHitQuery(
+	criteria apptypes.EventSearchCriteria,
+	queryValue string,
+	excludeSessionIDs []types.SessionID,
+) (string, []any) {
+	var builder strings.Builder
+	var args []any
+	if apptypes.CharacterizeLiteralQuery(queryValue).Filterable() {
+		builder.WriteString(`
+		SELECT sum.session_id, sum.summary_text, sum.event_count, s.started_at
+		  FROM search_projection_session_keywords k INDEXED BY idx_search_projection_session_keywords_by_kw
+		  JOIN search_projection_session_summaries sum
+		    ON sum.generation_id = k.generation_id AND sum.session_id = k.session_id
+		  JOIN sessions s ON s.session_id = sum.session_id
+		 WHERE k.generation_id = (
+		         SELECT active_generation_id
+		           FROM search_projection_state
+		          WHERE singleton = 1
+		       )
+		   AND k.keyword = ?`)
+		args = append(args, foldSearchASCII(queryValue))
+	} else {
+		builder.WriteString(`
+		SELECT sum.session_id, sum.summary_text, sum.event_count, s.started_at
+		  FROM search_projection_session_summaries sum
+		  JOIN sessions s ON s.session_id = sum.session_id
+		 WHERE sum.generation_id = (
+		         SELECT active_generation_id
+		           FROM search_projection_state
+		          WHERE singleton = 1
+		       )
+		   AND (
+		         EXISTS (
+		           SELECT 1
+		             FROM search_projection_session_keywords k
+		            WHERE k.generation_id = sum.generation_id
+		              AND k.session_id = sum.session_id
+		              AND k.keyword = ?
+		         )
+		         OR sum.summary_text LIKE ? ESCAPE '\'
+		       )`)
+		args = append(args, foldSearchASCII(queryValue), "%"+escapeLikeQuery(queryValue)+"%")
+	}
+	args = appendSessionSearchFilters(&builder, args, criteria, excludeSessionIDs)
+	builder.WriteString(" ORDER BY s.started_at_norm DESC, s.session_id DESC LIMIT ?")
+	args = append(args, criteria.Limit())
+	return builder.String(), args
+}
+
 func appendSessionSearchFilters(
 	builder *strings.Builder,
 	args []any,
@@ -162,17 +186,15 @@ func appendSessionSearchFilters(
 		builder.WriteString(" AND s.agent = ?")
 		args = append(args, value)
 	}
-	// sessions has no persisted _norm column, so every started_at comparison goes
-	// through ts_norm on both sides. RFC3339Nano is variable width and '.' 0x2E
-	// sorts below 'Z' 0x5A, so raw string comparison drops sub-second timestamps
-	// out of range (#1185).
+	// started_at_norm is the #2128 persisted form. Compare the stored column
+	// to a normalized bound so the sessions index can be used.
 	if !criteria.From().IsZero() {
-		builder.WriteString(" AND ts_norm(s.started_at) >= ts_norm(?)")
-		args = append(args, formatTimestamp(criteria.From()))
+		builder.WriteString(" AND s.started_at_norm >= ?")
+		args = append(args, normalizeRFC3339NanoForCompare(formatTimestamp(criteria.From())))
 	}
 	if !criteria.To().IsZero() {
-		builder.WriteString(" AND ts_norm(s.started_at) < ts_norm(?)")
-		args = append(args, formatTimestamp(criteria.To()))
+		builder.WriteString(" AND s.started_at_norm < ?")
+		args = append(args, normalizeRFC3339NanoForCompare(formatTimestamp(criteria.To())))
 	}
 	if criteria.FailuresOnly() {
 		// Session tier can honour failures through command aggregates only.

--- a/infrastructure/sqlite/search_projection_session_query_internal_test.go
+++ b/infrastructure/sqlite/search_projection_session_query_internal_test.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestBuildProjectionSessionHitQueryFilterableUsesKeywordIndex(t *testing.T) {
+	t.Parallel()
+	criteria := apptypes.NewEventSearchCriteriaBuilder(5).
+		Query("xyzzy-nomatch-2170").
+		Workspace(types.Workspace("github.com/duck8823/traceary")).
+		Build()
+	query, args := buildProjectionSessionHitQuery(criteria, "xyzzy-nomatch-2170", nil)
+	if strings.Contains(query, "LIKE") {
+		t.Fatal("filterable session SQL still LIKE-scans summary_text")
+	}
+	if !strings.Contains(query, "idx_search_projection_session_keywords_by_kw") {
+		t.Fatalf("filterable session SQL does not force keyword index:\n%s", query)
+	}
+	if strings.Contains(query, "ts_norm") {
+		t.Fatalf("filterable session SQL still wraps started_at in ts_norm:\n%s", query)
+	}
+	if len(args) < 2 {
+		t.Fatalf("args = %#v, want keyword plus limit", args)
+	}
+}
+
+func TestBuildProjectionSessionHitQueryUnfilterableKeepsLike(t *testing.T) {
+	t.Parallel()
+	criteria := apptypes.NewEventSearchCriteriaBuilder(5).Query("ab").Build()
+	query, _ := buildProjectionSessionHitQuery(criteria, "ab", nil)
+	if !strings.Contains(query, "LIKE") {
+		t.Fatal("unfilterable session SQL dropped the summary LIKE walk")
+	}
+}

--- a/infrastructure/sqlite/search_projection_session_tier_index_test.go
+++ b/infrastructure/sqlite/search_projection_session_tier_index_test.go
@@ -32,8 +32,9 @@ SELECT COALESCE(SUM(pgsize), 0)
        )`
 
 // TestSessionTierKeepsLikePathAndMeasuresPorterFTS is the #1756 scratch
-// measurement. SearchSessionPage stays on exact-keyword + LIKE. The porter
-// FTS is created only for the comparison, then dropped.
+// measurement. After #2170, filterable SearchSessionPage is exact-keyword
+// only; unfilterable short queries keep LIKE. The porter FTS is created
+// only for the comparison, then dropped.
 func TestSessionTierKeepsLikePathAndMeasuresPorterFTS(t *testing.T) {
 	t.Parallel()
 
@@ -47,15 +48,15 @@ func TestSessionTierKeepsLikePathAndMeasuresPorterFTS(t *testing.T) {
 
 	base := time.Date(2026, 6, 19, 10, 0, 0, 0, time.UTC)
 	labeled := []projectionSessionSeed{
-		{sessionID: "sess-unique", summary: "discussed unique-session-marker during planning", eventCount: 12, startedAt: base, workspace: workspace.String(), client: "cli", agent: "codex"},
-		{sessionID: "sess-filter", summary: "filter-needle older summary", eventCount: 4, startedAt: base.Add(time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
-		{sessionID: "sess-subsecond", summary: "planning notes with subsecond-marker", eventCount: 3, startedAt: base.Add(2 * time.Second), workspace: workspace.String(), client: "cli", agent: "codex"},
-		{sessionID: "sess-deployed", summary: "the service was deployed to staging", eventCount: 8, startedAt: base.Add(3 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
-		{sessionID: "sess-deploy", summary: "deploy the service tonight", eventCount: 5, startedAt: base.Add(4 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
-		{sessionID: "sess-case", summary: "Discussed DEPLOY pipeline", eventCount: 2, startedAt: base.Add(5 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
-		{sessionID: "sess-undeploy", summary: "we will undeploy later", eventCount: 1, startedAt: base.Add(6 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
-		{sessionID: "sess-cafe-ascii", summary: "cafe rollout notes", eventCount: 2, startedAt: base.Add(7 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
-		{sessionID: "sess-cafe-accent", summary: "café rollout notes", eventCount: 2, startedAt: base.Add(8 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex"},
+		{sessionID: "sess-unique", summary: "discussed unique-session-marker during planning", eventCount: 12, startedAt: base, workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"unique-session-marker"}},
+		{sessionID: "sess-filter", summary: "filter-needle older summary", eventCount: 4, startedAt: base.Add(time.Minute), workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"filter-needle"}},
+		{sessionID: "sess-subsecond", summary: "planning notes with subsecond-marker", eventCount: 3, startedAt: base.Add(2 * time.Second), workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"subsecond-marker"}},
+		{sessionID: "sess-deployed", summary: "the service was deployed to staging", eventCount: 8, startedAt: base.Add(3 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"deployed"}},
+		{sessionID: "sess-deploy", summary: "deploy the service tonight", eventCount: 5, startedAt: base.Add(4 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"deploy"}},
+		{sessionID: "sess-case", summary: "Discussed DEPLOY pipeline", eventCount: 2, startedAt: base.Add(5 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"deploy"}},
+		{sessionID: "sess-undeploy", summary: "we will undeploy later", eventCount: 1, startedAt: base.Add(6 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"undeploy"}},
+		{sessionID: "sess-cafe-ascii", summary: "cafe rollout notes", eventCount: 2, startedAt: base.Add(7 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"cafe"}},
+		{sessionID: "sess-cafe-accent", summary: "café rollout notes", eventCount: 2, startedAt: base.Add(8 * time.Minute), workspace: workspace.String(), client: "cli", agent: "codex", keywords: []string{"café"}},
 	}
 	seedCompleteProjection(t, dbPath, "gen-1756", nil, labeled, nil)
 
@@ -132,11 +133,11 @@ func TestSessionTierKeepsLikePathAndMeasuresPorterFTS(t *testing.T) {
 	}
 
 	deployLike := likeByQuery["deploy-stem"]
-	if !containsAll(deployLike.hits, []string{"sess-deployed", "sess-deploy", "sess-case"}) {
-		t.Fatalf("LIKE deploy hits = %v, want stemming-as-substring of deployed/deploy/DEPLOY", deployLike.hits)
+	if !containsAll(deployLike.hits, []string{"sess-deploy", "sess-case"}) {
+		t.Fatalf("keyword deploy hits = %v, want exact-keyword sess-deploy/sess-case (#2170)", deployLike.hits)
 	}
-	if deployLike.recall != 1 {
-		t.Fatalf("LIKE deploy recall = %v, want 1 (stemming is not a LIKE miss)", deployLike.recall)
+	if containsAll(deployLike.hits, []string{"sess-deployed"}) {
+		t.Fatalf("keyword deploy hits = %v, sess-deployed is substring-only and must not match", deployLike.hits)
 	}
 
 	var familyBefore, compareFTS, familyAfterDrop int64

--- a/schema/sqlite/migrations/000073_add_session_keyword_by_kw_index.sql
+++ b/schema/sqlite/migrations/000073_add_session_keyword_by_kw_index.sql
@@ -1,0 +1,6 @@
+-- Filterable session search starts at keyword equality. The table PK is
+-- (generation_id, session_id, keyword), so keyword is not a seek prefix.
+-- CREATE INDEX does not rewrite keyword rows. Previous binaries ignore it.
+
+CREATE INDEX IF NOT EXISTS idx_search_projection_session_keywords_by_kw
+  ON search_projection_session_keywords(generation_id, keyword, session_id);


### PR DESCRIPTION
Closes #2170

Leaves parent #2126 open.

## Summary

Default filterable `search` still LIKE-scanned every session summary (~28k) and ordered with `ts_norm(s.started_at)`.

- Migration `000073` adds `idx_search_projection_session_keywords_by_kw (generation_id, keyword, session_id)`.
- Filterable queries seek that index and join summaries/sessions. No `LIKE` on `summary_text`.
- Filter/order use `sessions.started_at_norm` (`ts_norm(?)` is not wrapped around the column).
- Unfilterable short queries keep the #1756 LIKE walk.
- `--kind` probe uses the same SearchSessionPage path, so filterable probes are keyword-first too.

JSON shape unchanged. Event decode authority unchanged.

## Tests

- Filterable SQL has `INDEXED BY idx_search_projection_session_keywords_by_kw` and no LIKE.
- Unfilterable SQL keeps LIKE.
- SearchSessionPage matches keyword hits, not summary substring-only rows.
- EXPLAIN uses the keyword index.

`go test ./...` and `go tool golangci-lint run` passed on this branch.