### PR TITLE
fix: skip fingerprint GROUP BY when a required trigram is absent

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **必須 trigram が無い filterable no-match は fingerprint の GROUP BY を省略する (#2176)** — 3-gram AND は posting が 1 つでも空なら一致しない。候補 SQL は cutover 後 tail だけ。decode が match 権威のまま。親 #2126 は open のまま。
 - **complete な search-projection が store open で cutover 後 tail を inventory する (#2173)** — いまは `sequence > high_water` を fail-open decode している。complete 世代の CatchUp が bounded な tail に fingerprint を書き `high_water` を進める（rebuild しない）。decode が match 権威のまま。親 #2126 は open のまま。
 - **フィルタ可能な session 検索が全 summary を LIKE 走査しない (#2170)** — 候補は `search_projection_session_keywords`（`idx_search_projection_session_keywords_by_kw`）。フィルタ/ソートは `sessions.started_at_norm`。短い unfilterable クエリは summary LIKE のまま。検索 JSON 形は不変。親 #2126 は open のまま。
 - **ストア Initialize が workspace-observation catch-up でイベント履歴を歩かない (#2169)** — 0 行バッチ後は `workspace_observation_catchup_state.exhausted` で以降の open を飛ばす。残バッチは `created_at_norm DESC`（`ts_norm(created_at)` ではない）。親 #2126 は open のまま。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Filterable no-match skips fingerprint GROUP BY when a required trigram is absent (#2176)** — AND of 3-gram fingerprints cannot match if any posting is empty; the candidate SQL keeps only the post-cutover tail. Decode remains the match authority. Leaves parent #2126 open.
 - **Complete search-projection inventories the post-cutover tail on store open (#2173)** — `sequence > high_water` is fail-open-decoded today; CatchUp on a complete generation fingerprints a bounded tail and advances `high_water` without a rebuild. Decode remains the match authority. Leaves parent #2126 open.
 - **Filterable session search no longer LIKE-scans every summary (#2170)** — candidates come from `search_projection_session_keywords` via `idx_search_projection_session_keywords_by_kw`. Filter/order use `sessions.started_at_norm`. Unfilterable short queries keep the summary LIKE walk. Search JSON shape is unchanged. Leaves parent #2126 open.
 - **Store Initialize no longer scans event history for workspace-observation catch-up (#2169)** — after a 0-row batch, `workspace_observation_catchup_state.exhausted` skips later opens. Remaining batches order by `created_at_norm DESC` (not `ts_norm(created_at)`). Leaves parent #2126 open.

--- a/infrastructure/sqlite/capacity_benchmark_queries.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries.go
@@ -20,7 +20,7 @@ type CapacityBenchmarkQuery struct {
 // prefilter, which is optional and store-state dependent).
 func CapacityBenchmarkQueries(ctx context.Context, db *sql.DB) ([]CapacityBenchmarkQuery, error) {
 	searchCriteria := apptypes.NewEventSearchCriteriaBuilder(20).Query("synthetic-needle").Build()
-	searchSQL, searchArgs := buildTieredSearchCandidateQuery(searchCriteria, "")
+	searchSQL, searchArgs := buildTieredSearchCandidateQuery(searchCriteria, "", false)
 	latestSQL := latestSessionBoundarySQL(ctx, db)
 	return []CapacityBenchmarkQuery{
 		{Name: "active", SQL: findActiveSessionQuery, Args: []any{"session_started", "", "", "", "", "", "", "session_started", "session_ended"}},

--- a/infrastructure/sqlite/event_search_authority.go
+++ b/infrastructure/sqlite/event_search_authority.go
@@ -4,6 +4,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -174,7 +175,15 @@ func (d *EventDatasource) searchTieredTopKMetadataTx(ctx context.Context, tx *sq
 		return nil, err
 	}
 	query := apptypes.CharacterizeLiteralQuery(criteria.Query())
-	candidateSQL, args := buildTieredSearchCandidateQuery(criteria, generation)
+	omitFingerprintArm := false
+	if generation != "" && query.Filterable() {
+		impossible, probeErr := literalFingerprintANDImpossible(ctx, tx, generation, query.Fingerprints())
+		if probeErr != nil {
+			return nil, probeErr
+		}
+		omitFingerprintArm = impossible
+	}
+	candidateSQL, args := buildTieredSearchCandidateQuery(criteria, generation, omitFingerprintArm)
 	rows, err := tx.QueryContext(ctx, candidateSQL, args...)
 	if err != nil {
 		return nil, xerrors.Errorf("query ordered tiered candidates: %w", err)
@@ -215,12 +224,39 @@ func (d *EventDatasource) searchTieredTopKMetadataTx(ctx context.Context, tx *sq
 	return hydrateEventSearchMetadataCandidates(ctx, tx, criteria, matched[start:])
 }
 
+// literalFingerprintANDImpossible reports that the fingerprint AND cannot match
+// any inventoried row: at least one required 3-gram has no posting in this
+// generation. Fail-open stays the post-cutover tail.
+func literalFingerprintANDImpossible(ctx context.Context, tx *sql.Tx, generation string, fingerprints []string) (bool, error) {
+	if len(fingerprints) == 0 {
+		return true, nil
+	}
+	// One LIMIT 1 seek per required trigram, stop at the first miss. A
+	// COUNT/GROUP BY over the IN-list pays the common trigrams (mat/atc/tch)
+	// even when an earlier required trigram has zero postings (#2176).
+	for _, fingerprint := range fingerprints {
+		var present int
+		err := tx.QueryRowContext(ctx, `
+SELECT 1
+  FROM literal_search_fingerprints
+ WHERE generation_id=? AND fingerprint_version=1 AND fingerprint=?
+ LIMIT 1`, generation, []byte(fingerprint)).Scan(&present)
+		if errors.Is(err, sql.ErrNoRows) {
+			return true, nil
+		}
+		if err != nil {
+			return false, xerrors.Errorf("probe literal fingerprint posting: %w", err)
+		}
+	}
+	return false, nil
+}
+
 // buildTieredSearchCandidateQuery composes the ordered candidate selection the
 // tiered search walk issues. The capacity benchmark measures the same SQL, so
 // it lives here rather than being transcribed there: a copy would drift the
 // moment either side changed, and a benchmark of SQL production no longer runs
 // measures nothing.
-func buildTieredSearchCandidateQuery(criteria apptypes.EventSearchCriteria, generation string) (string, []any) {
+func buildTieredSearchCandidateQuery(criteria apptypes.EventSearchCriteria, generation string, omitFingerprintArm bool) (string, []any) {
 	query := apptypes.CharacterizeLiteralQuery(criteria.Query())
 	var builder strings.Builder
 	const candidateSelect = `SELECT e.id,COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0)`
@@ -230,22 +266,34 @@ func buildTieredSearchCandidateQuery(criteria apptypes.EventSearchCriteria, gene
 	// without fingerprints are skipped: walking events or inventory to
 	// fail-open is O(history) even when those arms return empty. An empty
 	// generation or an unfilterable short query keeps the events walk.
+	// When a required trigram has no postings the AND cannot match; skip
+	// the IN/GROUP BY arm and keep only the tail (#2176).
 	if generation != "" && query.Filterable() {
-		fingerprints := query.Fingerprints()
 		builder.WriteString(candidateSelect)
-		builder.WriteString(` FROM (
+		if omitFingerprintArm {
+			builder.WriteString(` FROM (
+  SELECT q.event_id AS id
+    FROM search_projection_source_sequence q
+   WHERE q.sequence > (SELECT high_water FROM search_projection_state WHERE singleton=1)
+) candidates
+JOIN events e ON e.id=candidates.id
+LEFT JOIN command_audits a ON a.event_id=e.id
+WHERE 1=1`)
+		} else {
+			fingerprints := query.Fingerprints()
+			builder.WriteString(` FROM (
   SELECT fp.event_id AS id
     FROM literal_search_fingerprints fp INDEXED BY idx_literal_search_fingerprints_by_fp
    WHERE fp.generation_id=? AND fp.fingerprint_version=1 AND fp.fingerprint IN (`)
-		args = append(args, generation)
-		for i, fingerprint := range fingerprints {
-			if i > 0 {
-				builder.WriteByte(',')
+			args = append(args, generation)
+			for i, fingerprint := range fingerprints {
+				if i > 0 {
+					builder.WriteByte(',')
+				}
+				builder.WriteByte('?')
+				args = append(args, []byte(fingerprint))
 			}
-			builder.WriteByte('?')
-			args = append(args, []byte(fingerprint))
-		}
-		builder.WriteString(`)
+			builder.WriteString(`)
    GROUP BY fp.event_id
   HAVING COUNT(DISTINCT fp.fingerprint)=?
   UNION
@@ -256,7 +304,8 @@ func buildTieredSearchCandidateQuery(criteria apptypes.EventSearchCriteria, gene
 JOIN events e ON e.id=candidates.id
 LEFT JOIN command_audits a ON a.event_id=e.id
 WHERE 1=1`)
-		args = append(args, len(fingerprints))
+			args = append(args, len(fingerprints))
+		}
 	} else {
 		// The candidate set is events, not search_projection_source_sequence.
 		// That table is the projection's own checkpoint ledger: it is populated

--- a/infrastructure/sqlite/event_search_authority_internal_test.go
+++ b/infrastructure/sqlite/event_search_authority_internal_test.go
@@ -288,7 +288,7 @@ func TestTieredAuthorityFingerprintFirstPlanUsesByFpIndex(t *testing.T) {
 	seedTieredCompleteProjection(t, database, "generation")
 	seedLiteralFingerprints(t, database, "generation", "pre-match", "shared needle alpha")
 	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
-	query, args := buildTieredSearchCandidateQuery(criteria, "generation")
+	query, args := buildTieredSearchCandidateQuery(criteria, "generation", false)
 
 	raw, err := database.open(ctx)
 	if err != nil {
@@ -352,10 +352,80 @@ func TestTieredAuthorityNoMatchDoesNotWalkProjectedHistory(t *testing.T) {
 	}
 }
 
+func TestTieredAuthorityAbsentTrigramOmitsFingerprintGroupBy(t *testing.T) {
+	t.Parallel()
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("xyzzy-nomatch-2127").Build()
+	query, _ := buildTieredSearchCandidateQuery(criteria, "generation", true)
+	if strings.Contains(query, "GROUP BY fp.event_id") || strings.Contains(query, "HAVING COUNT(DISTINCT") {
+		t.Fatalf("absent-trigram SQL still groups fingerprints:\n%s", query)
+	}
+	if strings.Contains(query, "literal_search_fingerprints") {
+		t.Fatalf("absent-trigram SQL still reads fingerprints:\n%s", query)
+	}
+	if !strings.Contains(query, "q.sequence >") {
+		t.Fatalf("absent-trigram SQL dropped the fail-open tail:\n%s", query)
+	}
+}
+
+func TestLiteralFingerprintANDImpossibleDetectsAbsentTrigram(t *testing.T) {
+	ctx := context.Background()
+	database, _ := newTieredAuthorityFixture(t)
+	insertTieredSearchEvent(t, database, "pre-noise", "zzzz other text", time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	seedTieredCompleteProjection(t, database, "gen-absent")
+	seedLiteralFingerprints(t, database, "gen-absent", "pre-noise", "zzzz other text")
+
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	tx, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	query := apptypes.CharacterizeLiteralQuery("xyzzy-nomatch-2127")
+	impossible, probeErr := literalFingerprintANDImpossible(ctx, tx, "gen-absent", query.Fingerprints())
+	if probeErr != nil {
+		t.Fatalf("literalFingerprintANDImpossible() error = %v", probeErr)
+	}
+	if !impossible {
+		t.Fatal("expected absent required trigram to make fingerprint AND impossible")
+	}
+
+	presentQuery := apptypes.CharacterizeLiteralQuery("zzzz")
+	impossible, probeErr = literalFingerprintANDImpossible(ctx, tx, "gen-absent", presentQuery.Fingerprints())
+	if probeErr != nil {
+		t.Fatalf("literalFingerprintANDImpossible() present error = %v", probeErr)
+	}
+	if impossible {
+		t.Fatal("expected present trigrams to keep the fingerprint AND possible")
+	}
+}
+
+func TestTieredAuthorityAbsentTrigramStillFailOpensTail(t *testing.T) {
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "pre-noise", "zzzz other text", base)
+	seedTieredCompleteProjection(t, database, "gen-absent")
+	seedLiteralFingerprints(t, database, "gen-absent", "pre-noise", "zzzz other text")
+	insertTieredSearchEvent(t, database, "post-xyzzy", "contains xyzzy-nomatch-2127 in the body", base.Add(time.Second))
+
+	got, err := datasource.SearchMetadata(ctx, apptypes.NewEventSearchCriteriaBuilder(10).Query("xyzzy-nomatch-2127").Build())
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"post-xyzzy"}, metadataIDs(got)); diff != "" {
+		t.Fatalf("absent-trigram tail IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestTieredAuthorityUnfilterableKeepsEventsWalk(t *testing.T) {
 	t.Parallel()
 	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("ab").Build()
-	query, _ := buildTieredSearchCandidateQuery(criteria, "generation")
+	query, _ := buildTieredSearchCandidateQuery(criteria, "generation", false)
 	if strings.Contains(query, "literal_search_fingerprints") {
 		t.Fatalf("unfilterable query still uses fingerprints:\n%s", query)
 	}
@@ -367,7 +437,7 @@ func TestTieredAuthorityUnfilterableKeepsEventsWalk(t *testing.T) {
 func TestTieredAuthorityEmptyGenerationKeepsEventsWalk(t *testing.T) {
 	t.Parallel()
 	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
-	query, _ := buildTieredSearchCandidateQuery(criteria, "")
+	query, _ := buildTieredSearchCandidateQuery(criteria, "", false)
 	if strings.Contains(query, "literal_search_fingerprints") {
 		t.Fatalf("empty generation still uses fingerprints:\n%s", query)
 	}

--- a/infrastructure/sqlite/events_legacy_index_drop_internal_test.go
+++ b/infrastructure/sqlite/events_legacy_index_drop_internal_test.go
@@ -30,6 +30,7 @@ func TestShippedEventPlansDoNotUseDroppedCreatedAtIndexes(t *testing.T) {
 	searchSQL, searchArgs := buildTieredSearchCandidateQuery(
 		apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build(),
 		"generation",
+		false,
 	)
 	plans := []struct {
 		name  string


### PR DESCRIPTION
Closes #2176

Leaves parent #2126 open.

## Summary

After #2167 / #2173, filterable no-match still paid `fingerprint IN (…)` + `GROUP BY event_id HAVING COUNT(DISTINCT fingerprint)=N` on common 3-grams (`mat`/`atc`/`tch`) even when a required trigram (`xyz` / `yzz` / …) had zero postings.

Before building that arm, probe each required fingerprint with `LIMIT 1`. If any posting is absent, omit the fingerprint arm and keep only `sequence > high_water`. Decode remains the match authority. Search JSON shape is unchanged.

## Tests

- `buildTieredSearchCandidateQuery(..., omit=true)` does not emit `GROUP BY` / `HAVING COUNT(DISTINCT` / `literal_search_fingerprints`.
- Probe returns impossible for `xyzzy-nomatch-2127` against a generation that only has `zzzz other text` fingerprints, and possible for `zzzz`.
- Post-cutover event containing `xyzzy-nomatch-2127` still matches (fail-open tail).

`go test ./...` and `go tool golangci-lint run` passed on this branch.