### PR TITLE
fix: apply hook soft deadline only to the hook subcommand

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 ## [Unreleased]
 
 ### Fixed
+- **`--client hook` が 8s の hook soft deadline を継承しない (#2174)** — hook 呼び出しは `hook` サブコマンドだけ。`report --client hook` は通常 CLI コンテキスト（signal のみ）。親 #2126 は open のまま。
 - **必須 trigram が無く cutover 後 tail も空の filterable no-match が workspace イベントを歩かない (#2178)** — 候補は `sequence > high_water` だけ。空 tail は即 empty。非空 tail は sequence PK を MATERIALIZED してから events に JOIN。decode が match 権威のまま。親 #2126 は open のまま。
 - **必須 trigram が無い filterable no-match は fingerprint の GROUP BY を省略する (#2176)** — 3-gram AND は posting が 1 つでも空なら一致しない。候補 SQL は cutover 後 tail だけ。decode が match 権威のまま。親 #2126 は open のまま。
 - **complete な search-projection が store open で cutover 後 tail を inventory する (#2173)** — いまは `sequence > high_water` を fail-open decode している。complete 世代の CatchUp が bounded な tail に fingerprint を書き `high_water` を進める（rebuild しない）。decode が match 権威のまま。親 #2126 は open のまま。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 ## [Unreleased]
 
 ### Fixed
+- **`--client hook` no longer inherits the 8s hook soft deadline (#2174)** — only the `hook` subcommand is a hook invocation. `report --client hook` uses the ordinary CLI context (signals only). Leaves parent #2126 open.
 - **Filterable no-match with an empty post-cutover tail no longer walks workspace events (#2178)** — when a required trigram is absent, candidates are only `sequence > high_water`. An empty tail returns immediately; a non-empty tail is materialized from the sequence PK before joining events. Decode remains the match authority. Leaves parent #2126 open.
 - **Filterable no-match skips fingerprint GROUP BY when a required trigram is absent (#2176)** — AND of 3-gram fingerprints cannot match if any posting is empty; the candidate SQL keeps only the post-cutover tail. Decode remains the match authority. Leaves parent #2126 open.
 - **Complete search-projection inventories the post-cutover tail on store open (#2173)** — `sequence > high_water` is fail-open-decoded today; CatchUp on a complete generation fingerprints a bounded tail and advances `high_water` without a rebuild. Decode remains the match authority. Leaves parent #2126 open.

--- a/main.go
+++ b/main.go
@@ -385,12 +385,8 @@ func resolveHookSoftDeadline() time.Duration {
 }
 
 func isHookCommandArgs(args []string) bool {
-	for _, arg := range args[1:] {
-		if arg == "hook" {
-			return true
-		}
-	}
-	return false
+	argv := commandArgvWithoutFlags(args)
+	return len(argv) > 0 && argv[0] == "hook"
 }
 
 // isDetachedHookWorkerArgs reports hidden workers that run outside host

--- a/main_test.go
+++ b/main_test.go
@@ -22,8 +22,11 @@ func TestIsHookCommandArgs(t *testing.T) {
 		want bool
 	}{
 		{name: "direct hook command", args: []string{"traceary", "hook", "prompt", "claude"}, want: true},
+		{name: "session-start hook command", args: []string{"traceary", "hook", "session-start"}, want: true},
 		{name: "global flag before hook", args: []string{"traceary", "--config", "config.json", "hook", "prompt", "claude"}, want: true},
 		{name: "ordinary command", args: []string{"traceary", "doctor", "--client", "claude"}, want: false},
+		{name: "report client filter named hook", args: []string{"traceary", "report", "--client", "hook"}, want: false},
+		{name: "report json client filter named hook", args: []string{"traceary", "report", "--json", "--client", "hook", "--from", "2026-08-01"}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,6 +107,15 @@ func TestCommandContext_NonHookHasNoSoftDeadline(t *testing.T) {
 	defer cancel()
 	if _, ok := ctx.Deadline(); ok {
 		t.Fatal("non-hook command must not inherit the hook soft deadline")
+	}
+}
+
+func TestCommandContext_ReportClientHookHasNoSoftDeadline(t *testing.T) {
+	t.Setenv(hookSoftDeadlineEnvKey, "50ms")
+	ctx, cancel := commandContext([]string{"traceary", "report", "--json", "--client", "hook"})
+	defer cancel()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("report --client hook must not inherit the hook soft deadline")
 	}
 }
 


### PR DESCRIPTION
Closes #2174

Leaves parent #2126 open.

## Summary

`isHookCommandArgs` matched any argv token `hook`, so `traceary report --json --client hook` inherited the 8s hook soft deadline. Isolated-copy 7d / unbounded × `--client hook` failed at 8.05s; the same windows without `--client hook` succeeded.

Hook invocation is now the flag-stripped positional subcommand (`commandArgvWithoutFlags`, same as TUI detection). `--client hook` uses the ordinary CLI context (signals only).

## Tests

- `isHookCommandArgs(["traceary","report","--client","hook"])` is false
- `isHookCommandArgs(["traceary","hook","session-start"])` is true
- `commandContext` for `report --json --client hook` has no deadline
- existing hook / global-flag-before-hook / detached-worker cases stay

`go test ./...` and `go tool golangci-lint run` passed on this branch.