### PR TITLE
Prune accepted compact rollback copies via doctor --fix

### DIFF
--- a/.ai/spec/2184.md
+++ b/.ai/spec/2184.md
@@ -1,0 +1,72 @@
+# Issue 2184: accepted rollback prune and abandoned compact work leftovers
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — filesystem delete of compact artifacts; no schema; compact stdout JSON frozen; doctor stdout contract changes in the same PR.
+
+### Requirement summary
+- 目的: committed compact のあと、operator が受け入れた rollback sibling と、in-flight ではない abandoned compact work leftover を `doctor --fix` で境界付き削除できるようにする。
+- 現状: `inspectCompactRollbackCopies` は WARN のみで `FixFunc` が無い。`--fix` は何も消さない。`.traceary-compaction/*.jsonl` が terminal / 欠落だと `compact-in-flight` は PASS のまま、`<db>.compact-*` と SQLite sidecar（`-journal` / `-wal` / `-shm`、dogfood 上の `*.work-journal`）が残る。
+- 期待する振る舞い:
+  - `doctor --fix`（および `--dry-run` preview）が、**accepted rollback** である `<db>.rollback-<runid>` だけを消す。
+  - 受け入れの意思表示は `doctor --fix` 自体。compact `committed` では自動削除しない。stdout JSON（`rollback_retained` / `rollback_path`）は不変。
+  - in-flight な compact に属する candidate / sidecar / work-journal は絶対に消さない。
+  - abandoned leftover は `compact-in-flight` 上で WARN + `--fix` で掃除、または明示サーフェス。
+  - Message は reclaimable bytes を出し、volume が逼迫しているときは「この copy が残ると次の compact がブロックされる」と書く。
+- 非対象: committed 時の自動削除、新 compact フラグ、release サブコマンド、ライブホームストアへの repo バイナリ。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Rollback sibling | retained after `committed` | operator `--fix` unlinks that run’s file | never unlink on compact success; never unlink if a non-terminal journal for that run exists |
+| Compact journal | pre-pub / published / terminal | existing abandon for pre-pub only | swap_intent+ keeps resume/rollback |
+| Abandoned work leftover | candidate or SQLite sidecar with no non-terminal journal | `--fix` unlinks | never unlink when in-flight journal matches run id |
+| In-flight work | non-terminal `.jsonl` in `.traceary-compaction/` | leave files | doctor must still WARN via existing in-flight path |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Detect rollback siblings | `inspectCompactRollbackCopies` | already lists `<db>.rollback-*` | compact usecase (JSON frozen) |
+| Delete accepted rollback | same check’s `StructuredFixFunc` | filesystem-only; metadata-only doctor may run `--fix` without SQLite | store Initialize / migrations |
+| Detect abandoned leftovers | `inspectCompactInFlight` (extend) | issue asks to surface on this check | new check name would fork golden + operator vocabulary |
+| Delete abandoned leftovers | that check’s fix, after in-flight set is empty **or** leftover run id ∉ in-flight ids | | never `os.Remove` of an in-flight candidate |
+| Disk-full wording | rollback check message/hint using existing `inspectDoctorDiskFree` | | compact planner |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `doctor --fix` / `--dry-run` | operator | glob + Lstat regular files only (no follow symlink) | dry-run: no unlink; error wraps with `xerrors` |
+| Compact stdout JSON | scripts | unchanged field set | no new required flags |
+| Metadata-only large-store doctor | `TestRootCLI_DoctorLargeStore…` | `--fix` may unlink rollback/leftovers (no SQLite). Must still not `Initialize` | keep ≤1s, no SQLite |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Prune accepted rollback | fixture store + `<db>.rollback-<id>` regular file; no in-flight journal | `doctor --fix --db-path …` | file gone; check PASS; metrics `removed=1` | CLI |
+| Dry-run keeps file | same | `--fix --dry-run` | file remains; action names would-delete | CLI |
+| In-flight journal kept | non-terminal journal + matching `.compact-<id>` and `-journal` | `--fix` | those files remain | CLI |
+| Abandoned leftover cleaned | `.compact-<id>-journal` (or `.work-journal`) with **no** non-terminal jsonl | `--fix` | leftover gone; compact-in-flight PASS after | CLI |
+| Compact JSON frozen | successful compact in existing test | inspect JSON keys | `rollback_retained` / `rollback_path` still present | existing compact tests |
+| Symlink not deleted | rollback path is symlink | `--fix` | skip/warn; target not unlinked | CLI |
+| Disk wording | rollback present and `FilesystemFreeBytes` < rollback size | doctor (no --fix) | message/hint names reclaimable bytes and blocked compact | unit |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| Rollback prune | extend `doctor_compact_rollback_test.go` + large-store `--fix` expectation | FixFunc on rollback check | keep inspect vs fix split |
+| Abandoned leftover | new cases next to `doctor_compact_inflight` tests | glob leftovers not in in-flight ids | reuse sidecar suffix list `-wal/-shm/-journal` plus `*.work-journal` |
+| Golden | `testdata/doctor/default.golden.json` if hint/message/fix_command change | update **same PR** | |
+
+### Risks / rollback
+- 手続き化リスク: doctor に削除ロジックを直書きしすぎない。inspect は列挙、fix は列挙結果だけ unlink。
+- premature abstraction: 新しい “artifact janitor” パッケージは作らない。
+- migration / compatibility: compact JSON 不変。`--fix` が destructive になるのは operator が `--fix` を付けたときだけ。
+- rollback trigger: revert the PR; leftover files already deleted cannot be restored from doctor.
+
+### Implementation notes (binding)
+- Rollback glob stays `dbPath + ".rollback-*"`; only `Mode().IsRegular()`; refuse symlink.
+- In-flight protection: parse run id from `.rollback-<id>` / `.compact-<id>` and skip if `listCompactInFlightJournals` contains that id.
+- Leftover globs beside the store: `dbPath+".compact-*"`, plus files named `*.work-journal` in `filepath.Dir(dbPath)` whose name contains `.compact-`.
+- Never point a test or debug binary at `~/.config/traceary/traceary.db`.
+- English errors; table-driven English test names.
+- `Co-authored-by` on commits. PR body: `Closes #2184` and “Leaves parent #2188 open”. No GitHub close keyword next to `#2188`.

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -81,10 +81,13 @@ attestation）。しかし compacted store が実使用で正しいことの証�
 そのため Traceary は commit 時にも次回の成功 open 時にも
 `<db>.rollback-<run>` を削除せず、release 用の新コマンドも追加しません。
 
