### PR TITLE
fix: inventory post-cutover tail on a complete search-projection

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **complete な search-projection が store open で cutover 後 tail を inventory する (#2173)** — いまは `sequence > high_water` を fail-open decode している。complete 世代の CatchUp が bounded な tail に fingerprint を書き `high_water` を進める（rebuild しない）。decode が match 権威のまま。親 #2126 は open のまま。
 - **フィルタ可能な session 検索が全 summary を LIKE 走査しない (#2170)** — 候補は `search_projection_session_keywords`（`idx_search_projection_session_keywords_by_kw`）。フィルタ/ソートは `sessions.started_at_norm`。短い unfilterable クエリは summary LIKE のまま。検索 JSON 形は不変。親 #2126 は open のまま。
 - **ストア Initialize が workspace-observation catch-up でイベント履歴を歩かない (#2169)** — 0 行バッチ後は `workspace_observation_catchup_state.exhausted` で以降の open を飛ばす。残バッチは `created_at_norm DESC`（`ts_norm(created_at)` ではない）。親 #2126 は open のまま。
 - **フィルタ可能な no-match 検索が inventory 済みイベント履歴を歩かない (#2167)** — fail-open は cutover 後の `sequence > high_water` tail だけ。fingerprint の無い inventory 行は飛ばす。decode が match 権威のまま。親 #2126 は open のまま。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Complete search-projection inventories the post-cutover tail on store open (#2173)** — `sequence > high_water` is fail-open-decoded today; CatchUp on a complete generation fingerprints a bounded tail and advances `high_water` without a rebuild. Decode remains the match authority. Leaves parent #2126 open.
 - **Filterable session search no longer LIKE-scans every summary (#2170)** — candidates come from `search_projection_session_keywords` via `idx_search_projection_session_keywords_by_kw`. Filter/order use `sessions.started_at_norm`. Unfilterable short queries keep the summary LIKE walk. Search JSON shape is unchanged. Leaves parent #2126 open.
 - **Store Initialize no longer scans event history for workspace-observation catch-up (#2169)** — after a 0-row batch, `workspace_observation_catchup_state.exhausted` skips later opens. Remaining batches order by `created_at_norm DESC` (not `ts_norm(created_at)`). Leaves parent #2126 open.
 - **Filterable no-match search no longer walks inventoried event history (#2167)** — fail-open is only the post-cutover `sequence > high_water` tail. Inventoried rows without fingerprints are skipped. Decode remains the match authority. Leaves parent #2126 open.

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -32,6 +32,13 @@ type SearchProjectionCapacityRederiveStore interface {
 	RecordSearchProjectionCapacityRederivation(context.Context, string, time.Time)
 }
 
+// SearchProjectionCompleteTailStore inventories post-cutover source sequences
+// on a generation that is already complete (#2173). High-water stays frozen
+// after cutover today, so search fail-open-decodes every later event.
+type SearchProjectionCompleteTailStore interface {
+	CatchUpCompleteGenerationTail(context.Context, apptypes.SearchProjectionBudget, time.Time) (apptypes.SearchProjectionCatchUpResult, error)
+}
+
 type SearchProjectionInventoryStore interface {
 	SelectInventory(context.Context, apptypes.SearchProjectionBudget) (apptypes.SearchProjectionInventorySnapshot, error)
 	ApplyInventoryBatch(context.Context, apptypes.SearchProjectionInventoryPlan, time.Duration, time.Time) (apptypes.SearchProjectionProgress, error)
@@ -434,6 +441,23 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 		if status.CapacityRederived == 0 && status.GenerationID != "" {
 			if rederive, ok := u.store.(SearchProjectionCapacityRederiveStore); ok {
 				rederive.RecordSearchProjectionCapacityRederivation(ctx, status.GenerationID, now.UTC())
+			}
+		}
+		if tailStore, ok := u.store.(SearchProjectionCompleteTailStore); ok {
+			tail, tailErr := tailStore.CatchUpCompleteGenerationTail(ctx, b, now.UTC())
+			if tailErr != nil {
+				return tail, tailErr
+			}
+			if tail.Selected > 0 || tail.Written > 0 {
+				tail.Action = "complete_tail"
+				tail.Completed = true
+				if tail.State == "" {
+					tail.State = status.State
+				}
+				if tail.GenerationID == "" {
+					tail.GenerationID = status.GenerationID
+				}
+				return tail, nil
 			}
 		}
 		out.Action = "already_complete"

--- a/infrastructure/sqlite/search_projection_catchup.go
+++ b/infrastructure/sqlite/search_projection_catchup.go
@@ -282,6 +282,10 @@ func logSearchProjectionCatchUp(storePath string, result apptypes.SearchProjecti
 		"cutover_family_bytes_after", result.CutoverFamilyBytesAfter,
 		"session_tier_verified", result.SessionTierVerified,
 	}
+	if result.Action == "complete_tail" {
+		slog.Debug("search projection complete-generation tail catch-up batch completed", attrs...)
+		return
+	}
 	if result.Completed {
 		slog.Info("search projection catch-up completed generation", attrs...)
 		return

--- a/infrastructure/sqlite/search_projection_catchup_test.go
+++ b/infrastructure/sqlite/search_projection_catchup_test.go
@@ -648,3 +648,96 @@ func TestSearchProjectionCatchUp_AlternatingCommandEventsConverge(t *testing.T) 
 		t.Fatalf("lifecycle rows=%d, want bounded (<=4)", lifecycleRows)
 	}
 }
+
+// TestSearchProjectionCatchUp_CompleteGenerationInventoriesPostCutoverTail
+// pins #2173: a complete generation must still fingerprint sequence > high_water
+// on the next CatchUp so search fail-open does not decode the whole tail.
+func TestSearchProjectionCatchUp_CompleteGenerationInventoriesPostCutoverTail(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := infra.NewDatabase(dbPath, migrations)
+	store := infra.NewStoreManagementDatasource(database)
+	events := infra.NewEventDatasource(database)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("bootstrap Initialize() error = %v", err)
+	}
+
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	started := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	seedSession(t, dbPath, "sess-complete-tail", started, workspace.String())
+	if err := events.Save(ctx, newSearchEventWithSession(t, "evt-pre-cutover", "sess-complete-tail", workspace.String(), "pre-cutover unique marker alpha", started)); err != nil {
+		t.Fatalf("Save pre-cutover event: %v", err)
+	}
+
+	var status apptypes.SearchProjectionStatus
+	for i := 0; i < 40; i++ {
+		if err := store.Initialize(ctx); err != nil {
+			t.Fatalf("cutover Initialize #%d: %v", i+1, err)
+		}
+		status = projectionStatus(t, database)
+		if status.Completed {
+			break
+		}
+	}
+	if !status.Completed {
+		t.Fatalf("projection did not complete: %+v", status)
+	}
+	cutoverWater := status.HighWater
+
+	tailAt := started.Add(time.Minute)
+	if err := events.Save(ctx, newSearchEventWithSession(t, "evt-post-cutover", "sess-complete-tail", workspace.String(), "post-cutover unique marker beta", tailAt)); err != nil {
+		t.Fatalf("Save post-cutover event: %v", err)
+	}
+	var seqMax int64
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if err := db.QueryRow(`SELECT MAX(sequence) FROM search_projection_source_sequence`).Scan(&seqMax); err != nil {
+			t.Fatalf("max sequence: %v", err)
+		}
+	})
+	if seqMax <= cutoverWater {
+		t.Fatalf("post-cutover max sequence=%d, want > high_water %d", seqMax, cutoverWater)
+	}
+
+	uc := usecase.NewSearchProjectionUsecase(database)
+	result, err := uc.CatchUp(ctx, apptypes.DefaultSearchProjectionBudget(), tailAt)
+	if err != nil {
+		t.Fatalf("CatchUp complete tail: %v", err)
+	}
+	if result.Action != "complete_tail" {
+		t.Fatalf("CatchUp action = %q, want complete_tail", result.Action)
+	}
+	if result.Selected <= 0 {
+		t.Fatalf("CatchUp selected = %d, want tail rows", result.Selected)
+	}
+	if !result.Completed || result.State != "complete" {
+		t.Fatalf("CatchUp left state=%q completed=%v, want complete", result.State, result.Completed)
+	}
+
+	status = projectionStatus(t, database)
+	if status.HighWater != seqMax {
+		t.Fatalf("high_water=%d after tail catch-up, want %d", status.HighWater, seqMax)
+	}
+	var fpCount int
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if err := db.QueryRow(`SELECT COUNT(*) FROM literal_search_fingerprints WHERE event_id='evt-post-cutover'`).Scan(&fpCount); err != nil {
+			t.Fatalf("fingerprint count: %v", err)
+		}
+	})
+	if fpCount == 0 {
+		t.Fatal("post-cutover event has no fingerprints after complete-generation tail catch-up")
+	}
+
+	quiet, err := uc.CatchUp(ctx, apptypes.DefaultSearchProjectionBudget(), tailAt.Add(time.Second))
+	if err != nil {
+		t.Fatalf("CatchUp with empty tail: %v", err)
+	}
+	if quiet.Action != "already_complete" {
+		t.Fatalf("empty-tail CatchUp action = %q, want already_complete", quiet.Action)
+	}
+}

--- a/infrastructure/sqlite/search_projection_complete_tail.go
+++ b/infrastructure/sqlite/search_projection_complete_tail.go
@@ -1,0 +1,185 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// completeTailCatchUpMaxBatches caps one store-open drain of post-cutover
+// sequences. Default Rows=128 so 32 batches cover 4096 source rows — the same
+// bound DeepLiteralSearchBudget uses for a search walk. A busy host tail of
+// ~1.6k events then drains in one Initialize instead of 13 opens.
+const completeTailCatchUpMaxBatches = 32
+
+// CatchUpCompleteGenerationTail fingerprints source sequences above high_water
+// on a complete generation and advances high_water. It does not un-complete
+// the generation or start a rebuild (#2173).
+func (d *Database) CatchUpCompleteGenerationTail(ctx context.Context, b apptypes.SearchProjectionBudget, now time.Time) (apptypes.SearchProjectionCatchUpResult, error) {
+	out := apptypes.SearchProjectionCatchUpResult{State: "complete", Completed: true}
+	if b.Rows <= 0 {
+		return out, xerrors.Errorf("complete-generation tail catch-up row budget must be positive")
+	}
+	db, err := d.open(ctx)
+	if err != nil {
+		return out, xerrors.Errorf("open store for complete-generation tail catch-up: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var generationID string
+	var highWater int64
+	var state string
+	if err = db.QueryRowContext(ctx, `SELECT COALESCE(generation_id,''), high_water, state FROM search_projection_state WHERE singleton=1`).Scan(&generationID, &highWater, &state); err != nil {
+		return out, xerrors.Errorf("read complete-generation tail high_water: %w", err)
+	}
+	out.GenerationID = generationID
+	out.State = state
+	out.Checkpoint = highWater
+	if state != "complete" || generationID == "" {
+		return out, nil
+	}
+
+	for batch := 0; batch < completeTailCatchUpMaxBatches; batch++ {
+		if err = ctx.Err(); err != nil {
+			return out, xerrors.Errorf("complete-generation tail catch-up canceled: %w", err)
+		}
+		selected, written, nextWater, err := catchUpCompleteGenerationTailBatch(ctx, db, generationID, highWater, b.Rows, now)
+		if err != nil {
+			return out, err
+		}
+		if selected == 0 {
+			break
+		}
+		out.Batches++
+		out.Selected += selected
+		out.Written += written
+		out.Checkpoint = nextWater
+		highWater = nextWater
+		if selected < b.Rows {
+			break
+		}
+	}
+	return out, nil
+}
+
+func catchUpCompleteGenerationTailBatch(ctx context.Context, db *sql.DB, generationID string, highWater int64, limit int, now time.Time) (selected, written int, nextWater int64, err error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, 0, highWater, xerrors.Errorf("begin complete-generation tail catch-up: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `
+SELECT q.sequence, q.event_id, COALESCE(e.body_availability,''), e.id IS NULL
+  FROM search_projection_source_sequence q
+  LEFT JOIN events e ON e.id=q.event_id
+ WHERE q.sequence > ?
+ ORDER BY q.sequence
+ LIMIT ?`, highWater, limit)
+	if err != nil {
+		return 0, 0, highWater, xerrors.Errorf("select complete-generation tail: %w", err)
+	}
+
+	type tailRow struct {
+		sequence     int64
+		eventID      string
+		availability string
+		deleted      bool
+	}
+	batch := make([]tailRow, 0, limit)
+	for rows.Next() {
+		var row tailRow
+		if err = rows.Scan(&row.sequence, &row.eventID, &row.availability, &row.deleted); err != nil {
+			_ = rows.Close()
+			return 0, 0, highWater, xerrors.Errorf("scan complete-generation tail: %w", err)
+		}
+		batch = append(batch, row)
+	}
+	if err = rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, 0, highWater, xerrors.Errorf("iterate complete-generation tail: %w", err)
+	}
+	if err = rows.Close(); err != nil {
+		return 0, 0, highWater, xerrors.Errorf("close complete-generation tail: %w", err)
+	}
+	if len(batch) == 0 {
+		return 0, 0, highWater, nil
+	}
+
+	written = 0
+	for _, row := range batch {
+		if row.deleted {
+			continue
+		}
+		text, loadErr := completeTailEventText(ctx, tx, row.eventID, row.availability)
+		if loadErr != nil {
+			return 0, 0, highWater, loadErr
+		}
+		for _, fingerprint := range apptypes.CharacterizeLiteralQuery(text).Fingerprints() {
+			if _, err = tx.ExecContext(ctx, `INSERT OR IGNORE INTO literal_search_fingerprints(generation_id,source_sequence,event_id,fingerprint,fingerprint_version) VALUES(?,?,?,?,1)`, generationID, row.sequence, row.eventID, []byte(fingerprint)); err != nil {
+				return 0, 0, highWater, xerrors.Errorf("insert complete-generation tail fingerprint: %w", err)
+			}
+			written++
+		}
+	}
+
+	nextWater = batch[len(batch)-1].sequence
+	stamp := formatTimestamp(now.UTC())
+	result, err := tx.ExecContext(ctx, `UPDATE search_projection_state SET high_water=?, checkpoint=?, updated_at=? WHERE singleton=1 AND generation_id=? AND state='complete' AND high_water=?`, nextWater, nextWater, stamp, generationID, highWater)
+	if err != nil {
+		return 0, 0, highWater, xerrors.Errorf("advance complete-generation tail high_water: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, 0, highWater, xerrors.Errorf("count complete-generation tail high_water update: %w", err)
+	}
+	if n != 1 {
+		return 0, 0, highWater, xerrors.Errorf("complete-generation tail high_water did not advance")
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE search_projection_generation_lifecycle SET high_water=? WHERE generation_id=? AND state='complete'`, nextWater, generationID); err != nil {
+		return 0, 0, highWater, xerrors.Errorf("advance complete-generation lifecycle high_water: %w", err)
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE literal_search_projection_state SET high_water=?, updated_at=? WHERE singleton=1 AND generation_id=?`, nextWater, stamp, generationID); err != nil {
+		return 0, 0, highWater, xerrors.Errorf("advance complete-generation literal high_water: %w", err)
+	}
+	if err = tx.Commit(); err != nil {
+		return 0, 0, highWater, xerrors.Errorf("commit complete-generation tail catch-up: %w", err)
+	}
+	return len(batch), written, nextWater, nil
+}
+
+func completeTailEventText(ctx context.Context, tx *sql.Tx, eventID, availability string) (string, error) {
+	var body string
+	if availability == "available" {
+		plain, err := loadEventPlaintext(ctx, tx, eventID)
+		if err != nil {
+			return "", xerrors.Errorf("load complete-generation tail body: %w", err)
+		}
+		body, _ = visibleEventBody(string(plain), types.BodyAvailabilityAvailable)
+	}
+	cmd, err := hydrateAuditPayload(ctx, tx, eventID, "command")
+	if err != nil {
+		return "", xerrors.Errorf("load complete-generation tail command: %w", err)
+	}
+	in, err := hydrateAuditPayload(ctx, tx, eventID, "input")
+	if err != nil {
+		return "", xerrors.Errorf("load complete-generation tail input: %w", err)
+	}
+	output, err := hydrateAuditPayload(ctx, tx, eventID, "output")
+	if err != nil {
+		return "", xerrors.Errorf("load complete-generation tail output: %w", err)
+	}
+	parts := make([]string, 0, 4)
+	for _, v := range []string{body, cmd.String, in.String, output.String} {
+		if v != "" {
+			parts = append(parts, v)
+		}
+	}
+	return strings.Join(parts, "\n"), nil
+}


### PR DESCRIPTION
Closes #2173

Leaves parent #2126 open.

## Summary

A complete search-projection generation leaves `high_water` frozen. Isolated 16 GiB copy: 1623 `sequence > high_water` events with no fingerprints. Every filterable `search` fail-open-decodes that tail (~2.6 s no-match vs ≤2 s gate).

CatchUp on `state=complete` now fingerprints a bounded tail (default 128 rows × 32 batches) and advances `high_water` without un-completing or starting a rebuild. Empty tail stays `already_complete`.

Decode authority, fail-open for the remaining tail, and search JSON shape are unchanged.

## Tests

- Complete generation + one post-cutover Save: CatchUp action `complete_tail`, fingerprints exist, `high_water` equals `MAX(sequence)`.
- Second CatchUp with no tail: `already_complete`.

`go test ./...` and `go tool golangci-lint run` passed on this branch.