### PR TITLE
operator CLI does not fail SQLITE_BUSY on a current schema

### DIFF
--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -524,7 +524,8 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string, allowOffli
 // sqliteBusyTimeout is deliberately shorter than every packaged host hook
 // budget. Contention therefore returns control while the hook process still
 // has time to retain its write-ahead spool record instead of being killed at
-// the same instant SQLite's wait expires.
+// the same instant SQLite's wait expires. Operator CLI retries SQLITE_BUSY
+// separately; do not raise this constant for search/report/list (#2186).
 const sqliteBusyTimeout = 1000
 
 func sqliteDSN(dbPath string) string {

--- a/infrastructure/sqlite/migrate.go
+++ b/infrastructure/sqlite/migrate.go
@@ -24,22 +24,34 @@ func (d *Database) migrateAuthorized(ctx context.Context, db *sql.DB) error {
 }
 
 func (d *Database) migrateWithOptions(ctx context.Context, db *sql.DB, allowOffline bool) error {
-	if err := ensureSchemaMigrationsTable(ctx, db); err != nil {
-		return xerrors.Errorf("failed to create schema_migrations table: %w", err)
-	}
-
-	applied, err := loadAppliedMigrations(ctx, db)
-	if err != nil {
-		return xerrors.Errorf("failed to load applied migrations: %w", err)
-	}
-
 	migrations, err := inventoryEmbeddedMigrations(d.migrations)
 	if err != nil {
 		return xerrors.Errorf("failed to inventory exact migration catalog: %w", err)
 	}
 
+	applied, err := loadAppliedMigrations(ctx, db)
+	if err != nil {
+		if !schemaMigrationsTableMissing(err) {
+			return xerrors.Errorf("failed to load applied migrations: %w", err)
+		}
+		if err := ensureSchemaMigrationsTable(ctx, db); err != nil {
+			return xerrors.Errorf("failed to create schema_migrations table: %w", err)
+		}
+		applied, err = loadAppliedMigrations(ctx, db)
+		if err != nil {
+			return xerrors.Errorf("failed to load applied migrations: %w", err)
+		}
+	}
+
 	if err := rejectForeignAppliedMigrations(applied, migrations); err != nil {
 		return err
+	}
+	if catalogFullyApplied(applied, migrations) {
+		return nil
+	}
+
+	if err := ensureSchemaMigrationsTable(ctx, db); err != nil {
+		return xerrors.Errorf("failed to create schema_migrations table: %w", err)
 	}
 
 	for _, migration := range migrations {
@@ -70,6 +82,34 @@ func (d *Database) migrateWithOptions(ctx context.Context, db *sql.DB, allowOffl
 func isDataDependentOfflineMigration(version int64) bool {
 	entry, ok := preparedMigrationManifest[version]
 	return ok && entry.Class == MigrationDataDependentOffline
+}
+
+func catalogFullyApplied(applied map[int64]string, catalog []embeddedMigration) bool {
+	if len(catalog) == 0 {
+		return false
+	}
+	for _, migration := range catalog {
+		if _, exists := applied[migration.version]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func schemaMigrationsTableMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no such table") && strings.Contains(message, "schema_migrations")
+}
+
+func sqliteBusyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "sqlite_busy") || strings.Contains(message, "database is locked") || strings.Contains(message, "database table is locked")
 }
 
 func pendingOfflineMigrations(migrations []embeddedMigration, applied map[int64]string) []int64 {

--- a/infrastructure/sqlite/operator_open_busy_test.go
+++ b/infrastructure/sqlite/operator_open_busy_test.go
@@ -1,0 +1,134 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestMigrate_CurrentCatalogSkipsDDLWhileImmediateWriterHeld(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations := operatorOpenMigrations(t)
+	database := NewDatabase(dbPath, migrations)
+	if err := database.initialize(ctx); err != nil {
+		t.Fatalf("seed initialize error = %v", err)
+	}
+
+	locker, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open locker error = %v", err)
+	}
+	t.Cleanup(func() { _ = locker.Close() })
+	if _, err := locker.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE error = %v", err)
+	}
+	defer func() { _, _ = locker.ExecContext(ctx, "ROLLBACK") }()
+
+	db, err := database.open(ctx)
+	if err != nil {
+		t.Fatalf("open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	started := time.Now()
+	err = database.migrate(ctx, db)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("migrate() on current catalog while IMMEDIATE is held: %v", err)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("migrate() elapsed = %s, want no busy wait on a current catalog", elapsed)
+	}
+}
+
+func TestInitialize_CurrentCatalogDoesNotExecuteMigrationSQLUnderExclusiveWriter(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations := operatorOpenMigrations(t)
+	if err := NewDatabase(dbPath, migrations).initialize(ctx); err != nil {
+		t.Fatalf("seed initialize error = %v", err)
+	}
+
+	locker, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open locker error = %v", err)
+	}
+	t.Cleanup(func() { _ = locker.Close() })
+	if _, err := locker.ExecContext(ctx, "BEGIN EXCLUSIVE"); err != nil {
+		t.Fatalf("BEGIN EXCLUSIVE error = %v", err)
+	}
+	defer func() { _, _ = locker.ExecContext(ctx, "ROLLBACK") }()
+
+	err = NewDatabase(dbPath, migrations).initialize(ctx)
+	if err != nil && (strings.Contains(err.Error(), "version=73") || strings.Contains(err.Error(), "failed to execute migration SQL")) {
+		t.Fatalf("initialize() applied DDL on a current catalog: %v", err)
+	}
+}
+
+func TestInitialize_OperatorBusyRetryWaitsOutExclusiveWriter(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations := operatorOpenMigrations(t)
+	if err := NewDatabase(dbPath, migrations).initialize(ctx); err != nil {
+		t.Fatalf("seed initialize error = %v", err)
+	}
+
+	locker, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open locker error = %v", err)
+	}
+	t.Cleanup(func() { _ = locker.Close() })
+	if _, err := locker.ExecContext(ctx, "BEGIN EXCLUSIVE"); err != nil {
+		t.Fatalf("BEGIN EXCLUSIVE error = %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		_, _ = locker.ExecContext(context.Background(), "ROLLBACK")
+		close(released)
+	}()
+
+	err = retryInitializeOnBusy(ctx, 5*time.Second, func() error {
+		return NewDatabase(dbPath, migrations).initialize(ctx)
+	})
+	<-released
+	if err != nil {
+		t.Fatalf("operator initialize retry error = %v", err)
+	}
+}
+
+func retryInitializeOnBusy(ctx context.Context, limit time.Duration, initialize func() error) error {
+	deadline := time.Now().Add(limit)
+	var err error
+	for time.Now().Before(deadline) {
+		err = initialize()
+		if err == nil || !sqliteBusyError(err) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return err
+}
+
+func operatorOpenMigrations(t *testing.T) fs.FS {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return os.DirFS(filepath.Join(filepath.Dir(file), "..", "..", "schema", "sqlite", "migrations"))
+}

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -366,7 +366,7 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 	if c.event == nil {
 		return xerrors.New(Localize("list events query service is not configured", "イベント一覧クエリサービスが設定されていません"))
 	}
-	if err := c.storeManagement.Initialize(ctx); err != nil {
+	if err := initializeOperatorStore(ctx, c.storeManagement); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 	events, err := c.event.List(ctx, criteria)

--- a/presentation/cli/report.go
+++ b/presentation/cli/report.go
@@ -130,7 +130,7 @@ func (c *RootCLI) runReport(ctx context.Context, output io.Writer, input reportC
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
 	}
 	c.applyDatabasePath(resolvedDBPath)
-	if err := c.storeManagement.Initialize(ctx); err != nil {
+	if err := initializeOperatorStore(ctx, c.storeManagement); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -137,7 +137,7 @@ func (c *RootCLI) runSearch(ctx context.Context, warnWriter io.Writer, output io
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
 	}
 	c.applyDatabasePath(resolvedDBPath)
-	if err := c.storeManagement.Initialize(ctx); err != nil {
+	if err := initializeOperatorStore(ctx, c.storeManagement); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 

--- a/presentation/cli/store_operator_initialize.go
+++ b/presentation/cli/store_operator_initialize.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+// operatorStoreBusyRetry is longer than hook sqliteBusyTimeout (1000 ms) so
+// search/report/list wait out a writer instead of failing on an already-
+// current schema (#2186). Hook Initialize must not use this helper.
+const operatorStoreBusyRetry = 15 * time.Second
+
+func initializeOperatorStore(ctx context.Context, store interface {
+	Initialize(context.Context) error
+}) error {
+	deadline := time.Now().Add(operatorStoreBusyRetry)
+	if bound, ok := ctx.Deadline(); ok && bound.Before(deadline) {
+		deadline = bound
+	}
+	var err error
+	for {
+		err = store.Initialize(ctx)
+		if err == nil {
+			return nil
+		}
+		if !operatorSQLiteBusy(err) {
+			return xerrors.Errorf("initialize operator store: %w", err)
+		}
+		if !time.Now().Before(deadline) {
+			return xerrors.Errorf("initialize operator store: %w", err)
+		}
+		timer := time.NewTimer(50 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return xerrors.Errorf("initialize operator store: %w", err)
+		case <-timer.C:
+		}
+	}
+}
+
+func operatorSQLiteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "sqlite_busy") || strings.Contains(message, "database is locked") || strings.Contains(message, "database table is locked")
+}

--- a/presentation/cli/store_operator_initialize_test.go
+++ b/presentation/cli/store_operator_initialize_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type busyThenOKStore struct {
+	calls int
+}
+
+func (s *busyThenOKStore) Initialize(context.Context) error {
+	s.calls++
+	if s.calls < 3 {
+		return errors.New("failed to run SQLite migrations: failed to query schema_migrations: database is locked (5) (SQLITE_BUSY)")
+	}
+	return nil
+}
+
+func TestInitializeOperatorStoreRetriesBusyUntilSuccess(t *testing.T) {
+	t.Parallel()
+	store := &busyThenOKStore{}
+	if err := initializeOperatorStore(context.Background(), store); err != nil {
+		t.Fatalf("initializeOperatorStore() error = %v", err)
+	}
+	if store.calls != 3 {
+		t.Fatalf("Initialize calls = %d, want 3", store.calls)
+	}
+}
+
+func TestInitializeOperatorStoreDoesNotRetryNonBusy(t *testing.T) {
+	t.Parallel()
+	store := initializeOnceStore{err: errors.New("schema_migrations records version 1 as x")}
+	if err := initializeOperatorStore(context.Background(), store); err == nil {
+		t.Fatal("initializeOperatorStore() error = nil, want non-busy failure")
+	}
+}
+
+func TestInitializeOperatorStoreHonorsContextDeadline(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := initializeOperatorStore(ctx, busyForeverStore{})
+	if err == nil {
+		t.Fatal("initializeOperatorStore() error = nil, want busy failure at deadline")
+	}
+	if !operatorSQLiteBusy(err) {
+		t.Fatalf("error = %v, want SQLITE_BUSY", err)
+	}
+}
+
+type initializeOnceStore struct{ err error }
+
+func (s initializeOnceStore) Initialize(context.Context) error { return s.err }
+
+type busyForeverStore struct{}
+
+func (busyForeverStore) Initialize(context.Context) error {
+	return errors.New("database is locked (5) (SQLITE_BUSY)")
+}


### PR DESCRIPTION
## Summary

Operator `search` / `report` / `list` no longer hard-fail in ~1s with `failed to execute migration SQL (version=73): SQLITE_BUSY` when the catalog is already current.

- `migrate` now reads `schema_migrations` first and skips DDL when every catalog version is applied.
- Operator open retries SQLITE_BUSY for up to 15s. Hook `sqliteBusyTimeout` remains 1000 ms.

## Acceptance

- With a writer holding the store for >1 s on a current schema, operator search does not fail the whole command on migration 73.
- Hook busy timeout stays 1000 ms.
- Search JSON shape is unchanged.

Closes #2186

Leaves parent #2187 open.