-operator が解放する手段は、compact 成功 JSON の `rollback_path`
-（`rollback_retained: true`）を削除することです。削除するとその run の
-`traceary store compact rollback RUN_ID` は使えなくなります。
+operator が解放する手段は、書き換えを受け入れたあとの `traceary doctor --fix`
+です（または compact 成功 JSON の `rollback_path` / `rollback_retained: true`
+を手で削除します）。compact の commit では sibling を消しません。削除するとその
+run の `traceary store compact rollback RUN_ID` は使えなくなります。
 `traceary doctor` は隣に残った copy を `compact-rollback-copy` として報告します。
+in-flight ではない abandoned `<db>.compact-*` / `*.work-journal` leftover も
+`doctor --fix` が削除します。
 
 ## maintenance手順
 

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -96,10 +96,13 @@ correct in use. Traceary therefore **does not** delete `<db>.rollback-<run>`
 on commit or on the next successful open, and it does not add a release
 subcommand.
 
-The operator releases the copy by deleting the path named in the compact
-success JSON (`rollback_path`, with `rollback_retained: true`). Deleting it
-gives up `traceary store compact rollback RUN_ID` for that run.
-`traceary doctor` reports a leftover sibling as `compact-rollback-copy`.
+The operator releases the copy with `traceary doctor --fix` after accepting
+the rewrite (or by deleting the path named in the compact success JSON:
+`rollback_path`, with `rollback_retained: true`). Compact commit never deletes
+the sibling. Deleting it gives up `traceary store compact rollback RUN_ID` for
+that run. `traceary doctor` reports a leftover sibling as
+`compact-rollback-copy`. Abandoned `<db>.compact-*` / `*.work-journal`
+leftovers that are not in-flight are also removed by `doctor --fix`.
 
 ## Maintenance sequence
 

