### PR TITLE
store compact completes the search projection before returning

### DIFF
--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -26,9 +26,11 @@ type wallBudgetStore struct {
 	measuredReads      int
 	state              string
 	resumeReady        bool
+	starts             int
 }
 
 func (s *wallBudgetStore) Start(context.Context, apptypes.SearchProjectionBudget, time.Time) (apptypes.SearchProjectionGeneration, error) {
+	s.starts++
 	return apptypes.SearchProjectionGeneration{}, nil
 }
 
@@ -74,6 +76,22 @@ func (s *wallBudgetStore) CleanupBatch(context.Context, apptypes.ProjectionBatch
 }
 func (*wallBudgetStore) MarkFailed(context.Context, string, int64, string, time.Time) error {
 	return nil
+}
+
+func TestCompleteGenerationLeavesMatchingCompleteGeneration(t *testing.T) {
+	t.Parallel()
+	b := apptypes.DefaultSearchProjectionBudget()
+	store := &wallBudgetStore{budget: b, state: "complete"}
+	u := usecase.NewSearchProjectionUsecase(store)
+	if err := u.CompleteGeneration(context.Background(), b, time.Now()); err != nil {
+		t.Fatalf("CompleteGeneration() error = %v", err)
+	}
+	if store.starts != 0 {
+		t.Fatalf("Start called %d times, want 0 for a matching complete generation", store.starts)
+	}
+	if store.applied {
+		t.Fatal("Resume applied a batch on a matching complete generation")
+	}
 }
 
 func TestProjectionBatchPlanEnforcesStrictLogicalMutationByteCap(t *testing.T) {

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -703,3 +703,72 @@ func (u *SearchProjectionUsecase) ControlStatus(ctx context.Context) (apptypes.S
 	}
 	return status, nil
 }
+
+// CompleteGeneration starts or resumes a generation and drives it to
+// `complete` under the caller's context. Compact holds the exclusive store
+// lease across this call so live writers cannot interleave `source changed`
+// (#2163). It does not start a replacement generation when one is already
+// complete with a matching budget hash.
+func (u *SearchProjectionUsecase) CompleteGeneration(ctx context.Context, b apptypes.SearchProjectionBudget, now time.Time) error {
+	if !b.Valid() {
+		return &apptypes.SearchProjectionNoProgressError{Reason: "invalid generation budget"}
+	}
+	now = now.UTC()
+	status, err := u.ControlStatus(ctx)
+	if err != nil {
+		return err
+	}
+	if status.State == "complete" && status.ConfigHash == b.ConfigHash() {
+		if tail, ok := u.store.(SearchProjectionCompleteTailStore); ok {
+			if _, tailErr := tail.CatchUpCompleteGenerationTail(ctx, b, now); tailErr != nil {
+				return xerrors.Errorf("catch up complete generation tail: %w", tailErr)
+			}
+		}
+		status, err = u.ControlStatus(ctx)
+		if err != nil {
+			return err
+		}
+		if status.State == "complete" {
+			return nil
+		}
+	}
+	if status.GenerationID != "" && status.State != "complete" && status.State != "abandoned" {
+		if _, abandonErr := u.Abandon(ctx, now); abandonErr != nil {
+			var noProgress *apptypes.SearchProjectionNoProgressError
+			if !errors.As(abandonErr, &noProgress) || noProgress.Reason != "no derived generation exists" {
+				return abandonErr
+			}
+		}
+	}
+	if _, startErr := u.StartGeneration(ctx, b, now); startErr != nil {
+		return startErr
+	}
+	return u.resumeUntilComplete(ctx, b, now)
+}
+
+func (u *SearchProjectionUsecase) resumeUntilComplete(ctx context.Context, b apptypes.SearchProjectionBudget, now time.Time) error {
+	idle := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return xerrors.Errorf("complete search projection: %w", err)
+		}
+		result, err := u.ResumeUntil(ctx, b, apptypes.SearchProjectionRunOptions{
+			MaxBatches:    1024,
+			TotalWallTime: time.Hour,
+		}, now)
+		if err != nil {
+			return err
+		}
+		if result.StopReason == "complete" || result.Progress.Completed {
+			return nil
+		}
+		if result.Progress.Selected == 0 && result.Progress.Written == 0 && result.Progress.Cleaned == 0 && result.Progress.Evicted == 0 {
+			idle++
+			if idle >= 3 {
+				return xerrors.Errorf("search projection did not reach complete (stop_reason=%s)", result.StopReason)
+			}
+			continue
+		}
+		idle = 0
+	}
+}

