### PR TITLE
fix: do not walk workspace events for an empty post-cutover tail

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **必須 trigram が無く cutover 後 tail も空の filterable no-match が workspace イベントを歩かない (#2178)** — 候補は `sequence > high_water` だけ。空 tail は即 empty。非空 tail は sequence PK を MATERIALIZED してから events に JOIN。decode が match 権威のまま。親 #2126 は open のまま。
 - **必須 trigram が無い filterable no-match は fingerprint の GROUP BY を省略する (#2176)** — 3-gram AND は posting が 1 つでも空なら一致しない。候補 SQL は cutover 後 tail だけ。decode が match 権威のまま。親 #2126 は open のまま。
 - **complete な search-projection が store open で cutover 後 tail を inventory する (#2173)** — いまは `sequence > high_water` を fail-open decode している。complete 世代の CatchUp が bounded な tail に fingerprint を書き `high_water` を進める（rebuild しない）。decode が match 権威のまま。親 #2126 は open のまま。
 - **フィルタ可能な session 検索が全 summary を LIKE 走査しない (#2170)** — 候補は `search_projection_session_keywords`（`idx_search_projection_session_keywords_by_kw`）。フィルタ/ソートは `sessions.started_at_norm`。短い unfilterable クエリは summary LIKE のまま。検索 JSON 形は不変。親 #2126 は open のまま。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **Filterable no-match with an empty post-cutover tail no longer walks workspace events (#2178)** — when a required trigram is absent, candidates are only `sequence > high_water`. An empty tail returns immediately; a non-empty tail is materialized from the sequence PK before joining events. Decode remains the match authority. Leaves parent #2126 open.
 - **Filterable no-match skips fingerprint GROUP BY when a required trigram is absent (#2176)** — AND of 3-gram fingerprints cannot match if any posting is empty; the candidate SQL keeps only the post-cutover tail. Decode remains the match authority. Leaves parent #2126 open.
 - **Complete search-projection inventories the post-cutover tail on store open (#2173)** — `sequence > high_water` is fail-open-decoded today; CatchUp on a complete generation fingerprints a bounded tail and advances `high_water` without a rebuild. Decode remains the match authority. Leaves parent #2126 open.
 - **Filterable session search no longer LIKE-scans every summary (#2170)** — candidates come from `search_projection_session_keywords` via `idx_search_projection_session_keywords_by_kw`. Filter/order use `sessions.started_at_norm`. Unfilterable short queries keep the summary LIKE walk. Search JSON shape is unchanged. Leaves parent #2126 open.

--- a/infrastructure/sqlite/event_search_authority.go
+++ b/infrastructure/sqlite/event_search_authority.go
@@ -182,6 +182,18 @@ func (d *EventDatasource) searchTieredTopKMetadataTx(ctx context.Context, tx *sq
 			return nil, probeErr
 		}
 		omitFingerprintArm = impossible
+		if omitFingerprintArm {
+			tailExists, tailErr := literalPostCutoverTailExists(ctx, tx)
+			if tailErr != nil {
+				return nil, tailErr
+			}
+			if !tailExists {
+				// Inventoried rows cannot match, and there is no fail-open
+				// tail. Do not run the events-workspace nested loop SQLite
+				// chooses for `sequence > high_water` joined to events (#2178).
+				return nil, nil
+			}
+		}
 	}
 	candidateSQL, args := buildTieredSearchCandidateQuery(criteria, generation, omitFingerprintArm)
 	rows, err := tx.QueryContext(ctx, candidateSQL, args...)
@@ -251,6 +263,26 @@ SELECT 1
 	return false, nil
 }
 
+// literalPostCutoverTailExists reports whether any inventoried sequence is
+// newer than the frozen high_water. The seek is the INTEGER PRIMARY KEY range
+// `sequence > high_water`; an empty tail must not be discovered by walking
+// events.
+func literalPostCutoverTailExists(ctx context.Context, tx *sql.Tx) (bool, error) {
+	var present int
+	err := tx.QueryRowContext(ctx, `
+SELECT 1
+  FROM search_projection_source_sequence
+ WHERE sequence > (SELECT high_water FROM search_projection_state WHERE singleton=1)
+ LIMIT 1`).Scan(&present)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, xerrors.Errorf("probe post-cutover search tail: %w", err)
+	}
+	return true, nil
+}
+
 // buildTieredSearchCandidateQuery composes the ordered candidate selection the
 // tiered search walk issues. The capacity benchmark measures the same SQL, so
 // it lives here rather than being transcribed there: a copy would drift the
@@ -271,10 +303,18 @@ func buildTieredSearchCandidateQuery(criteria apptypes.EventSearchCriteria, gene
 	if generation != "" && query.Filterable() {
 		builder.WriteString(candidateSelect)
 		if omitFingerprintArm {
+			// MATERIALIZED forces the PK range `sequence > high_water` to
+			// run first. Without it SQLite drives from the workspace
+			// created_at_norm index and probes the sequence unique index
+			// once per workspace event, which is O(history) when the tail
+			// is empty (#2178).
 			builder.WriteString(` FROM (
-  SELECT q.event_id AS id
-    FROM search_projection_source_sequence q
-   WHERE q.sequence > (SELECT high_water FROM search_projection_state WHERE singleton=1)
+  WITH tail AS MATERIALIZED (
+    SELECT q.event_id AS id
+      FROM search_projection_source_sequence q
+     WHERE q.sequence > (SELECT high_water FROM search_projection_state WHERE singleton=1)
+  )
+  SELECT id FROM tail
 ) candidates
 JOIN events e ON e.id=candidates.id
 LEFT JOIN command_audits a ON a.event_id=e.id

--- a/infrastructure/sqlite/event_search_authority_internal_test.go
+++ b/infrastructure/sqlite/event_search_authority_internal_test.go
@@ -365,6 +365,120 @@ func TestTieredAuthorityAbsentTrigramOmitsFingerprintGroupBy(t *testing.T) {
 	if !strings.Contains(query, "q.sequence >") {
 		t.Fatalf("absent-trigram SQL dropped the fail-open tail:\n%s", query)
 	}
+	if !strings.Contains(query, "AS MATERIALIZED") {
+		t.Fatalf("absent-trigram SQL does not materialize the tail first:\n%s", query)
+	}
+}
+
+func TestLiteralPostCutoverTailExists(t *testing.T) {
+	ctx := context.Background()
+	database, _ := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "pre-noise", "zzzz other text", base)
+	seedTieredCompleteProjection(t, database, "gen-tail-probe")
+
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	tx, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	exists, probeErr := literalPostCutoverTailExists(ctx, tx)
+	if probeErr != nil {
+		t.Fatalf("literalPostCutoverTailExists() error = %v", probeErr)
+	}
+	if exists {
+		t.Fatal("expected empty tail after complete generation freeze")
+	}
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	insertTieredSearchEvent(t, database, "post-row", "later", base.Add(time.Second))
+	tx, err = raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	exists, probeErr = literalPostCutoverTailExists(ctx, tx)
+	if probeErr != nil {
+		t.Fatalf("literalPostCutoverTailExists() post error = %v", probeErr)
+	}
+	if !exists {
+		t.Fatal("expected post-cutover sequence to count as a tail")
+	}
+}
+
+func TestTieredAuthorityAbsentTrigramEmptyTailReturnsNoCandidates(t *testing.T) {
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	insertTieredSearchEvent(t, database, "pre-noise", "zzzz other text", time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	seedTieredCompleteProjection(t, database, "gen-empty-tail")
+	seedLiteralFingerprints(t, database, "gen-empty-tail", "pre-noise", "zzzz other text")
+
+	got, err := datasource.SearchMetadata(ctx, apptypes.NewEventSearchCriteriaBuilder(10).Query("xyzzy-nomatch-2127").Build())
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("empty-tail IDs = %v, want empty", metadataIDs(got))
+	}
+}
+
+func TestTieredAuthorityOmittedTailPlanDoesNotDriveFromWorkspaceEvents(t *testing.T) {
+	ctx := context.Background()
+	database, _ := newTieredAuthorityFixture(t)
+	insertTieredSearchEvent(t, database, "pre-noise", "zzzz other text", time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	seedTieredCompleteProjection(t, database, "generation")
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).
+		Query("xyzzy-nomatch-2127").
+		Workspace(mustWorkspace(t, "w")).
+		Build()
+	query, args := buildTieredSearchCandidateQuery(criteria, "generation", true)
+
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	rows, err := raw.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var details []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err = rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		details = append(details, strings.ToLower(detail))
+	}
+	if err = rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	plan := strings.Join(details, "\n")
+	if !strings.Contains(plan, "search_projection_source_sequence") && !strings.Contains(plan, "tail") {
+		t.Fatalf("omit-tail plan does not mention the sequence tail:\n%s", plan)
+	}
+	if len(details) > 0 && strings.Contains(details[0], "idx_events_workspace_created_at_norm_id_desc") {
+		t.Fatalf("omit-tail plan still drives from the workspace events index:\n%s", plan)
+	}
+}
+
+func mustWorkspace(t *testing.T, raw string) domtypes.Workspace {
+	t.Helper()
+	workspace, err := domtypes.WorkspaceFrom(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return workspace
 }
 
 func TestLiteralFingerprintANDImpossibleDetectsAbsentTrigram(t *testing.T) {


### PR DESCRIPTION
Closes #2178

Leaves parent #2126 open.

## Summary

After #2176, filterable no-match omits fingerprint `GROUP BY` and keeps only `sequence > high_water`. On the isolated 16 GiB copy that tail is empty, but SQLite still drove the join from `idx_events_workspace_created_at_norm_id_desc` and probed the sequence unique index once per workspace event (~3 s on the debug-built CLI vs ≤2 s).

When the fingerprint AND is impossible and the tail `LIMIT 1` seek is empty, SearchMetadata returns immediately. A non-empty tail is `WITH tail AS MATERIALIZED` from the sequence PK before joining events.

Decode authority and search JSON shape are unchanged.

## Tests

- Empty tail after a complete generation: `literalPostCutoverTailExists` is false; a later insert is true.
- Absent trigram + empty tail: `SearchMetadata` returns no IDs.
- Omit SQL contains `AS MATERIALIZED` and EXPLAIN does not drive from the workspace events index.
- Existing fail-open tail test still returns the post-cutover match.

`go test ./...` and `go tool golangci-lint run` passed on this branch.

Isolated-copy debug CLI `search xyzzy-nomatch-2127 --json --limit 5`: 1.42 s / 0.94 s.