--- a/presentation/cli/doctor_compact_inflight.go
+++ b/presentation/cli/doctor_compact_inflight.go
@@ -43,14 +43,22 @@ func inspectCompactInFlightJournalsWithFix(dbPath string, now time.Time, fix fun
 			Message: localizef("failed to inspect compaction journals: %v", "compaction journal を検査できません: %v", err),
 		}
 	}
-	if len(journals) == 0 {
+	leftovers, leftoverErr := listAbandonedCompactLeftovers(dbPath)
+	if leftoverErr != nil {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusWarn,
+			Message: localizef("failed to inspect compact leftovers: %v", "compact leftover を検査できません: %v", leftoverErr),
+		}
+	}
+	if len(journals) == 0 && len(leftovers) == 0 {
 		return doctorCheck{
 			Name:    name,
 			Status:  doctorStatusPass,
 			Message: Localize("no in-flight compaction journal is present", "進行中の compaction journal はありません"),
 		}
 	}
-	parts := make([]string, 0, len(journals))
+	parts := make([]string, 0, len(journals)+1)
 	prePub := 0
 	for _, journal := range journals {
 		age := now.Sub(journal.UpdatedAt).Truncate(time.Second)
@@ -68,29 +76,85 @@ func inspectCompactInFlightJournalsWithFix(dbPath string, now time.Time, fix fun
 			prePub++
 		}
 	}