--- a/application/usecase/store_compaction.go
+++ b/application/usecase/store_compaction.go
@@ -17,14 +17,15 @@ import (
 )
 
 type storeCompactionUsecase struct {
-	journal       application.StoreCompactionJournal
-	builder       application.StoreCompactionBuilder
-	files         application.StoreCompactionFiles
-	lease         application.StoreCompactionLease
-	progress      application.CompactionProgress
-	now           func() time.Time
-	expectedStore string
-	cover         func(ctx context.Context, work string, cutoff time.Time) error
+	journal            application.StoreCompactionJournal
+	builder            application.StoreCompactionBuilder
+	files              application.StoreCompactionFiles
+	lease              application.StoreCompactionLease
+	progress           application.CompactionProgress
+	now                func() time.Time
+	expectedStore      string
+	cover              func(ctx context.Context, work string, cutoff time.Time) error
+	completeProjection func(ctx context.Context, store string) error
 }
 
 type compactFilterSetter interface {
@@ -43,6 +44,15 @@ func BindCompactionWorkCover(u application.StoreCompactionUsecase, cover func(ct
 func BindCompactionProgress(u application.StoreCompactionUsecase, progress application.CompactionProgress) {
 	if concrete, ok := u.(*storeCompactionUsecase); ok {
 		concrete.progress = progress
+	}
+}
+
+// BindCompactionProjectionComplete runs after a successful rewrite while the
+// exclusive lease is still held, so default compact cannot return with an
+// in-flight search generation (#2163).
+func BindCompactionProjectionComplete(u application.StoreCompactionUsecase, complete func(ctx context.Context, store string) error) {
+	if concrete, ok := u.(*storeCompactionUsecase); ok {
+		concrete.completeProjection = complete
 	}
 }
 
@@ -133,6 +143,9 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 				if in.Force {
 					remaining, remainingBytes = 0, 0
 				}
+				if err := u.finishSearchProjection(ctx); err != nil {
+					return application.CompactResult{}, err
+				}
 				return application.CompactResult{
 					BytesBefore:               before.Size(),
 					BytesAfter:                after.Size(),
@@ -157,6 +170,9 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 	if in.Force {
 		remaining, remainingBytes = 0, 0
 	}
+	if err := u.finishSearchProjection(ctx); err != nil {
+		return application.CompactResult{}, err
+	}
 	return application.CompactResult{
 		Run:                       run,
 		BytesBefore:               before.Size(),
@@ -169,6 +185,17 @@ func (u *storeCompactionUsecase) Compact(ctx context.Context, in application.Com
 		EstimatedReclaimableBytes: estimated,
 		CompactStrategy:           strategy,
 	}, nil
+}
+
+func (u *storeCompactionUsecase) finishSearchProjection(ctx context.Context) error {
+	if u.completeProjection == nil {
+		return nil
+	}
+	u.reportWindow("search_projection")
+	if err := u.completeProjection(ctx, u.expectedStore); err != nil {
+		return fmt.Errorf("complete search projection after compact: %w", err)
+	}
+	return nil
 }
 
 type reclaimableBytesInspector interface {

--- a/infrastructure/filesystem/file_retention_datasource_unix_test.go
+++ b/infrastructure/filesystem/file_retention_datasource_unix_test.go
@@ -35,21 +35,15 @@ func TestFileRetentionLiveGenerationHonorsContextWhileExclusiveLeaseHeld(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer release()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	started := time.Now()
-	_, liveErr := fileRetentionLiveGeneration(ctx, "backup", path)
-	if liveErr == nil || !strings.Contains(liveErr.Error(), "self-deadlock") {
-		release()
-		t.Fatalf("live generation error=%v, want same-process self-deadlock", liveErr)
+	if _, liveErr := fileRetentionLiveGeneration(ctx, "backup", path); liveErr != nil {
+		t.Fatalf("live generation while this process holds exclusive: %v", liveErr)
 	}
 	if time.Since(started) > time.Second {
-		release()
-		t.Fatal("live generation did not fail promptly")
-	}
-	release()
-	if _, err := fileRetentionLiveGeneration(context.Background(), "backup", path); err != nil {
-		t.Fatalf("live generation after lease release: %v", err)
+		t.Fatal("live generation hung while exclusive lease was held")
 	}
 }
 

--- a/infrastructure/sqlite/compact_search_projection_test.go
+++ b/infrastructure/sqlite/compact_search_projection_test.go
@@ -1,0 +1,107 @@
+package sqlite_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain"
+	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestDefaultCompactCompletesSearchProjectionSoSearchDoesNotHitBudget(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "traceary.db")
+	migrations := onDiskSQLiteMigrations(t)
+	database := infra.NewDatabase(dbPath, migrations)
+	if err := infra.NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	const matchToken = "uniquetokenxyz"
+	seedHistoricalSearchEvents(t, dbPath, 4200, func(index int) string {
+		if index == 100 {
+			return matchToken + " unique token body"
+		}
+		return "fillerword fillerword fillerword"
+	})
+
+	svc := usecase.NewStoreCompactionUsecase(
+		dbPath,
+		&infra.CompactionFileJournal{Dir: filepath.Join(dir, ".traceary-compaction")},
+		&infra.SQLiteCompactionBuilder{},
+		infra.StoreReplacementFiles{CallerHoldsExclusiveLease: true},
+		infra.StoreLeaseCoordinator{},
+	)
+	usecase.BindCompactionProjectionComplete(svc, func(ctx context.Context, store string) error {
+		return usecase.NewSearchProjectionUsecase(infra.NewDatabase(store, migrations)).CompleteGeneration(
+			ctx, apptypes.DefaultSearchProjectionBudget(), time.Now(),
+		)
+	})
+	result, err := svc.Compact(ctx, application.CompactInput{Source: dbPath, Now: time.Now()})
+	if err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+	if result.Run.Phase != domain.CompactionCommitted {
+		t.Fatalf("phase=%s, want committed", result.Run.Phase)
+	}
+	if result.CompactStrategy == "" {
+		t.Fatal("compact_strategy is empty")
+	}
+
+	after := infra.NewDatabase(dbPath, migrations)
+	status, err := usecase.NewSearchProjectionUsecase(after).ControlStatus(ctx)
+	if err != nil {
+		t.Fatalf("ControlStatus() error = %v", err)
+	}
+	if status.State != "complete" {
+		t.Fatalf("search-projection state=%s phase=%s, want complete", status.State, status.Phase)
+	}
+
+	events, err := infra.NewEventDatasource(after).Search(
+		ctx,
+		matchToken,
+		types.Workspace("github.com/duck8823/traceary"),
+		"",
+		"",
+		"",
+		"",
+		time.Time{},
+		time.Time{},
+		5,
+		0,
+		false,
+	)
+	if err != nil {
+		var unavailable *queryservice.EventSearchUnavailableError
+		if errors.As(err, &unavailable) {
+			t.Fatalf("Search() hit index-incomplete budget after default compact: %v", err)
+		}
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("Search() returned no events for the seeded token")
+	}
+
+	sessionPage, err := infra.NewEventDatasource(after).SearchSessionPage(
+		ctx,
+		apptypes.NewEventSearchCriteriaBuilder(5).
+			Query(matchToken).
+			Workspace(types.Workspace("github.com/duck8823/traceary")).
+			Build(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("SearchSessionPage() error = %v", err)
+	}
+	if sessionPage.State() == "" {
+		t.Fatal("SearchSessionPage() session-tier state is empty on a complete generation")
+	}
+}

--- a/infrastructure/sqlite/store_lease.go
+++ b/infrastructure/sqlite/store_lease.go
@@ -70,6 +70,12 @@ func selfDeadlockError(lockPath string) error {
 	return fmt.Errorf("%w on %s: this process already holds the exclusive lease", errStoreLeaseSelfDeadlock, lockPath)
 }
 
+// heldExclusiveLease is attached to connections opened while this process
+// already holds LOCK_EX. Close must not unlock that exclusive fd.
+type heldExclusiveLease struct{}
+
+func (heldExclusiveLease) Close() error { return nil }
+
 func canonicalStorePath(path string) (string, error) {
 	absolute, err := filepath.Abs(path)
 	if err != nil {
@@ -173,7 +179,11 @@ func (c *storeLeaseConnector) Connect(ctx context.Context) (driver.Conn, error) 
 		return nil, err
 	}
 	if processHoldsExclusiveLease(c.lockPath) {
-		return nil, selfDeadlockError(c.lockPath)
+		// flock is per open file description. A second LOCK_SH on another
+		// fd can never succeed while this process holds LOCK_EX (#2149).
+		// Compact still needs SQLite connections for projection complete
+		// (#2163). The exclusive fd already excludes cooperating processes.
+		return c.openHeldExclusive(ctx)
 	}
 	ctx, cancel := bindSharedLeaseDeadline(ctx)
 	defer cancel()
@@ -192,6 +202,21 @@ func (c *storeLeaseConnector) Connect(ctx context.Context) (driver.Conn, error) 
 		return nil, err
 	}
 	return &storeLeaseConn{Conn: conn, lease: lease}, nil
+}
+
+func (c *storeLeaseConnector) openHeldExclusive(ctx context.Context) (driver.Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	conn, err := c.driver.Open(c.dsn)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateStoreLinkIdentity(c.storePath); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return &storeLeaseConn{Conn: conn, lease: heldExclusiveLease{}}, nil
 }
 
 type storeLeaseConn struct {

--- a/infrastructure/sqlite/store_lease_exclusive_test.go
+++ b/infrastructure/sqlite/store_lease_exclusive_test.go
@@ -47,7 +47,7 @@ func TestAcquireExclusive_TimesOutWhileSharedConnHeld(t *testing.T) {
 	}
 }
 
-func TestCoordinatedOpen_FailsFastWhenThisProcessHoldsExclusive(t *testing.T) {
+func TestCoordinatedOpen_SucceedsWhenThisProcessHoldsExclusive(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "store.db")
 	release, err := (StoreLeaseCoordinator{}).AcquireExclusive(context.Background(), path)
 	if err != nil {
@@ -57,9 +57,29 @@ func TestCoordinatedOpen_FailsFastWhenThisProcessHoldsExclusive(t *testing.T) {
 	started := time.Now()
 	db := openCoordinatedDB(path, sqliteDSN(path))
 	defer func() { _ = db.Close() }()
-	err = db.PingContext(context.Background())
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("exclusive holder must open SQLite without a second flock: %v", err)
+	}
+	if time.Since(started) > time.Second {
+		t.Fatalf("exclusive-holder open took %s, want no shared-lease poll", time.Since(started))
+	}
+}
+
+func TestAcquireSharedLease_FailsFastWhenThisProcessHoldsExclusive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	release, err := (StoreLeaseCoordinator{}).AcquireExclusive(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	lockPath, err := canonicalLeasePath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	_, err = acquireAdvisoryLease(context.Background(), lockPath, false)
 	if err == nil {
-		t.Fatal("coordinated ping succeeded while this process holds exclusive")
+		t.Fatal("shared acquire succeeded on a second fd while this process holds exclusive")
 	}
 	if !strings.Contains(err.Error(), "self-deadlock") || !strings.Contains(err.Error(), storeLeaseSuffix) {
 		t.Fatalf("error should name self-deadlock and lock path, got %v", err)

--- a/main.go
+++ b/main.go
@@ -258,6 +258,12 @@ func run() error {
 			})
 			svc := usecase.NewStoreCompactionUsecase(path, journal, builder, sqlite.StoreReplacementFiles{CallerHoldsExclusiveLease: true}, sqlite.StoreLeaseCoordinator{})
 			usecase.BindCompactionWorkCover(svc, compactWorkCover(migrationsSubFS))
+			usecase.BindCompactionProjectionComplete(svc, func(ctx context.Context, store string) error {
+				previous := db.Path()
+				db.SetPath(store)
+				defer db.SetPath(previous)
+				return usecase.NewSearchProjectionUsecase(db).CompleteGeneration(ctx, apptypes.DefaultSearchProjectionBudget(), time.Now())
+			})
 			return svc
 		}),
 		cli.WithFileRetention(fileRetentionUsecase),


### PR DESCRIPTION
## Summary

Default `traceary store compact` now drives the search projection to `complete` while the exclusive store lease is still held. Operators no longer need `--projection-rebuild` for search to work after compact, and live writers cannot interleave `source changed` mid-rebuild.

Same-process coordinated SQLite opens skip a second `LOCK_SH` while this process holds exclusive (flock is per open file description). Other processes remain blocked by the exclusive fd.

## Acceptance

- After a successful default compact, `search` of a filterable token does not hit the 4096-row `index_incomplete` budget.
- Compact stdout JSON keys are unchanged.
- Compact does not return with an in-flight generation.

Closes #2163

Leaves parent #2187 open.