### PR TITLE
Scale hook spool drain with backlog and doctor wall

### DIFF
--- a/.ai/spec/2151.md
+++ b/.ai/spec/2151.md
@@ -1,0 +1,66 @@
+# Issue 2151: hook spool drain budget for requeue-scale backlog
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — changes live hook latency vs drain throughput; doctor `--fix` loop; counter **shape** frozen.
+
+### Requirement summary
+- 目的: requeue 後の数千件 spool を、organic hook でも doctor `--fix` でも現実的な時間で減らせる。
+- 現状: opportunistic drain は `hookSpoolReplayBatchLimit=5`。実測 ~96 records/h。doctor `--fix` の pending drain は `min(pending+requeued, 200)` の **1 回**。dead-letter requeue だけが 45s wall loop。
+- 期待する振る舞い:
+  - follow-up hook: backlog 比例の drain 上限（hard cap あり）。host 10s budget と `hookSpoolDrainReserve` / low-headroom は維持。
+  - `doctor --fix`: pending が閾値を超えたら 45s wall 内で drain round を繰り返す。残りは既存 counters で報告。新フラグなし。
+  - debug log に drained-per-run（replayed/failed/limit）を残す（既存 `slog.Debug("hook spool drain", …)` を拡充）。
+- 非対象: hook-spool の doctor カウンターキー名・JSON shape の変更。`sqliteBusyTimeout`。ライブホームストア。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Opportunistic drain | after successful current delivery | replay pending oldest-first | never fail current delivery; remaining ≤2s → 0; <4s → 1 |
+| Backlog-proportional budget | pending count N | count = min(hardCap, max(5, f(N))) then min with time allowance | interactive latency: stop when remaining ≤ reserve |
+| Doctor drain | `--fix` | loop `drainHookSpoolRecordsDetailed` until wall or remaining=0 | wall = existing 45s; per-round cap may stay 200 |
+| Counter shape | warn/pass message | same field names / metric keys | snapshot in same PR only if text wrapping needs it — prefer **no** message shape change |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Time allowance | `hookSpoolDrainAllowance` | already the latency guard | do not lengthen packaged 10s |
+| Backlog scale | new pure fn used by opportunistic path only | testable without I/O | doctor path uses wall loop instead |
+| Doctor rounds | `inspectHookSpoolDiagnosticsFromScan` structuredFix | already drains pending | filesystem-metadata-only large-store path still must not open payloads unless existing full-mode path |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `hookSpoolDrainAllowance(remaining)` | opportunistic | keep signature | unchanged table tests |
+| `hookSpoolBacklogDrainLimit(pending, remaining) int` | opportunistic | pending from dir listing | 0 when allowance is 0 |
+| doctor StructuredFixFunc | `--fix` | loop until `hookSpoolDeadRequeueDoctorWall` | existing wrapcheck |
+
+Binding numbers (do not bikeshed in implementation):
+- `hookSpoolReplayBatchLimit` stays 5 as the **minimum** full-headroom batch.
+- Hard cap for one hook invocation: **32** (order-of-magnitude vs 5; still ≪ 3k).
+- Scale: `min(32, max(5, pending/100))` when remaining ≥ 4s; still `min` with `hookSpoolDrainAllowance`.
+- Doctor: if pending > 200, loop drain rounds of 200 until 45s or remaining 0.
+- Organic-hook count to clear 3k at cap 32: ~94 invocations vs ~600 at 5. Combined with doctor 45s loop this meets “one `--fix` or stated organic count an order of magnitude smaller than ~96/h wait”.
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Scale table | pending 0/5/500/3000, remaining 8s | backlog limit | 5 / 5 / 5 / 30 (3000/100) capped 32 | unit |
+| Reserve still 0 | remaining 2s, pending 3000 | opportunistic | drain 0 | unit |
+| Low headroom 1 | remaining 3s, pending 3000 | opportunistic | drain 1 | unit |
+| Doctor loop | 3k tiny records (no SQLite if using replay stub) | `--fix` | remaining drops by ≫200 in one invocation or wall exhausted with remainder reported in **existing** metric keys | CLI with stub |
+| Counter shape | existing golden / message regex tests | doctor json | keys `pending=` / `replayed=` etc unchanged | contract |
+
+### TDD plan
+| Behavior | Red | Green | Refactor |
+|---|---|---|---|
+| Scale fn | table next to `hookSpoolDrainAllowance` tests | pure fn | |
+| Doctor loop | fixture with >200 pending; stub drain cheap | loop in structuredFix | do not change metric map keys |
+| Debug log | existing drain test | extra fields `pending` `drained` | |
+
+### Risks / rollback
+- 手続き化リスク: doctor と hook で別の ad-hoc ループを増やしすぎない。共有は `drainHookSpoolRecordsDetailed`。
+- latency: hard cap 32 and time allowance are the guard; do not raise packaged host budget.
+- rollback: revert PR; spool files remain durable.
+
+PR: `Closes #2151`; Leaves parent #2188 open.

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -20,9 +20,15 @@ import (
 
 const (
 	hookSpoolSchemaVersion = 1
-	// hookSpoolReplayBatchLimit caps opportunistic drain work per hook
-	// invocation so replay cannot exhaust the host timeout budget.
+	// hookSpoolReplayBatchLimit is the minimum opportunistic drain batch when
+	// remaining host budget is outside the low-headroom window.
 	hookSpoolReplayBatchLimit = 5
+	// hookSpoolReplayBacklogCap is the maximum opportunistic drain batch when
+	// pending backlog is large. Time allowance still wins (0 / 1 in reserve).
+	hookSpoolReplayBacklogCap = 32
+	// hookSpoolDoctorDrainRoundLimit is one drain round inside doctor --fix.
+	// Rounds repeat until the 45s wall or the queue is empty.
+	hookSpoolDoctorDrainRoundLimit = 200
 	// hookSpoolRetryLimit is the maximum number of delivery attempts for a
 	// replayable spool record (first delivery + 2 retries). After this many
 	// failed attempts the record is retained under spool/dead/ and excluded
@@ -78,6 +84,26 @@ func hookSpoolDrainAllowance(remaining time.Duration) int {
 		return 1
 	}
 	return hookSpoolReplayBatchLimit
+}
+
+// hookSpoolBacklogDrainLimit scales opportunistic drain with pending count
+// while preserving the 0 / 1 time-allowance bands.
+func hookSpoolBacklogDrainLimit(pending int, remaining time.Duration) int {
+	allowance := hookSpoolDrainAllowance(remaining)
+	if allowance <= 1 {
+		return allowance
+	}
+	if pending < 0 {
+		pending = 0
+	}
+	scaled := pending / 100
+	if scaled < hookSpoolReplayBatchLimit {
+		scaled = hookSpoolReplayBatchLimit
+	}
+	if scaled > hookSpoolReplayBacklogCap {
+		scaled = hookSpoolReplayBacklogCap
+	}
+	return scaled
 }
 
 // hookSpoolDrainRemaining is the wall-clock budget left for opportunistic
@@ -203,10 +229,16 @@ func (c *RootCLI) runHookDurably(
 		// remaining budget is inside the reserve window so host watchdogs do
 		// not kill an already-successful hook.
 		if ctx.Err() == nil {
-			limit := hookSpoolDrainAllowance(hookSpoolDrainRemaining(ctx, startedAt, time.Now()))
+			remaining := hookSpoolDrainRemaining(ctx, startedAt, time.Now())
+			pending, pendingErr := countHookSpoolPendingPaths(time.Now().UTC())
+			if pendingErr != nil {
+				slog.Debug("hook spool drain pending count failed", "error", pendingErr)
+				pending = 0
+			}
+			limit := hookSpoolBacklogDrainLimit(pending, remaining)
 			if limit > 0 {
 				if replayed, failed := c.drainHookSpoolRecords(ctx, limit); replayed > 0 || failed > 0 {
-					slog.Debug("hook spool drain", "replayed", replayed, "failed", failed, "limit", limit)
+					slog.Debug("hook spool drain", "replayed", replayed, "failed", failed, "limit", limit, "pending", pending, "drained", replayed)
 				}
 			}
 		}
@@ -233,6 +265,44 @@ func (c *RootCLI) drainHookSpoolRecords(ctx context.Context, limit int) (replaye
 	// the structured result keeps replay failures and unreadable records
 	// disjoint.
 	return result.Replayed, result.Failed + result.Unreadable
+}
+
+func (c *RootCLI) drainHookSpoolRecordsUntil(ctx context.Context, pending int) hookSpoolDrainResult {
+	aggregated := hookSpoolDrainResult{}
+	deadline := hookSpoolDeadRequeueNow().Add(hookSpoolDeadRequeueDoctorWall)
+	remaining := pending
+	for remaining > 0 {
+		if err := ctx.Err(); err != nil {
+			aggregated.Err = xerrors.Errorf("hook spool drain cancelled: %w", err)
+			return aggregated
+		}
+		if !hookSpoolDeadRequeueNow().Before(deadline) {
+			aggregated.Remaining = remaining
+			return aggregated
+		}
+		round := remaining
+		if round > hookSpoolDoctorDrainRoundLimit {
+			round = hookSpoolDoctorDrainRoundLimit
+		}
+		result := c.drainHookSpoolRecordsDetailed(ctx, round)
+		if result.Err != nil {
+			aggregated.Err = result.Err
+			aggregated.Remaining = result.Remaining
+			return aggregated
+		}
+		if result.Replayed == 0 {
+			if aggregated.Replayed == 0 && aggregated.Failed == 0 && aggregated.Unreadable == 0 {
+				return result
+			}
+			return aggregated
+		}
+		aggregated.Replayed += result.Replayed
+		aggregated.Failed += result.Failed
+		aggregated.Unreadable += result.Unreadable
+		aggregated.Remaining = result.Remaining
+		remaining = result.Remaining
+	}
+	return aggregated
 }
 
 func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) hookSpoolDrainResult {
@@ -1388,13 +1458,12 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 				"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、未処理 hook spool record 最大 %d 件を drain し、古い dead-letter %d 件と orphan tmp %d 件を prune します",
 				requeued,
 				skippedNontransient,
-				min(pending+requeued, 200),
+				pending+requeued,
 				pruned,
 				prunedTmp,
 			)}, nil
 		}