-	check := doctorCheck{
-		Name:   name,
-		Status: doctorStatusWarn,
-		Message: localizef(
-			"in-flight compaction journal(s): %s",
-			"進行中の compaction journal: %s",
-			strings.Join(parts, "; "),
-		),
-		Hint: Localize(
-			"Pre-publication phases (planned / copy_intent / copy_retry_intent / candidate_prepared) can be abandoned by `traceary doctor --fix` or the next `store compact` when the source identity has moved. swap_intent and later keep today's resume/rollback semantics.",
-			"publication 前の phase（planned / copy_intent / copy_retry_intent / candidate_prepared）は、source identity が動いていれば `traceary doctor --fix` または次の `store compact` が abandon します。swap_intent 以降は従来の resume/rollback です。",
-		),
+	if len(leftovers) > 0 {
+		parts = append(parts, localizef(
+			"abandoned leftover(s)=%s",
+			"abandoned leftover=%s",
+			strings.Join(leftovers, ", "),
+		))
 	}
-	if prePub > 0 && fix != nil {
-		check.FixCommand = "traceary doctor --fix"
+	hint := Localize(
+		"Pre-publication phases (planned / copy_intent / copy_retry_intent / candidate_prepared) can be abandoned by `traceary doctor --fix` or the next `store compact` when the source identity has moved. swap_intent and later keep today's resume/rollback semantics. Abandoned leftover `<db>.compact-*` / `*.work-journal` files with no in-flight journal are removed by `traceary doctor --fix`. In-flight work files are never deleted.",
+		"publication 前の phase（planned / copy_intent / copy_retry_intent / candidate_prepared）は、source identity が動いていれば `traceary doctor --fix` または次の `store compact` が abandon します。swap_intent 以降は従来の resume/rollback です。in-flight journal が無い abandoned leftover（`<db>.compact-*` / `*.work-journal`）は `traceary doctor --fix` が削除します。in-flight の work file は消しません。",
+	)
+	message := localizef(
+		"in-flight compaction journal(s): %s",
+		"進行中の compaction journal: %s",
+		strings.Join(parts, "; "),
+	)
+	if len(journals) == 0 {
+		message = localizef(
+			"abandoned compact leftover file(s) with no in-flight journal: %s",
+			"in-flight journal が無い abandoned compact leftover: %s",
+			strings.Join(leftovers, ", "),
+		)
+	}
+	check := doctorCheck{
+		Name:    name,
+		Status:  doctorStatusWarn,
+		Message: message,
+		Hint:    hint,
+	}
+	combined := composeCompactInFlightFix(dbPath, fix, leftovers)
+	if (prePub > 0 && fix != nil) || len(leftovers) > 0 {
+		check.FixCommand = doctorFixCommand(dbPath)
 		check.AutoFixAvailable = true
-		check.StructuredFixFunc = fix
+		check.StructuredFixFunc = combined
 		check.FixFunc = func(ctx context.Context, dryRun bool) (string, error) {
-			result, err := fix(ctx, dryRun)
+			result, err := combined(ctx, dryRun)
 			return result.Action, err
 		}
 	}
 	return check
+}
+
+func composeCompactInFlightFix(
+	dbPath string,
+	journalFix func(context.Context, bool) (doctorFixResult, error),
+	leftovers []string,
+) func(context.Context, bool) (doctorFixResult, error) {
+	return func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
+		action := ""
+		metrics := map[string]int{}
+		if journalFix != nil {
+			result, err := journalFix(ctx, dryRun)
+			if err != nil {
+				return doctorFixResult{}, xerrors.Errorf("failed to abandon stale compaction journal: %w", err)
+			}
+			action = result.Action
+			for k, v := range result.Metrics {
+				metrics[k] = v
+			}
+		}
+		if len(leftovers) > 0 {
+			left, err := fixAbandonedCompactLeftovers(ctx, dbPath, dryRun)
+			if err != nil {
+				return doctorFixResult{}, xerrors.Errorf("failed to remove abandoned compact leftovers: %w", err)
+			}
+			if action == "" {
+				action = left.Action
+			} else {
+				action = action + "; " + left.Action
+			}
+			for k, v := range left.Metrics {
+				metrics[k] = v
+			}
+		}
+		if action == "" {
+			action = Localize("no compact leftover was removed", "削除した compact leftover はありません")
+		}
+		return doctorFixResult{Action: action, Metrics: metrics}, nil
+	}
 }
 
 func (c *RootCLI) inspectCompactInFlight(dbPath string, now time.Time) doctorCheck {

--- a/presentation/cli/doctor_compact_inflight_test.go
+++ b/presentation/cli/doctor_compact_inflight_test.go
@@ -95,3 +95,77 @@ func TestInspectCompactInFlightJournals_SwapIntentWarnsWithoutAutoFix(t *testing
 		t.Fatalf("check=%#v, want warn without autofix", check)
 	}
 }
