### PR TITLE
Auto-resolve Claude SessionEnd cancellation markers via doctor --fix

### DIFF
--- a/.ai/spec/2153.md
+++ b/.ai/spec/2153.md
@@ -1,0 +1,67 @@
+# Issue 2153: doctor --fix auto-resolves Claude SessionEnd cancellation markers
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — doctor WARN/fix contract; marker GC; large-store metadata-only must not grow SQLite opens.
+
+### Requirement summary
+- 目的: 未解決 Claude SessionEnd cancellation marker を、他の hook residue と同じく `doctor --fix` で bounded に片付けられるようにする。
+- 現状: 同一ストアで session が ended なら Resolved として `--fix` 済み。しかし (1) ≥2GiB の metadata-only doctor は lookup を nil にし ended 判定しない、(2) 同一 session の複数 marker は全部 unresolved、(3) un-ended marker は何歳でも残る、(4) WARN hint は手動削除のみ。
+- 期待する振る舞い:
+  - 同一ストアで `sessions.ended_at` がある marker は `--fix` で消える（ended は session ID が再利用されないため “later terminal state” と同義。ended_at が marker より前でも terminal residue）。
+  - 同一 session_id の複数 marker は newest だけ WARN 対象。古い duplicate は `--fix` 対象。
+  - `hookSpoolDeadRetention`（14d）より古い marker は un-ended / unknown でも `--fix` で GC。
+  - 14d 未満で未終了の newest marker は WARN のまま。
+  - HINT に `doctor --fix` の自動パスを書く。JSON フィールド名は不変。
+- 非対象: large-store doctor への追加 SQLite open（既存 O(1) page metadata 以外）。`sqliteBusyTimeout`。live home store。parent #2188 close。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Marker | started file under diagnostics/ | evidence SessionEnd did not finish | never delete in-flight write; 0-byte skipped |
+| Resolved | same db_path + session ended | `--fix` unlinks | lookup only when sessions != nil |
+| Duplicate | older same session_id | `--fix` unlinks; newest kept | empty session_id cannot dedupe |
+| Ancient | StartedAt < now-14d | `--fix` unlinks even if un-ended | 14d = dead-letter retention |
+| Actionable remaining | newest, same store, not ended, not ancient | WARN, no auto-delete | hint names --fix for the other classes |
+| Unknown store | other/missing db_path | not actionable; aged 14d GC | filesystem path still GC/dedupe |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Classify same-store vs unknown vs ended | `classifyHookCancellationDiagnostics` | keep | do not open SQLite from filesystem inspect |
+| Dedupe / 14d GC set | new pure helpers on scanned records | testable without I/O | begin-time cap/window GC stays 7d/20 |
+| `--fix` unlink | existing `resolvedHookCancellationDiagnosticFix` (generalized copy) | same unlink | do not Initialize store |
+| Large-store inspect | `inspectClaudeHookCancellationDiagnosticsFilesystem` | still nil lookup | no extra SELECT |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `hookDiagnosticSessionLookup` | full doctor only | FindEndedSessionIDs | wrap; fail the check |
+| `hookCancellationDiagnosticCleanupRecords(...)` | inspect | resolved ∪ duplicates ∪ ancient | paths unique |
+| doctor JSON | CLI | message/hint text may gain one sentence | field names unchanged |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Ended session | same-store marker, lookup returns id | inspect + --fix | marker gone | unit + doctor CLI |
+| Duplicate | 3 markers same session, un-ended | inspect | unresolved=1; --fix removes 2 older; newest remains | unit |
+| Ancient | 15d un-ended newest | inspect --fix | removed; no remaining actionable | unit + CLI |
+| Genuine | 1d un-ended newest | inspect --fix | file remains; WARN | unit |
+| Hint | actionable remaining | inspect | hint contains doctor --fix | CLI substring |
+| Unknown 15d | other db_path, 15d | --fix | removed (update 8d fixture) | CLI |
+| Filesystem | lookup nil, 3 dupes | inspect | still dedupes; none classified resolved | unit |
+
+### TDD plan
+| Behavior | Red | Green | Refactor |
+|---|---|---|---|
+| Dedupe helper | table newest-first | pure fn | |
+| 14d cutoff | 15d vs 1d | use hookSpoolDeadRetention | |
+| inspect remaining vs fix set | fixture files | inspectWithLookup | |
+| doctor --fix CLI | ended + dupe + ancient + genuine | executeDoctorJSON | |
+
+### Risks / rollback
+- 手続き化: inspect 関数をさらに長くしない。cleanup set を pure helper に出す。
+- large-store: extra SQLite は入れない。ended 解決は full doctor。13G では 14d+dedupe のみ（既存契約）。
+- rollback: revert PR; markers are files.
+
+PR: `Closes #2153`; Leaves parent #2188 open.

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -941,6 +941,9 @@ func TestRootCLI_DoctorCommand_ClaudeHookCancellationDiagnostics(t *testing.T) {
 		if check.Hint == "" || !strings.Contains(check.Hint, "Traceary reached Claude SessionEnd") {
 			t.Fatalf("claude-hook-cancellations hint = %q, want actionable cancellation hint", check.Hint)
 		}
+		if !strings.Contains(check.Hint, "doctor --fix") {
+			t.Fatalf("claude-hook-cancellations hint = %q, want automatic doctor --fix path", check.Hint)
+		}
 	})
 
 	t.Run("marker from another store is unknown, not actionable", func(t *testing.T) {
@@ -1021,7 +1024,7 @@ func TestRootCLI_DoctorCommand_ClaudeHookCancellationDiagnostics(t *testing.T) {
   "status": "started",
   "started_at": %q
 }
-`, time.Now().UTC().Add(-8*24*time.Hour).Format(time.RFC3339Nano))
+`, time.Now().UTC().Add(-15*24*time.Hour).Format(time.RFC3339Nano))
 		agedPath := filepath.Join(diagnosticsDir, "claude-SessionEnd-aged-unknown.json")
 		if err := os.WriteFile(agedPath, []byte(agedUnknown), 0o600); err != nil {
 			t.Fatalf("WriteFile(aged unknown marker) error = %v", err)

--- a/presentation/cli/hook_diagnostics.go
+++ b/presentation/cli/hook_diagnostics.go
@@ -31,9 +31,12 @@ const (
 	hookCancellationDiagnosticPhaseStoreInitialized  = "store_initialized"
 
 	// hookCancellationDiagnosticRetentionWindow bounds how long a marker for a
-	// given (client, host_event) stays eligible for begin-time GC and how old
-	// an Unknown-store marker must be before `doctor --fix` removes it.
+	// given (client, host_event) stays eligible for begin-time GC.
 	hookCancellationDiagnosticRetentionWindow = 7 * 24 * time.Hour
+	// hookCancellationDiagnosticDoctorRetention is how old a marker must be
+	// before doctor --fix GCs it even when the session is still open or the
+	// store affinity is unknown. Aligned with dead-letter prune (#2153).
+	hookCancellationDiagnosticDoctorRetention = hookSpoolDeadRetention
 	// hookCancellationDiagnosticRetentionCap bounds how many markers for a
 	// given (client, host_event) survive begin-time GC regardless of age, so
 	// the diagnostics directory cannot grow unbounded even under a tight
@@ -134,8 +137,10 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsWithLookup(ctx context
 		}
 	}
 
-	agedUnknown := agedHookCancellationDiagnostics(classification.Unknown, time.Now().UTC().Add(-hookCancellationDiagnosticRetentionWindow))
-	fixRecords := append(append([]hookCancellationDiagnostic{}, classification.Resolved...), agedUnknown...)
+	now := time.Now().UTC()
+	fixRecords := hookCancellationDiagnosticCleanupRecords(classification, now)
+	remainingActionable := excludeHookCancellationDiagnostics(classification.Actionable, fixRecords)
+	agedUnknown := agedHookCancellationDiagnostics(classification.Unknown, now.Add(-hookCancellationDiagnosticDoctorRetention))
 	fixCommand := ""
 	var fix doctorFixFunc
 	if len(fixRecords) > 0 {
@@ -143,19 +148,25 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsWithLookup(ctx context
 		fix = resolvedHookCancellationDiagnosticFix(fixRecords)
 	}
 
-	if len(classification.Actionable) == 0 {
+	if len(remainingActionable) == 0 {
 		if len(fixRecords) > 0 {
+			duplicateOrAged := len(fixRecords) - len(classification.Resolved) - len(agedUnknown)
+			if duplicateOrAged < 0 {
+				duplicateOrAged = 0
+			}
 			return doctorCheck{
 				Name:   checkName,
 				Status: doctorStatusWarn,
 				Hint: Localize(
-					"the referenced sessions have ended, or the markers reference another store and have aged past the retention window; preview the safe marker cleanup with the fix command",
-					"参照先 session は終了済みか、marker が別ストアを参照したまま retention window を超えています。fix command で安全な marker cleanup を preview してください",
+					"the referenced sessions have ended, older duplicate markers were kept, or the markers have aged past the 14-day retention window; preview the safe marker cleanup with the fix command",
+					"参照先 session は終了済みか、同一 session の古い duplicate、または 14 日の retention window を超えた marker です。fix command で安全な marker cleanup を preview してください",
 				),
 				Message: localizef(
-					"found %d resolved and %d aged unknown-store Claude SessionEnd hook cancellation diagnostic(s) eligible for cleanup%s",
-					"cleanup 可能な解決済み Claude SessionEnd hook cancellation diagnostic が %d 件、別ストア参照で retention window を超えた marker が %d 件あります%s",
+					"found %d Claude SessionEnd hook cancellation diagnostic(s) eligible for cleanup (resolved=%d, duplicate_or_aged=%d, aged_unknown=%d)%s",
+					"cleanup 可能な Claude SessionEnd hook cancellation diagnostic が %d 件あります (resolved=%d, duplicate_or_aged=%d, aged_unknown=%d)%s",
+					len(fixRecords),
 					len(classification.Resolved),
+					duplicateOrAged,
 					len(agedUnknown),
 					formatUnreadableHookDiagnosticsSuffix(scan.Unreadable),
 				),
@@ -195,18 +206,18 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsWithLookup(ctx context
 		}
 	}
 
-	latest := classification.Actionable[0]
+	latest := remainingActionable[0]
 	check := doctorCheck{
 		Name:   checkName,
 		Status: doctorStatusWarn,
 		Hint: Localize(
-			"the marker means Traceary reached Claude SessionEnd but did not complete cleanly; inspect the file and recent `traceary list --agent claude` output, then remove the marker after confirming it is stale. If Claude cancels before Traceary starts, no marker can be written.",
-			"この marker は Traceary が Claude SessionEnd まで到達したものの正常完了していないことを示します。file と最近の `traceary list --agent claude` を確認し、stale と判断できたら marker を削除してください。Claude が Traceary 起動前に cancel した場合、marker は書けません。",
+			"the marker means Traceary reached Claude SessionEnd but did not complete cleanly; inspect the file and recent `traceary list --agent claude` output. `traceary doctor --fix` removes markers whose sessions later ended, older duplicate markers for the same session, and markers older than 14 days. Remove any remaining marker after confirming it is stale. If Claude cancels before Traceary starts, no marker can be written.",
+			"この marker は Traceary が Claude SessionEnd まで到達したものの正常完了していないことを示します。file と最近の `traceary list --agent claude` を確認してください。`traceary doctor --fix` は後から終了した session の marker、同一 session の古い duplicate、14 日を超えた marker を削除します。残った marker は stale と判断できたら削除してください。Claude が Traceary 起動前に cancel した場合、marker は書けません。",
 		),
 		Message: localizef(
 			"found %d unresolved Claude SessionEnd hook cancellation diagnostic(s), %d resolved, %d unknown-store; latest phase=%s host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
 			"未解決の Claude SessionEnd hook cancellation diagnostic が %d 件、解決済みが %d 件、ストア不明が %d 件あります。latest phase=%s host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
-			len(classification.Actionable),
+			len(remainingActionable),
 			len(classification.Resolved),
 			len(classification.Unknown),
 			emptyAsDash(latest.Phase),
@@ -300,15 +311,91 @@ func resolvedHookCancellationDiagnosticFix(records []hookCancellationDiagnostic)
 	}
 	return func(_ context.Context, dryRun bool) (string, error) {
 		if dryRun {
-			return fmt.Sprintf("would remove %d resolved Claude SessionEnd hook cancellation diagnostic(s)", len(paths)), nil
+			return fmt.Sprintf("would remove %d Claude SessionEnd hook cancellation diagnostic(s)", len(paths)), nil
 		}
 		for _, path := range paths {
 			if err := clearHookCancellationDiagnostic(path); err != nil {
 				return "", err
 			}
 		}
-		return fmt.Sprintf("removed %d resolved Claude SessionEnd hook cancellation diagnostic(s)", len(paths)), nil
+		return fmt.Sprintf("removed %d Claude SessionEnd hook cancellation diagnostic(s)", len(paths)), nil
 	}
+}
+
+// olderDuplicateHookCancellationDiagnostics returns older markers that share a
+// session_id with a newer marker. Empty session IDs cannot be deduped.
+func olderDuplicateHookCancellationDiagnostics(records []hookCancellationDiagnostic) []hookCancellationDiagnostic {
+	sorted := append([]hookCancellationDiagnostic{}, records...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if !sorted[i].StartedAt.Equal(sorted[j].StartedAt) {
+			return sorted[i].StartedAt.After(sorted[j].StartedAt)
+		}
+		return sorted[i].Path < sorted[j].Path
+	})
+	seen := make(map[string]struct{}, len(sorted))
+	older := make([]hookCancellationDiagnostic, 0)
+	for _, record := range sorted {
+		id := strings.TrimSpace(record.SessionID)
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			older = append(older, record)
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+	return older
+}
+
+func uniqueHookCancellationDiagnosticsByPath(groups ...[]hookCancellationDiagnostic) []hookCancellationDiagnostic {
+	seen := map[string]struct{}{}
+	out := make([]hookCancellationDiagnostic, 0)
+	for _, group := range groups {
+		for _, record := range group {
+			path := strings.TrimSpace(record.Path)
+			if path == "" {
+				continue
+			}
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			out = append(out, record)
+		}
+	}
+	return out
+}
+
+func excludeHookCancellationDiagnostics(records, excluded []hookCancellationDiagnostic) []hookCancellationDiagnostic {
+	skip := make(map[string]struct{}, len(excluded))
+	for _, record := range excluded {
+		skip[strings.TrimSpace(record.Path)] = struct{}{}
+	}
+	out := make([]hookCancellationDiagnostic, 0, len(records))
+	for _, record := range records {
+		if _, ok := skip[strings.TrimSpace(record.Path)]; ok {
+			continue
+		}
+		out = append(out, record)
+	}
+	return out
+}
+
+// hookCancellationDiagnosticCleanupRecords is the --fix set: ended sessions,
+// older per-session duplicates, and markers older than the 14-day window.
+func hookCancellationDiagnosticCleanupRecords(
+	classification hookCancellationDiagnosticClassification,
+	now time.Time,
+) []hookCancellationDiagnostic {
+	cutoff := now.Add(-hookCancellationDiagnosticDoctorRetention)
+	sameStore := append(append([]hookCancellationDiagnostic{}, classification.Actionable...), classification.Resolved...)
+	return uniqueHookCancellationDiagnosticsByPath(
+		classification.Resolved,
+		olderDuplicateHookCancellationDiagnostics(sameStore),
+		agedHookCancellationDiagnostics(classification.Actionable, cutoff),
+		agedHookCancellationDiagnostics(classification.Unknown, cutoff),
+	)
 }
 
 func beginHookCancellationDiagnostic(client, hostEvent, hookCommand string, sessionID types.SessionID, workspace types.Workspace, dbPath string) (string, error) {

--- a/presentation/cli/hook_diagnostics_test.go
+++ b/presentation/cli/hook_diagnostics_test.go
@@ -122,7 +122,7 @@ func TestResolvedHookCancellationDiagnosticFix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dry-run fix error = %v", err)
 	}
-	if action != "would remove 1 resolved Claude SessionEnd hook cancellation diagnostic(s)" {
+	if action != "would remove 1 Claude SessionEnd hook cancellation diagnostic(s)" {
 		t.Fatalf("dry-run action = %q", action)
 	}
 	if _, err := os.Stat(path); err != nil {
@@ -133,11 +133,157 @@ func TestResolvedHookCancellationDiagnosticFix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply fix error = %v", err)
 	}
-	if action != "removed 1 resolved Claude SessionEnd hook cancellation diagnostic(s)" {
+	if action != "removed 1 Claude SessionEnd hook cancellation diagnostic(s)" {
 		t.Fatalf("apply action = %q", action)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("marker still exists after apply: %v", err)
+	}
+}
+
+func TestOlderDuplicateHookCancellationDiagnostics(t *testing.T) {
+	t.Parallel()
+	newer := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	records := []hookCancellationDiagnostic{
+		{Path: "old.json", SessionID: "same", StartedAt: newer.Add(-48 * time.Hour)},
+		{Path: "newest.json", SessionID: "same", StartedAt: newer},
+		{Path: "mid.json", SessionID: "same", StartedAt: newer.Add(-time.Hour)},
+		{Path: "other.json", SessionID: "other", StartedAt: newer.Add(-time.Hour)},
+		{Path: "empty.json", SessionID: "", StartedAt: newer.Add(-time.Hour)},
+	}
+	got := olderDuplicateHookCancellationDiagnostics(records)
+	if diff := cmp.Diff([]string{"mid.json", "old.json"}, diagnosticPaths(got)); diff != "" {
+		t.Fatalf("older duplicate paths mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestHookCancellationDiagnosticCleanupRecords(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	classification := hookCancellationDiagnosticClassification{
+		Actionable: []hookCancellationDiagnostic{
+			{Path: "newest-open.json", SessionID: "open", StartedAt: now.Add(-time.Hour)},
+			{Path: "older-open.json", SessionID: "open", StartedAt: now.Add(-2 * time.Hour)},
+			{Path: "ancient-open.json", SessionID: "ancient", StartedAt: now.Add(-hookCancellationDiagnosticDoctorRetention - time.Hour)},
+		},
+		Resolved: []hookCancellationDiagnostic{
+			{Path: "ended.json", SessionID: "ended", StartedAt: now.Add(-time.Hour)},
+		},
+		Unknown: []hookCancellationDiagnostic{
+			{Path: "fresh-unknown.json", SessionID: "other-store", StartedAt: now.Add(-time.Hour)},
+			{Path: "aged-unknown.json", SessionID: "other-store-old", StartedAt: now.Add(-hookCancellationDiagnosticDoctorRetention - time.Hour)},
+		},
+	}
+	got := hookCancellationDiagnosticCleanupRecords(classification, now)
+	if diff := cmp.Diff([]string{"ended.json", "older-open.json", "ancient-open.json", "aged-unknown.json"}, diagnosticPaths(got)); diff != "" {
+		t.Fatalf("cleanup paths mismatch (-want +got):\n%s", diff)
+	}
+	remaining := excludeHookCancellationDiagnostics(classification.Actionable, got)
+	if diff := cmp.Diff([]string{"newest-open.json"}, diagnosticPaths(remaining)); diff != "" {
+		t.Fatalf("remaining actionable mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestInspectClaudeHookCancellationDiagnostics_FixEndedDuplicatesAndAncient(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	diagDir := filepath.Join(stateDir, hookDiagnosticsDirName)
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	const dbPath = "/store/current.db"
+	write := func(name, sessionID string, startedAt time.Time) string {
+		path := filepath.Join(diagDir, name)
+		writeHookCancellationDiagnosticForTest(t, path, hookCancellationDiagnostic{
+			SchemaVersion: hookCancellationDiagnosticSchemaVersion,
+			Client:        "claude",
+			HostEvent:     "SessionEnd",
+			HookCommand:   "cmd",
+			SessionID:     sessionID,
+			DBPath:        dbPath,
+			Status:        hookCancellationDiagnosticStatusStarted,
+			StartedAt:     startedAt,
+		})
+		return path
+	}
+	endedPath := write("ended.json", "ended-session", now.Add(-2*time.Hour))
+	newestOpen := write("open-new.json", "open-session", now.Add(-time.Hour))
+	olderOpen := write("open-old.json", "open-session", now.Add(-3*time.Hour))
+	ancientPath := write("ancient.json", "ancient-session", now.Add(-hookCancellationDiagnosticDoctorRetention-time.Hour))
+	genuinePath := newestOpen
+
+	lookup := &hookDiagnosticSessionLookupStub{ended: map[types.SessionID]struct{}{"ended-session": {}}}
+	root := &RootCLI{}
+	check := root.inspectClaudeHookCancellationDiagnosticsWithLookup(context.Background(), dbPath, "", lookup)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q message=%q", check.Status, check.Message)
+	}
+	if !strings.Contains(check.Hint, "doctor --fix") {
+		t.Fatalf("hint %q, want doctor --fix automatic path", check.Hint)
+	}
+	if !strings.Contains(check.Message, "found 1 unresolved") {
+		t.Fatalf("message %q, want 1 unresolved remaining", check.Message)
+	}
+	if !check.AutoFixAvailable || check.FixFunc == nil {
+		t.Fatalf("expected auto-fix: %+v", check)
+	}
+
+	action, err := check.FixFunc(context.Background(), true)
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if !strings.Contains(action, "would remove 3") {
+		t.Fatalf("dry-run action=%q, want 3 removals", action)
+	}
+	for _, path := range []string{endedPath, olderOpen, ancientPath, genuinePath} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("dry-run removed %s: %v", path, err)
+		}
+	}
+
+	if _, err := check.FixFunc(context.Background(), false); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(genuinePath); err != nil {
+		t.Fatalf("genuine un-ended newest marker must remain: %v", err)
+	}
+	for _, path := range []string{endedPath, olderOpen, ancientPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s survived --fix: err=%v", path, err)
+		}
+	}
+}
+
+func TestInspectClaudeHookCancellationDiagnosticsFilesystem_DedupesWithoutLookup(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	diagDir := filepath.Join(stateDir, hookDiagnosticsDirName)
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	const dbPath = "/store/current.db"
+	for i, age := range []time.Duration{time.Hour, 2 * time.Hour, 3 * time.Hour} {
+		writeHookCancellationDiagnosticForTest(t, filepath.Join(diagDir, fmt.Sprintf("dup-%d.json", i)), hookCancellationDiagnostic{
+			SchemaVersion: hookCancellationDiagnosticSchemaVersion,
+			Client:        "claude",
+			HostEvent:     "SessionEnd",
+			SessionID:     "same-session",
+			DBPath:        dbPath,
+			Status:        hookCancellationDiagnosticStatusStarted,
+			StartedAt:     now.Add(-age),
+		})
+	}
+	root := &RootCLI{}
+	check := root.inspectClaudeHookCancellationDiagnosticsFilesystem(context.Background(), dbPath, "")
+	if !strings.Contains(check.Message, "found 1 unresolved") {
+		t.Fatalf("filesystem inspect must dedupe without SQLite lookup: %q", check.Message)
+	}
+	if !check.AutoFixAvailable {
+		t.Fatalf("older duplicates must still be auto-fixable without session lookup")
 	}
 }
 


### PR DESCRIPTION
## 概要
Closes #2153

Leaves parent #2188 open.

## 変更内容
- `doctor --fix` removes Claude SessionEnd cancellation markers whose sessions later ended (existing same-store lookup).
- Per-session dedupe keeps the newest marker; older duplicates are cleanup-eligible even without a store lookup (large-store metadata-only path included).
- Markers older than 14 days (`hookSpoolDeadRetention`) are GC'd, including un-ended and unknown-store markers.
- WARN hint names the automatic `doctor --fix` path. JSON field names unchanged.
- Large-store doctor still does not open SQLite for this check.

## テスト確認
- [x] `go test ./...`
- [x] `go tool golangci-lint run`
- [x] `go build ./...`