-		limit := min(pending+requeued, 200)
-		result := c.drainHookSpoolRecordsDetailed(ctx, limit)
+		result := c.drainHookSpoolRecordsUntil(ctx, pending+requeued)
 		if result.Err != nil {
 			return doctorFixResult{}, result.Err
 		}

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -230,6 +230,32 @@ func TestHookSpoolDrainAllowance(t *testing.T) {
 	}
 }
 
+func TestHookSpoolBacklogDrainLimit(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		pending   int
+		remaining time.Duration
+		want      int
+	}{
+		{name: "reserve wins over backlog", pending: 3000, remaining: 2 * time.Second, want: 0},
+		{name: "low headroom stays 1", pending: 3000, remaining: 3 * time.Second, want: 1},
+		{name: "empty backlog uses minimum batch", pending: 0, remaining: 8 * time.Second, want: hookSpoolReplayBatchLimit},
+		{name: "small backlog uses minimum batch", pending: 5, remaining: 8 * time.Second, want: hookSpoolReplayBatchLimit},
+		{name: "500 pending still minimum", pending: 500, remaining: 8 * time.Second, want: hookSpoolReplayBatchLimit},
+		{name: "3000 pending scales to 30", pending: 3000, remaining: 8 * time.Second, want: 30},
+		{name: "huge backlog hits cap", pending: 10000, remaining: 8 * time.Second, want: hookSpoolReplayBacklogCap},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hookSpoolBacklogDrainLimit(tc.pending, tc.remaining); got != tc.want {
+				t.Fatalf("hookSpoolBacklogDrainLimit(%d, %v) = %d, want %d", tc.pending, tc.remaining, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHookSpoolDrainRemaining_NoDeadlineUsesPackagedBudget(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
@@ -973,6 +999,40 @@ func TestInspectHookSpoolDiagnostics_FixFuncDrains(t *testing.T) {
 	}
 	if len(records) != 0 {
 		t.Fatalf("after doctor --fix, remaining=%d", len(records))
+	}
+}
+
+func TestDrainHookSpoolRecordsUntil_LoopsPastRoundLimit(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	eventStub := &spoolEventUsecaseStub{}
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+	total := hookSpoolDoctorDrainRoundLimit + 5
+	base := time.Now().UTC().Add(-time.Minute)
+	for i := 0; i < total; i++ {
+		record := hookSpoolRecord{
+			SchemaVersion: hookSpoolSchemaVersion,
+			Command:       "prompt",
+			Client:        "claude",
+			Payload:       fmt.Sprintf(`{"prompt":"until-%d","session_id":"s-%d","cwd":"/tmp"}`, i, i),
+			CreatedAt:     base.Add(time.Duration(i) * time.Millisecond),
+		}
+		if _, err := persistHookSpoolRecord(record); err != nil {
+			t.Fatalf("persist %d: %v", i, err)
+		}
+	}
+	result := root.drainHookSpoolRecordsUntil(context.Background(), total)
+	if result.Err != nil {
+		t.Fatalf("until: %v", result.Err)
+	}
+	if result.Replayed != total {
+		t.Fatalf("replayed=%d remaining=%d, want %d", result.Replayed, result.Remaining, total)
+	}
+	if eventStub.logCalls != total {
+		t.Fatalf("logCalls=%d, want %d", eventStub.logCalls, total)
 	}
 }
 


### PR DESCRIPTION
## 概要
Closes #2151

Leaves parent #2188 open.

## 変更内容
- Follow-up hooks: backlog-proportional opportunistic drain (min 5, cap 32) while keeping the 0/1 host time-reserve bands.
- `doctor --fix`: drain pending records in 200-record rounds until the existing 45s wall or no successful replay remains.
- Debug log includes `pending` and `drained`. Doctor counter keys unchanged.

## テスト確認
- [x] `go test ./presentation/cli/`
- [x] `go tool golangci-lint run`
- [x] `go build ./...`