+
+func TestInspectCompactInFlightJournals_AbandonedLeftoverIsFixable(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "traceary.db")
+	if err := os.WriteFile(dbPath, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	leftover := dbPath + ".compact-deadbeefdeadbeefdeadbeefdeadbeef-journal"
+	if err := os.WriteFile(leftover, []byte("sqlite-journal"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	work := filepath.Join(root, "traceary.db.compact-deadbeefdeadbeefdeadbeefdeadbeef.work-journal")
+	if err := os.WriteFile(work, []byte("work"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	check := inspectCompactInFlightJournals(dbPath, time.Now().UTC())
+	if check.Status != doctorStatusWarn || !check.AutoFixAvailable || check.StructuredFixFunc == nil {
+		t.Fatalf("check=%#v, want warn with leftover autofix", check)
+	}
+	if !strings.Contains(check.Message, leftover) {
+		t.Fatalf("message=%q, want leftover path", check.Message)
+	}
+	if _, err := check.StructuredFixFunc(t.Context(), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(leftover); err != nil {
+		t.Fatalf("dry-run removed leftover: %v", err)
+	}
+	if _, err := check.StructuredFixFunc(t.Context(), false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(leftover); !os.IsNotExist(err) {
+		t.Fatalf("leftover still present: %v", err)
+	}
+	if _, err := os.Lstat(work); !os.IsNotExist(err) {
+		t.Fatalf("work-journal still present: %v", err)
+	}
+	after := inspectCompactInFlightJournals(dbPath, time.Now().UTC())
+	if after.Status != doctorStatusPass {
+		t.Fatalf("after=%#v, want pass", after)
+	}
+}
+
+func TestInspectCompactInFlightJournals_DoesNotDeleteInFlightWork(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "traceary.db")
+	dir := filepath.Join(root, compactJournalDirName)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	run := domain.CompactionRun{
+		ID:        "dddddddddddddddddddddddddddddddd",
+		Phase:     domain.CompactionSwapIntent,
+		UpdatedAt: time.Now().UTC(),
+	}
+	encoded, err := json.Marshal(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, run.ID+".jsonl"), append(encoded, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	work := dbPath + ".compact-" + run.ID + "-journal"
+	if err := os.WriteFile(work, []byte("live"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	check := inspectCompactInFlightJournals(dbPath, time.Now().UTC())
+	if check.AutoFixAvailable {
+		t.Fatalf("in-flight swap_intent leftover must not be auto-fixed: %+v", check)
+	}
+	if _, err := os.Lstat(work); err != nil {
+		t.Fatalf("in-flight work missing: %v", err)
+	}
+}

--- a/presentation/cli/doctor_compact_leftovers.go
+++ b/presentation/cli/doctor_compact_leftovers.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+func compactInFlightIDSet(dbPath string) (map[string]struct{}, error) {
+	journals, err := listCompactInFlightJournals(filepath.Join(filepath.Dir(dbPath), compactJournalDirName))
+	if err != nil {
+		return nil, err
+	}
+	ids := make(map[string]struct{}, len(journals))
+	for _, journal := range journals {
+		if journal.ID != "" {
+			ids[journal.ID] = struct{}{}
+		}
+	}
+	return ids, nil
+}
+
+func compactArtifactRunID(dbPath, path string) string {
+	base := filepath.Base(dbPath)
+	name := filepath.Base(path)
+	for _, kind := range []string{".compact-", ".rollback-"} {
+		prefix := base + kind
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(name, prefix)
+		for _, suffix := range []string{".work-journal", "-journal", "-wal", "-shm"} {
+			rest = strings.TrimSuffix(rest, suffix)
+		}
+		return rest
+	}
+	return ""
+}
+
+func listAbandonedCompactLeftovers(dbPath string) ([]string, error) {
+	inflight, err := compactInFlightIDSet(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	matches, err := filepath.Glob(dbPath + ".compact-*")
+	if err != nil {
+		return nil, xerrors.Errorf("failed to inspect compact work leftovers: %w", err)
+	}
+	workJournals, err := filepath.Glob(filepath.Join(filepath.Dir(dbPath), "*.work-journal"))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to inspect compact work-journal leftovers: %w", err)
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, path := range append(append([]string{}, matches...), workJournals...) {
+		if _, dup := seen[path]; dup {
+			continue
+		}
+		seen[path] = struct{}{}
+		info, statErr := os.Lstat(path)
+		if statErr != nil || info == nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if !strings.Contains(filepath.Base(path), ".compact-") {
+			continue
+		}
+		runID := compactArtifactRunID(dbPath, path)
+		if runID == "" {
+			continue
+		}
+		if _, live := inflight[runID]; live {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out, nil
+}
+
+func unlinkRegularCompactArtifacts(paths []string, dryRun bool) (removed int, err error) {
+	for _, path := range paths {
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				continue
+			}
+			return removed, xerrors.Errorf("failed to inspect compact leftover %s: %w", path, statErr)
+		}
+		if info == nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if dryRun {
+			removed++
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return removed, xerrors.Errorf("failed to remove compact leftover %s: %w", path, err)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+func fixAbandonedCompactLeftovers(ctx context.Context, dbPath string, dryRun bool) (doctorFixResult, error) {
+	if err := ctx.Err(); err != nil {
+		return doctorFixResult{}, xerrors.Errorf("compact leftover fix canceled: %w", err)
+	}
+	leftovers, err := listAbandonedCompactLeftovers(dbPath)
+	if err != nil {
+		return doctorFixResult{}, err
+	}
+	removed, err := unlinkRegularCompactArtifacts(leftovers, dryRun)
+	if err != nil {
+		return doctorFixResult{}, err
+	}
+	if dryRun {
+		return doctorFixResult{
+			Action: localizef(
+				"would remove %d abandoned compact leftover file(s)",
+				"abandoned compact leftover を %d 件削除します",
+				removed,
+			),
+			Metrics: map[string]int{"removed": removed},
+		}, nil
+	}
+	return doctorFixResult{
+		Action: localizef(
+			"removed %d abandoned compact leftover file(s)",
+			"abandoned compact leftover を %d 件削除しました",
+			removed,
+		),
+		Metrics: map[string]int{"removed": removed},
+	}, nil
+}
+
+func doctorFixCommand(dbPath string) string {
+	if strings.TrimSpace(dbPath) == "" {
+		return "traceary doctor --fix"
+	}
+	return "traceary doctor --fix --db-path " + shellQuote(dbPath)
+}

--- a/presentation/cli/doctor_compact_rollback_test.go
+++ b/presentation/cli/doctor_compact_rollback_test.go
@@ -35,8 +35,77 @@ func TestInspectCompactRollbackCopies(t *testing.T) {
 		if !strings.Contains(check.Message, rollback) {
 			t.Fatalf("Message = %q, want path", check.Message)
 		}
-		if !strings.Contains(check.Hint, "compact rollback") {
-			t.Fatalf("Hint = %q", check.Hint)
+		if !strings.Contains(check.Message, "reclaimable") {
+			t.Fatalf("Message = %q, want reclaimable bytes", check.Message)
+		}
+		if !strings.Contains(check.Hint, "doctor --fix") {
+			t.Fatalf("Hint = %q, want doctor --fix", check.Hint)
+		}
+		if !check.AutoFixAvailable || check.StructuredFixFunc == nil {
+			t.Fatalf("want auto-fix, got %+v", check)
+		}
+	})
+
+	t.Run("dry-run keeps the accepted rollback copy", func(t *testing.T) {
+		dir := t.TempDir()
+		db := filepath.Join(dir, "traceary.db")
+		rollback := db + ".rollback-abc123"
+		if err := os.WriteFile(rollback, []byte("old-store"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		check := inspectCompactRollbackCopies(db)
+		result, err := check.StructuredFixFunc(t.Context(), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Metrics["removed"] != 1 {
+			t.Fatalf("metrics=%v", result.Metrics)
+		}
+		if _, err := os.Lstat(rollback); err != nil {
+			t.Fatalf("dry-run removed %s: %v", rollback, err)
+		}
+	})
+
+	t.Run("fix removes the accepted rollback copy", func(t *testing.T) {
+		dir := t.TempDir()
+		db := filepath.Join(dir, "traceary.db")
+		rollback := db + ".rollback-abc123"
+		if err := os.WriteFile(rollback, []byte("old-store"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		check := inspectCompactRollbackCopies(db)
+		if _, err := check.StructuredFixFunc(t.Context(), false); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Lstat(rollback); !os.IsNotExist(err) {
+			t.Fatalf("rollback still present: %v", err)
+		}
+		after := inspectCompactRollbackCopies(db)
+		if after.Status != doctorStatusPass {
+			t.Fatalf("after status=%q", after.Status)
+		}
+	})
+
+	t.Run("symlink rollback is not unlinked", func(t *testing.T) {
+		dir := t.TempDir()
+		db := filepath.Join(dir, "traceary.db")
+		target := filepath.Join(dir, "real-old")
+		if err := os.WriteFile(target, []byte("keep"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rollback := db + ".rollback-abc123"
+		if err := os.Symlink(target, rollback); err != nil {
+			t.Fatal(err)
+		}
+		check := inspectCompactRollbackCopies(db)
+		if check.Status != doctorStatusPass {
+			t.Fatalf("symlink should not count as retained copy: %+v", check)
+		}
+		if check.StructuredFixFunc != nil {
+			t.Fatal("unexpected fix on pass check")
+		}
+		if _, err := os.Lstat(target); err != nil {
+			t.Fatalf("symlink target was removed: %v", err)
 		}
 	})
 }

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -59,7 +59,8 @@ func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string, s
 }
 
 // inspectCompactRollbackCopies reports leftover <db>.rollback-<run> files.
-// The copy is retained until the operator deletes it (#1827); doctor only names it.
+// Compact commit never deletes the sibling (#1827). doctor --fix unlinks an
+// accepted copy after the operator opts in.
 func inspectCompactRollbackCopies(dbPath string) doctorCheck {
 	const name = "compact-rollback-copy"
 	if strings.TrimSpace(dbPath) == "" {
@@ -102,20 +103,91 @@ func inspectCompactRollbackCopies(dbPath string) doctorCheck {
 		total += copy.size
 		parts = append(parts, fmt.Sprintf("%s (%s)", copy.path, formatByteSize(copy.size)))
 	}
-	return doctorCheck{
-		Name:   name,
-		Status: doctorStatusWarn,
-		Message: localizef(
-			"compact rollback copy still retained (%s total): %s",
-			"compact rollback copy が残っています（合計 %s）: %s",
-			formatByteSize(total),
-			strings.Join(parts, ", "),
-		),
-		Hint: Localize(
-			"Apply-time verification is not in-use proof. Keep the file until you accept the rewrite, then delete it. Deleting it gives up `traceary store compact rollback RUN_ID` for that run.",
-			"apply 時の検証は実使用の正しさの証明ではありません。書き換えを受け入れるまで残し、その後削除してください。削除するとその run の `traceary store compact rollback RUN_ID` は使えなくなります。",
-		),
+	message := localizef(
+		"compact rollback copy still retained (%s total, reclaimable %s): %s",
+		"compact rollback copy が残っています（合計 %s、回収可能 %s）: %s",
+		formatByteSize(total),
+		formatByteSize(total),
+		strings.Join(parts, ", "),
+	)
+	if free, freeErr := inspectDoctorDiskFree(dbPath); freeErr == nil && free < total {
+		message += localizef(
+			"; further compact is blocked while the copy remains (filesystem free %s)",
+			"。copy が残っている間は次の compact がブロックされます（空き %s）",
+			formatByteSize(free),
+		)
 	}
+	check := doctorCheck{
+		Name:    name,
+		Status:  doctorStatusWarn,
+		Message: message,
+		Hint: Localize(
+			"Apply-time verification is not in-use proof. Compact commit does not delete the sibling. After you accept the rewrite, `traceary doctor --fix` deletes that run's rollback copy only (never an in-flight journal). Deleting it gives up `traceary store compact rollback RUN_ID` for that run.",
+			"apply 時の検証は実使用の正しさの証明ではありません。compact の commit では sibling を消しません。書き換えを受け入れたあと `traceary doctor --fix` がその run の rollback copy だけを削除します（in-flight journal は消しません）。削除するとその run の `traceary store compact rollback RUN_ID` は使えなくなります。",
+		),
+		FixCommand:       doctorFixCommand(dbPath),
+		AutoFixAvailable: true,
+	}
+	check.StructuredFixFunc = func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
+		return fixAcceptedCompactRollbackCopies(ctx, dbPath, dryRun)
+	}
+	check.FixFunc = func(ctx context.Context, dryRun bool) (string, error) {
+		result, err := fixAcceptedCompactRollbackCopies(ctx, dbPath, dryRun)
+		return result.Action, err
+	}
+	return check
+}
+
+func fixAcceptedCompactRollbackCopies(ctx context.Context, dbPath string, dryRun bool) (doctorFixResult, error) {
+	if err := ctx.Err(); err != nil {
+		return doctorFixResult{}, xerrors.Errorf("compact rollback fix canceled: %w", err)
+	}
+	inflight, err := compactInFlightIDSet(dbPath)
+	if err != nil {
+		return doctorFixResult{}, err
+	}
+	matches, err := filepath.Glob(dbPath + ".rollback-*")
+	if err != nil {
+		return doctorFixResult{}, xerrors.Errorf("failed to inspect compact rollback copies: %w", err)
+	}
+	var removable []string
+	skippedInFlight := 0
+	for _, match := range matches {
+		info, statErr := os.Lstat(match)
+		if statErr != nil || info == nil || !info.Mode().IsRegular() {
+			continue
+		}
+		runID := compactArtifactRunID(dbPath, match)
+		if _, live := inflight[runID]; live && runID != "" {
+			skippedInFlight++
+			continue
+		}
+		removable = append(removable, match)
+	}
+	removed, err := unlinkRegularCompactArtifacts(removable, dryRun)
+	if err != nil {
+		return doctorFixResult{}, err
+	}
+	if dryRun {
+		return doctorFixResult{
+			Action: localizef(
+				"would remove %d accepted compact rollback cop(ies) (skipped_in_flight=%d)",
+				"accepted compact rollback copy を %d 件削除します (skipped_in_flight=%d)",
+				removed,
+				skippedInFlight,
+			),
+			Metrics: map[string]int{"removed": removed, "skipped_in_flight": skippedInFlight},
+		}, nil
+	}
+	return doctorFixResult{
+		Action: localizef(
+			"removed %d accepted compact rollback cop(ies) (skipped_in_flight=%d)",
+			"accepted compact rollback copy を %d 件削除しました (skipped_in_flight=%d)",
+			removed,
+			skippedInFlight,
+		),
+		Metrics: map[string]int{"removed": removed, "skipped_in_flight": skippedInFlight},
+	}, nil
 }
 
 // inspectStoreGrowthBudgetWithClock returns the store-size check and, when the

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -563,7 +563,8 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 	stdout := &bytes.Buffer{}
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
-	// Even --fix must stay non-destructive in metadata-only mode.
+	// --fix may unlink compact rollback siblings (filesystem only) but must
+	// still not open SQLite or run InitializeAuthorized.
 	rootCmd.SetArgs([]string{"doctor", "--db-path", largeStore, "--json", "--warnings-ok", "--fix"})
 
 	started := time.Now()
@@ -605,8 +606,11 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 		t.Fatalf("large-store-diagnostics = %#v, want explicit metadata-only warning", check)
 	}
 	rollback := statusByName(report, "compact-rollback-copy")
-	if rollback.Status != "warn" || !strings.Contains(rollback.Message, rollbackPath) {
-		t.Fatalf("compact-rollback-copy = %#v, want warn naming %s", rollback, rollbackPath)
+	if rollback.Status != "pass" {
+		t.Fatalf("compact-rollback-copy = %#v, want pass after --fix unlinked %s", rollback, rollbackPath)
+	}
+	if _, err := os.Lstat(rollbackPath); !os.IsNotExist(err) {
+		t.Fatalf("rollback copy still present after metadata-only --fix: %v", err)
 	}
 	cost := statusByName(report, "store-operator-cost")
 	if cost.Status != "skip" || report.OperatorCost == nil || report.OperatorCost.ResidentBytes != 2<<30 {


### PR DESCRIPTION
## 概要
Closes #2184

Leaves parent #2188 open.

## 変更内容
- `doctor --fix` deletes accepted `<db>.rollback-*` regular files after the operator opts in. Compact commit still retains the sibling (`rollback_retained` / `rollback_path` unchanged).
- Abandoned `<db>.compact-*` / `*.work-journal` leftovers with no in-flight journal are removed the same way. In-flight work files are never deleted.
- Doctor text names reclaimable bytes and, when free space is smaller than the copy, that further compact is blocked.
- Metadata-only large-store `--fix` may unlink these files without opening SQLite.

## テスト確認
- [x] `go test ./presentation/cli/` (targeted + full package)
- [x] `go test ./...`
- [x] `go tool golangci-lint run`
- [x] `go build ./...`