### PR TITLE
fix: doctor WARN for stale binaries and retired mcp-server processes

### DIFF
--- a/.ai/spec/2155.md
+++ b/.ai/spec/2155.md
@@ -1,0 +1,31 @@
+# #2155 Doctor stale Traceary processes
+
+Parent: #2188. Closes only #2155.
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Purpose: `traceary doctor` WARNs on long-running processes whose executable is a Traceary binary with a version different from the running one, or a retired `mcp-server` surface. Metadata-only (ps-level), bounded, silent PASS when none.
+- Docs: `docs/release/post-upgrade-plugins.md` (+ ja) gains a "stale processes" section.
+- Out: auto-kill, `--fix` reap, changing existing doctor JSON keys, pointing a repo-built binary at the live home store.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint |
+|---|---|---|---|
+| Process snapshot | pid, exe, argv, startedAt | listed from OS; never exec the target | scan cap 4096; report cap 8 |
+| Stale binary | version ≠ running, or different inode with unknown version | WARN pid+version+age | version from Cellar path or `debug/buildinfo.ReadFile` |
+| Retired MCP | argv token `mcp-server` | WARN even on current version | MCP removed in v0.35 |
+| Healthy | same version or same file, not mcp-server | not listed | skip self PID |
+
+### Responsibility
+- Listing: OS adapter (`ps` on Darwin, `/proc` on Linux).
+- Classification: pure function on snapshots + current version/exe/pid.
+- Doctor wiring: Environment check `stale-processes`, store-independent, after `path`, both large-store and full doctor.
+
+### Behavior tests
+- Empty list → PASS.
+- Synthetic 0.33.0 pid → WARN includes pid and version.
+- Current-version `mcp-server` → WARN.
+- Same current exe, not mcp → PASS.
+- Shipped `doctor --json` sees the check.
+- List error → WARN, not FAIL.

--- a/docs/release/post-upgrade-plugins.ja.md
+++ b/docs/release/post-upgrade-plugins.ja.md
@@ -44,6 +44,21 @@ release 済みバイナリを更新するたびに、次を実行してくださ
 
 doctor が正確な非対話コマンドを `FixCommand` に出す場合は、そちらを優先してください。ホスト CLI のフラグを推測で追加してはいけません。
 
+## 古いプロセス
+
+Homebrew / `go install` の更新は PATH 上のバイナリを置き換えますが、**すでに動いているプロセスは古い実行ファイルのまま**です。2026-08-18 の dogfood では、置き換わった Cellar バイナリ（0.32–0.34）上の `traceary mcp-server` が長時間残っていました。MCP は v0.35.0 で引退しており、これらのプロセスは store-lease プロトコルより前のものです。stale なホスト session が compact 中にそれらへリクエストすると、排他制御なしで書き込めます。
+
+`traceary doctor` はこれを `stale-processes` チェックとして報告します（store-independent、ps-level）。pid・version・age と reap 案内付きの WARN で、該当がなければ黙って PASS します。plugin-cache の WARN は **live process を対象にしません**。
+
+バイナリを更新するたびに:
+
+1. `traceary doctor --json` を実行し、`stale-processes` を確認する。
+2. 各 pid を起動したホスト session を終了し、store lease なしの書き込みを止める。
+3. `ps -p <pid>` で確認し、未使用なら `kill <pid>`。
+4. 残っている `mcp-server` エントリを host config から削除する。[MCP の引退](../mcp/README.ja.md) を参照。
+
+plugin-version が `pass` でも、古いバイナリのプロセスが残っていない証明にはなりません。
+
 ## Gemini managed hook generation の更新
 
 `./scripts/install-gemini-extension.sh` は `~/.gemini/extensions/traceary/` 内の extension パッケージを入れ直します（uninstall のあと `install --consent`、実行中 CLI の tag に pin）。`~/.gemini/settings.json` 内にすでに存在する Traceary 管理の hook エントリは**書き換えません**。それらのエントリは古い hook generation によって書かれたものであり、timeout が古い値のまま残ることがあります（例: 現行の 10000 ms に対して 5000 ms）。Doctor はこれを `gemini-config=warn` として `installed=…ms desired=…ms` のドリフトメッセージと共に報告します。

--- a/docs/release/post-upgrade-plugins.md
+++ b/docs/release/post-upgrade-plugins.md
@@ -44,6 +44,21 @@ After every released binary upgrade:
 
 Prefer the `FixCommand` printed by doctor when it provides an exact non-interactive command. Do not invent host CLI flags.
 
+## Stale processes
+
+Homebrew / `go install` upgrades replace the on-PATH binary, but **already-running processes keep the old executable**. The 2026-08-18 dogfood found long-lived `traceary mcp-server` processes on superseded Cellar binaries (0.32–0.34). MCP was retired in v0.35.0; those processes predate the store-lease protocol, so a stale host session that talks to them mid-compact can write without exclusive access.
+
+`traceary doctor` reports this as the `stale-processes` check (store-independent, ps-level). It WARNs with pid, version, age, and reap guidance, and PASSes silently when none are running. Plugin-cache WARNs do **not** cover live processes.
+
+After every binary upgrade:
+
+1. Run `traceary doctor --json` and inspect `stale-processes`.
+2. Quit the host session that launched each pid so it cannot write without a store lease.
+3. Confirm with `ps -p <pid>`, then `kill <pid>` only if the process is unused.
+4. Remove leftover `mcp-server` entries from host config. See [MCP retirement](../mcp/README.md).
+
+Do not treat a `pass` plugin-version check as proof that no stale binaries are still running.
+
 ## Gemini managed hook generation refresh
 
 `./scripts/install-gemini-extension.sh` replaces the extension package in

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -369,6 +369,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		report.Checks = append(report.Checks, c.inspectCompactInFlight(resolvedDBPath, time.Now()))
 		report.Checks = append(report.Checks, buildOperatorCostCheck(residentCost))
 		report.Checks = append(report.Checks, inspectTracearyOnPath())
+		report.Checks = append(report.Checks, inspectStaleTracearyProcesses(input.currentVersion, time.Now()))
 		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(snapshot, resolvedDBPath, pageErr == nil))
 		report.Checks = append(report.Checks, largeStoreProjectionGenerationCheck(pageMeta, pageErr))
 		if c.attestationAnchorInspector != nil {
@@ -413,6 +414,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 	}
 	report.Checks = append(report.Checks, c.inspectStoreGrowthBudget(ctx, resolvedDBPath, snapshot)...)
 	report.Checks = append(report.Checks, inspectTracearyOnPath())
+	report.Checks = append(report.Checks, inspectStaleTracearyProcesses(input.currentVersion, time.Now()))
 
 	report.Checks = append(report.Checks, inspectDoctorConfig())
 

--- a/presentation/cli/doctor_report.go
+++ b/presentation/cli/doctor_report.go
@@ -140,7 +140,7 @@ func doctorSectionNameForCheck(name string) string {
 	switch {
 	case name == "db-path" || name == "db-write" || name == "store-capacity" || name == "search-projection-budget" || name == "search-projection-parked" || name == "search-projection-generation" || name == "stale-active-sessions" || name == "archive-retention" || name == "offline-migrations" || name == "workspace-aliases" || strings.HasSuffix(name, "-capacity-retention") || name == "audit-reliability" || name == "content-event-reliability" || name == "sensitive-access-audit" || name == "retry-loops" || name == "body-codec":
 		return "Database"
-	case name == "config" || name == "project-dir" || name == "version" || name == "path":
+	case name == "config" || name == "project-dir" || name == "version" || name == "path" || name == "stale-processes":
 		return "Environment"
 	case strings.Contains(name, "plugin"):
 		return "Plugins"

--- a/presentation/cli/doctor_scope.go
+++ b/presentation/cli/doctor_scope.go
@@ -13,7 +13,7 @@ func doctorDBPathWasExplicit(flagPath string) bool {
 
 func doctorCheckIsStoreIndependent(name string) bool {
 	switch strings.TrimSpace(name) {
-	case "path", "config", "version", "project-dir",
+	case "path", "config", "version", "project-dir", "stale-processes",
 		"hook-spool", "hook-state-residue", "hook-memory-extract", "hook-grok-transcript",
 		"claude-hook-cancellations", "claude-plugin-cache":
 		return true

--- a/presentation/cli/doctor_stale_processes.go
+++ b/presentation/cli/doctor_stale_processes.go
@@ -34,6 +34,11 @@ type tracearyProcessSnapshot struct {
 	Executable string
 	Args       []string
 	StartedAt  time.Time
+	// Unlinked is true when the kernel still runs an inode that is no
+	// longer at Executable (Linux `/proc/<pid>/exe` ends with
+	// " (deleted)"). The path then names a replacement file — version
+	// and same-file checks against it would inspect the new binary.
+	Unlinked bool
 }
 
 type staleTracearyProcessFinding struct {
@@ -106,8 +111,11 @@ func classifyStaleTracearyProcesses(snapshots []tracearyProcessSnapshot, current
 			exe = snapshot.Args[0]
 		}
 		retired := processInvokesRetiredMCPServer(snapshot.Args)
-		sameRunningBinary := currentExe != "" && exe != "" && sameFile(exe, currentExe)
+		sameRunningBinary := !snapshot.Unlinked && currentExe != "" && exe != "" && sameFile(exe, currentExe)
 		version := inspectTracearyProcessVersion(exe, currentVersion, sameRunningBinary)
+		if snapshot.Unlinked {
+			version = ""
+		}
 		if !retired && (sameRunningBinary || versionsMatch(version, current)) {
 			continue
 		}
@@ -353,7 +361,7 @@ func listTracearyProcessSnapshotsLinux() ([]tracearyProcessSnapshot, error) {
 		if argsErr != nil || len(args) == 0 {
 			continue
 		}
-		exe := linuxProcExecutable(pid, args[0])
+		exe, unlinked := linuxProcExecutable(pid, args[0])
 		if !looksLikeTracearyExecutable(exe) && !looksLikeTracearyExecutable(args[0]) && !processInvokesRetiredMCPServer(args) {
 			continue
 		}
@@ -368,6 +376,7 @@ func listTracearyProcessSnapshotsLinux() ([]tracearyProcessSnapshot, error) {
 			Executable: exe,
 			Args:       args,
 			StartedAt:  startedAt,
+			Unlinked:   unlinked,
 		})
 	}
 	return snapshots, nil
@@ -392,13 +401,14 @@ func readProcCmdline(pid int) ([]string, error) {
 	return args, nil
 }
 
-func linuxProcExecutable(pid int, argv0 string) string {
+func linuxProcExecutable(pid int, argv0 string) (string, bool) {
 	target, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "exe"))
 	if err != nil {
-		return argv0
+		return argv0, false
 	}
+	unlinked := strings.HasSuffix(target, " (deleted)")
 	target = strings.TrimSuffix(target, " (deleted)")
-	return target
+	return target, unlinked
 }
 
 func linuxBootTime(now time.Time) (time.Time, error) {

--- a/presentation/cli/doctor_stale_processes.go
+++ b/presentation/cli/doctor_stale_processes.go
@@ -1,0 +1,439 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"debug/buildinfo"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	doctorStaleProcessesCheckName = "stale-processes"
+	doctorStaleProcessScanLimit   = 4096
+	doctorStaleProcessReportLimit = 8
+	doctorStaleProcessListTimeout = 2 * time.Second
+	doctorRetiredMCPServerCommand = "mcp-server"
+	linuxProcClockTicksPerSecond  = 100
+	linuxProcStatStartTimeField   = 20
+)
+
+var cellarTracearyVersionPattern = regexp.MustCompile(`(?i)[/\\]Cellar[/\\]traceary[/\\]([^/\\]+)[/\\]`)
+
+type tracearyProcessSnapshot struct {
+	PID        int
+	Executable string
+	Args       []string
+	StartedAt  time.Time
+}
+
+type staleTracearyProcessFinding struct {
+	PID     int
+	Version string
+	Age     string
+	Reason  string
+	Exe     string
+}
+
+func inspectStaleTracearyProcesses(currentVersion string, now time.Time) doctorCheck {
+	check := doctorCheck{Name: doctorStaleProcessesCheckName}
+	snapshots, err := listTracearyProcessSnapshotsFunc()
+	if err != nil {
+		check.Status = doctorStatusWarn
+		check.Message = localizef("failed to enumerate Traceary processes: %v", "Traceary プロセスの列挙に失敗しました: %v", err)
+		check.Hint = Localize("rerun doctor after confirming `ps` (macOS) or /proc (Linux) is readable", "macOS では `ps`、Linux では /proc が読めることを確認して doctor を再実行してください")
+		return check
+	}
+	findings := classifyStaleTracearyProcesses(snapshots, currentVersion, now)
+	if len(findings) == 0 {
+		check.Status = doctorStatusPass
+		check.Message = Localize("no stale Traceary binaries or retired mcp-server processes are running", "古い Traceary バイナリや引退した mcp-server プロセスは実行されていません")
+		return check
+	}
+	shown := findings
+	extra := 0
+	if len(shown) > doctorStaleProcessReportLimit {
+		extra = len(shown) - doctorStaleProcessReportLimit
+		shown = shown[:doctorStaleProcessReportLimit]
+	}
+	parts := make([]string, 0, len(shown))
+	pids := make([]string, 0, len(shown))
+	for _, finding := range shown {
+		parts = append(parts, fmt.Sprintf("pid=%d version=%s age=%s reason=%s", finding.PID, finding.Version, finding.Age, finding.Reason))
+		pids = append(pids, strconv.Itoa(finding.PID))
+	}
+	message := localizef(
+		"stale Traceary processes: %s",
+		"古い Traceary プロセスがあります: %s",
+		strings.Join(parts, "; "),
+	)
+	if extra > 0 {
+		message += localizef(" (and %d more)", "（ほか %d 件）", extra)
+	}
+	check.Status = doctorStatusWarn
+	check.Message = message
+	check.Hint = Localize(
+		"quit the host session that launched these processes so they cannot write without a store lease; confirm with `ps -p <pid>` then `kill <pid>` only if unused. MCP (`mcp-server`) was retired in v0.35.0 — remove leftover host config (see docs/mcp/README.md)",
+		"store lease なしで書き込ませないよう、これらのプロセスを起動したホスト session を終了してください。`ps -p <pid>` で確認し、未使用なら `kill <pid>`。MCP（`mcp-server`）は v0.35.0 で引退しています。残っている host config を削除してください（docs/mcp/README.ja.md）",
+	)
+	check.FixCommand = "ps -p " + strings.Join(pids, ",")
+	return check
+}
+
+func classifyStaleTracearyProcesses(snapshots []tracearyProcessSnapshot, currentVersion string, now time.Time) []staleTracearyProcessFinding {
+	selfPID := os.Getpid()
+	currentExe, _ := osExecutableFunc()
+	current := normalizeDoctorVersion(currentVersion)
+	findings := make([]staleTracearyProcessFinding, 0)
+	for _, snapshot := range snapshots {
+		if snapshot.PID <= 0 || snapshot.PID == selfPID {
+			continue
+		}
+		if !snapshotLooksLikeTraceary(snapshot) {
+			continue
+		}
+		exe := strings.TrimSpace(snapshot.Executable)
+		if exe == "" && len(snapshot.Args) > 0 {
+			exe = snapshot.Args[0]
+		}
+		retired := processInvokesRetiredMCPServer(snapshot.Args)
+		sameRunningBinary := currentExe != "" && exe != "" && sameFile(exe, currentExe)
+		version := inspectTracearyProcessVersion(exe, currentVersion, sameRunningBinary)
+		if !retired && (sameRunningBinary || versionsMatch(version, current)) {
+			continue
+		}
+		reason := "stale-binary"
+		if retired {
+			reason = "retired-mcp-server"
+		}
+		reportedVersion := version
+		if reportedVersion == "" {
+			reportedVersion = "unknown"
+		}
+		findings = append(findings, staleTracearyProcessFinding{
+			PID:     snapshot.PID,
+			Version: reportedVersion,
+			Age:     formatProcessAge(snapshot.StartedAt, now),
+			Reason:  reason,
+			Exe:     exe,
+		})
+		if len(findings) >= doctorStaleProcessScanLimit {
+			break
+		}
+	}
+	return findings
+}
+
+func snapshotLooksLikeTraceary(snapshot tracearyProcessSnapshot) bool {
+	if looksLikeTracearyExecutable(snapshot.Executable) {
+		return true
+	}
+	if len(snapshot.Args) > 0 && looksLikeTracearyExecutable(snapshot.Args[0]) {
+		return true
+	}
+	return processInvokesRetiredMCPServer(snapshot.Args)
+}
+
+func looksLikeTracearyExecutable(path string) bool {
+	base := filepath.Base(strings.TrimSpace(path))
+	base = strings.TrimSuffix(base, ".exe")
+	if idx := strings.Index(base, " (deleted)"); idx >= 0 {
+		base = strings.TrimSpace(base[:idx])
+	}
+	return base == "traceary"
+}
+
+func processInvokesRetiredMCPServer(args []string) bool {
+	for _, arg := range args {
+		if arg == doctorRetiredMCPServerCommand {
+			return true
+		}
+	}
+	return false
+}
+
+func versionsMatch(processVersion, currentVersion string) bool {
+	processVersion = normalizeDoctorVersion(processVersion)
+	currentVersion = normalizeDoctorVersion(currentVersion)
+	if processVersion == "" || currentVersion == "" {
+		return false
+	}
+	if isDevBuild(processVersion) || isDevBuild(currentVersion) {
+		return processVersion == currentVersion
+	}
+	return processVersion == currentVersion
+}
+
+func inspectTracearyProcessVersion(exe, currentVersion string, sameRunningBinary bool) string {
+	if sameRunningBinary {
+		return normalizeDoctorVersion(currentVersion)
+	}
+	if version := cellarTracearyVersion(exe); version != "" {
+		return version
+	}
+	if version := goBuildInfoVersion(exe); version != "" {
+		return version
+	}
+	return ""
+}
+
+func cellarTracearyVersion(exe string) string {
+	match := cellarTracearyVersionPattern.FindStringSubmatch(exe)
+	if len(match) < 2 {
+		return ""
+	}
+	return normalizeDoctorVersion(match[1])
+}
+
+func goBuildInfoVersion(exe string) string {
+	if strings.TrimSpace(exe) == "" {
+		return ""
+	}
+	info, err := buildinfo.ReadFile(exe)
+	if err != nil || info == nil {
+		return ""
+	}
+	version := strings.TrimSpace(info.Main.Version)
+	if version == "" || version == "(devel)" {
+		return ""
+	}
+	return normalizeDoctorVersion(version)
+}
+
+func formatProcessAge(startedAt, now time.Time) string {
+	if startedAt.IsZero() || now.IsZero() {
+		return "unknown"
+	}
+	duration := now.Sub(startedAt)
+	if duration < 0 {
+		duration = 0
+	}
+	switch {
+	case duration >= 24*time.Hour:
+		return fmt.Sprintf("%dd", int(duration.Hours()/24))
+	case duration >= time.Hour:
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	case duration >= time.Minute:
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	}
+}
+
+func defaultListTracearyProcessSnapshots() ([]tracearyProcessSnapshot, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return listTracearyProcessSnapshotsDarwin()
+	case "linux":
+		return listTracearyProcessSnapshotsLinux()
+	default:
+		return nil, nil
+	}
+}
+
+func listTracearyProcessSnapshotsDarwin() ([]tracearyProcessSnapshot, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), doctorStaleProcessListTimeout)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, "ps", "-axo", "pid=,etime=,args=").Output()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list processes with ps: %w", err)
+	}
+	return parsePSTracearyProcessSnapshots(string(output), time.Now()), nil
+}
+
+func parsePSTracearyProcessSnapshots(output string, now time.Time) []tracearyProcessSnapshot {
+	lines := strings.Split(output, "\n")
+	snapshots := make([]tracearyProcessSnapshot, 0)
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		args := fields[2:]
+		exe := args[0]
+		if !looksLikeTracearyExecutable(exe) && !processInvokesRetiredMCPServer(args) {
+			continue
+		}
+		snapshots = append(snapshots, tracearyProcessSnapshot{
+			PID:        pid,
+			Executable: exe,
+			Args:       args,
+			StartedAt:  now.Add(-parsePSElapsed(fields[1])),
+		})
+		if len(snapshots) >= doctorStaleProcessScanLimit {
+			break
+		}
+	}
+	return snapshots
+}
+
+func parsePSElapsed(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	days := 0
+	rest := value
+	if dayPart, after, ok := strings.Cut(value, "-"); ok {
+		parsedDays, err := strconv.Atoi(dayPart)
+		if err != nil {
+			return 0
+		}
+		days = parsedDays
+		rest = after
+	}
+	parts := strings.Split(rest, ":")
+	var hours, minutes, seconds int
+	var err error
+	switch len(parts) {
+	case 1:
+		seconds, err = strconv.Atoi(parts[0])
+	case 2:
+		minutes, err = strconv.Atoi(parts[0])
+		if err == nil {
+			seconds, err = strconv.Atoi(parts[1])
+		}
+	case 3:
+		hours, err = strconv.Atoi(parts[0])
+		if err == nil {
+			minutes, err = strconv.Atoi(parts[1])
+		}
+		if err == nil {
+			seconds, err = strconv.Atoi(parts[2])
+		}
+	default:
+		return 0
+	}
+	if err != nil {
+		return 0
+	}
+	return time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second
+}
+
+func listTracearyProcessSnapshotsLinux() ([]tracearyProcessSnapshot, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read /proc: %w", err)
+	}
+	now := time.Now()
+	boot, bootErr := linuxBootTime(now)
+	snapshots := make([]tracearyProcessSnapshot, 0)
+	scanned := 0
+	for _, entry := range entries {
+		if scanned >= doctorStaleProcessScanLimit {
+			break
+		}
+		name := entry.Name()
+		pid, convErr := strconv.Atoi(name)
+		if convErr != nil || pid <= 0 {
+			continue
+		}
+		scanned++
+		args, argsErr := readProcCmdline(pid)
+		if argsErr != nil || len(args) == 0 {
+			continue
+		}
+		exe := linuxProcExecutable(pid, args[0])
+		if !looksLikeTracearyExecutable(exe) && !looksLikeTracearyExecutable(args[0]) && !processInvokesRetiredMCPServer(args) {
+			continue
+		}
+		startedAt := time.Time{}
+		if bootErr == nil {
+			if start, startErr := linuxProcStartTime(pid, boot); startErr == nil {
+				startedAt = start
+			}
+		}
+		snapshots = append(snapshots, tracearyProcessSnapshot{
+			PID:        pid,
+			Executable: exe,
+			Args:       args,
+			StartedAt:  startedAt,
+		})
+	}
+	return snapshots, nil
+}
+
+func readProcCmdline(pid int) ([]string, error) {
+	payload, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read cmdline for pid %d: %w", pid, err)
+	}
+	if len(payload) == 0 {
+		return nil, nil
+	}
+	parts := bytes.Split(payload, []byte{0})
+	args := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		args = append(args, string(part))
+	}
+	return args, nil
+}
+
+func linuxProcExecutable(pid int, argv0 string) string {
+	target, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "exe"))
+	if err != nil {
+		return argv0
+	}
+	target = strings.TrimSuffix(target, " (deleted)")
+	return target
+}
+
+func linuxBootTime(now time.Time) (time.Time, error) {
+	payload, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return time.Time{}, xerrors.Errorf("failed to read /proc/uptime: %w", err)
+	}
+	fields := strings.Fields(string(payload))
+	if len(fields) == 0 {
+		return time.Time{}, xerrors.New("empty /proc/uptime")
+	}
+	uptime, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return time.Time{}, xerrors.Errorf("failed to parse /proc/uptime: %w", err)
+	}
+	return now.Add(-time.Duration(uptime * float64(time.Second))), nil
+}
+
+func linuxProcStartTime(pid int, boot time.Time) (time.Time, error) {
+	payload, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return time.Time{}, xerrors.Errorf("failed to read stat for pid %d: %w", pid, err)
+	}
+	rest := payload
+	idx := bytes.LastIndex(payload, []byte(")"))
+	if idx >= 0 && idx+2 <= len(payload) {
+		rest = payload[idx+2:]
+	}
+	fields := strings.Fields(string(rest))
+	if len(fields) < linuxProcStatStartTimeField {
+		return time.Time{}, xerrors.Errorf("stat for pid %d is truncated", pid)
+	}
+	ticks, err := strconv.ParseUint(fields[linuxProcStatStartTimeField-1], 10, 64)
+	if err != nil {
+		return time.Time{}, xerrors.Errorf("failed to parse starttime for pid %d: %w", pid, err)
+	}
+	return boot.Add(time.Duration(ticks) * time.Second / linuxProcClockTicksPerSecond), nil
+}

--- a/presentation/cli/doctor_stale_processes_cli_test.go
+++ b/presentation/cli/doctor_stale_processes_cli_test.go
@@ -1,0 +1,98 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_DoctorWarnsOnSyntheticStaleTracearyProcess(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	setTracearyPathToCurrentExecutable(t)
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	now := time.Now()
+	cli.SetListTracearyProcessSnapshotsForTest(func() ([]cli.TracearyProcessSnapshot, error) {
+		return []cli.TracearyProcessSnapshot{{
+			PID:        7766,
+			Executable: "/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary",
+			Args:       []string{"/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary", "mcp-server"},
+			StartedAt:  now.Add(-13 * 24 * time.Hour),
+		}}, nil
+	})
+	t.Cleanup(cli.ResetListTracearyProcessSnapshotsForTest)
+
+	dbPath := t.TempDir() + "/traceary.db"
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{})).Command()
+	rootCmd.Version = "0.44.1"
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", dbPath, "--client", "codex", "--project-dir", projectDir, "--json", "--warnings-ok"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout=%s", err, stdout.String())
+	}
+	report := decodeDoctorReport(t, stdout.Bytes())
+	var found *doctorCheck
+	for i := range report.Checks {
+		if report.Checks[i].Name == "stale-processes" {
+			found = &report.Checks[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("stale-processes check missing from report: %s", stdout.String())
+	}
+	if found.Status != "warn" {
+		t.Fatalf("status = %q, want warn; msg=%q", found.Status, found.Message)
+	}
+	if !strings.Contains(found.Message, "pid=7766") || !strings.Contains(found.Message, "0.33.0") {
+		t.Fatalf("message should name pid and version, got %q", found.Message)
+	}
+	if found.Section != "Environment" {
+		t.Fatalf("section = %q", found.Section)
+	}
+}
+
+func TestRootCLI_DoctorPassesWhenNoStaleTracearyProcesses(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	setTracearyPathToCurrentExecutable(t)
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+	cli.SetEmptyTracearyProcessSnapshotsForTest()
+	t.Cleanup(cli.ResetListTracearyProcessSnapshotsForTest)
+
+	dbPath := t.TempDir() + "/traceary.db"
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{})).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"doctor", "--db-path", dbPath, "--client", "codex", "--project-dir", projectDir, "--json", "--warnings-ok"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout=%s", err, stdout.String())
+	}
+	report := decodeDoctorReport(t, stdout.Bytes())
+	var found *doctorCheck
+	for i := range report.Checks {
+		if report.Checks[i].Name == "stale-processes" {
+			found = &report.Checks[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("stale-processes check missing from report")
+	}
+	if found.Status != "pass" {
+		t.Fatalf("status = %q, want pass; msg=%q", found.Status, found.Message)
+	}
+}

--- a/presentation/cli/doctor_stale_processes_test.go
+++ b/presentation/cli/doctor_stale_processes_test.go
@@ -1,0 +1,213 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInspectStaleTracearyProcesses(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	origExecutable := osExecutableFunc
+	t.Cleanup(func() {
+		osExecutableFunc = origExecutable
+		ResetListTracearyProcessSnapshotsForTest()
+	})
+
+	t.Run("passes when no Traceary processes are listed", func(t *testing.T) {
+		SetEmptyTracearyProcessSnapshotsForTest()
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Name != doctorStaleProcessesCheckName {
+			t.Fatalf("name = %q", got.Name)
+		}
+		if got.Status != doctorStatusPass {
+			t.Fatalf("status = %q, want pass; msg=%q", got.Status, got.Message)
+		}
+		if !strings.Contains(got.Message, "no stale Traceary binaries") {
+			t.Fatalf("message = %q", got.Message)
+		}
+	})
+
+	t.Run("warns with pid and version for a stale Homebrew binary", func(t *testing.T) {
+		osExecutableFunc = func() (string, error) {
+			return "/opt/homebrew/opt/traceary/bin/traceary", nil
+		}
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return []tracearyProcessSnapshot{{
+				PID:        7766,
+				Executable: "/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary",
+				Args:       []string{"/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary", "mcp-server"},
+				StartedAt:  now.Add(-13 * 24 * time.Hour),
+			}}, nil
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusWarn {
+			t.Fatalf("status = %q, want warn; msg=%q", got.Status, got.Message)
+		}
+		if !strings.Contains(got.Message, "pid=7766") || !strings.Contains(got.Message, "version=0.33.0") {
+			t.Fatalf("message should name pid and version, got %q", got.Message)
+		}
+		if !strings.Contains(got.Message, "age=13d") {
+			t.Fatalf("message should name age, got %q", got.Message)
+		}
+		if !strings.Contains(got.Message, "retired-mcp-server") {
+			t.Fatalf("message should name retired mcp reason, got %q", got.Message)
+		}
+		if got.FixCommand != "ps -p 7766" {
+			t.Fatalf("FixCommand = %q", got.FixCommand)
+		}
+		if !strings.Contains(got.Hint, "kill") {
+			t.Fatalf("hint should include reap guidance, got %q", got.Hint)
+		}
+	})
+
+	t.Run("warns on retired mcp-server even when the version matches", func(t *testing.T) {
+		current := writeExecutable(t, t.TempDir(), "traceary")
+		osExecutableFunc = func() (string, error) { return current, nil }
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return []tracearyProcessSnapshot{{
+				PID:        4242,
+				Executable: current,
+				Args:       []string{current, "mcp-server"},
+				StartedAt:  now.Add(-8 * 24 * time.Hour),
+			}}, nil
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusWarn {
+			t.Fatalf("status = %q, want warn; msg=%q", got.Status, got.Message)
+		}
+		if !strings.Contains(got.Message, "pid=4242") || !strings.Contains(got.Message, "retired-mcp-server") {
+			t.Fatalf("message = %q", got.Message)
+		}
+		if !strings.Contains(got.Message, "version=0.44.1") {
+			t.Fatalf("message should use the running version for the same binary, got %q", got.Message)
+		}
+	})
+
+	t.Run("passes for the current binary when it is not mcp-server", func(t *testing.T) {
+		current := writeExecutable(t, t.TempDir(), "traceary")
+		osExecutableFunc = func() (string, error) { return current, nil }
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return []tracearyProcessSnapshot{{
+				PID:        99999,
+				Executable: current,
+				Args:       []string{current, "doctor", "--json"},
+				StartedAt:  now.Add(-time.Minute),
+			}}, nil
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusPass {
+			t.Fatalf("status = %q, want pass; msg=%q", got.Status, got.Message)
+		}
+	})
+
+	t.Run("warns when process listing fails", func(t *testing.T) {
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return nil, errors.New("ps: unavailable")
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusWarn {
+			t.Fatalf("status = %q, want warn; msg=%q", got.Status, got.Message)
+		}
+		if !strings.Contains(got.Message, "ps: unavailable") {
+			t.Fatalf("message = %q", got.Message)
+		}
+	})
+}
+
+func TestParsePSElapsed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want time.Duration
+	}{
+		{name: "seconds only", in: "09", want: 9 * time.Second},
+		{name: "minutes and seconds", in: "03:01", want: 3*time.Minute + time.Second},
+		{name: "hours", in: "01:02:03", want: time.Hour + 2*time.Minute + 3*time.Second},
+		{name: "days", in: "13-04:00:00", want: 13*24*time.Hour + 4*time.Hour},
+		{name: "empty", in: "", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parsePSElapsed(tt.in); got != tt.want {
+				t.Fatalf("parsePSElapsed(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePSTracearyProcessSnapshots(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	output := strings.Join([]string{
+		" 7766 13-00:00:00 /opt/homebrew/Cellar/traceary/0.33.0/bin/traceary mcp-server",
+		"  120 00:00:01 /usr/bin/ssh -N",
+		" 4242    08:00:00 /opt/homebrew/Cellar/traceary/0.32.1/bin/traceary hook session claude start",
+	}, "\n")
+	got := parsePSTracearyProcessSnapshots(output, now)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].PID != 7766 || got[0].Args[1] != "mcp-server" {
+		t.Fatalf("first snapshot = %+v", got[0])
+	}
+	if got[1].PID != 4242 {
+		t.Fatalf("second snapshot = %+v", got[1])
+	}
+}
+
+func TestCellarTracearyVersion(t *testing.T) {
+	t.Parallel()
+	got := cellarTracearyVersion("/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary")
+	if got != "0.33.0" {
+		t.Fatalf("got %q", got)
+	}
+	if cellarTracearyVersion("/usr/local/bin/traceary") != "" {
+		t.Fatalf("non-cellar path should be empty")
+	}
+}
+
+func TestDoctorSectionAndScopeForStaleProcesses(t *testing.T) {
+	t.Parallel()
+	if got := doctorSectionNameForCheck(doctorStaleProcessesCheckName); got != "Environment" {
+		t.Fatalf("section = %q", got)
+	}
+	if !doctorCheckIsStoreIndependent(doctorStaleProcessesCheckName) {
+		t.Fatal("stale-processes should be store-independent")
+	}
+}
+
+func TestClassifyStaleTracearyProcessesSkipsSelfPID(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	origExecutable := osExecutableFunc
+	t.Cleanup(func() { osExecutableFunc = origExecutable })
+	osExecutableFunc = func() (string, error) {
+		return "/opt/homebrew/opt/traceary/bin/traceary", nil
+	}
+	findings := classifyStaleTracearyProcesses([]tracearyProcessSnapshot{{
+		PID:        os.Getpid(),
+		Executable: "/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary",
+		Args:       []string{"/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary", "mcp-server"},
+		StartedAt:  now.Add(-time.Hour),
+	}}, "0.44.1", now)
+	if len(findings) != 0 {
+		t.Fatalf("findings = %+v, want none for self PID", findings)
+	}
+}
+
+func TestLooksLikeTracearyExecutable(t *testing.T) {
+	t.Parallel()
+	if !looksLikeTracearyExecutable("/opt/homebrew/bin/traceary") {
+		t.Fatal("expected traceary path to match")
+	}
+	if !looksLikeTracearyExecutable("traceary.exe") {
+		t.Fatal("expected windows executable name to match")
+	}
+	if looksLikeTracearyExecutable("/usr/bin/grep") {
+		t.Fatal("grep must not match")
+	}
+}

--- a/presentation/cli/doctor_stale_processes_test.go
+++ b/presentation/cli/doctor_stale_processes_test.go
@@ -103,6 +103,30 @@ func TestInspectStaleTracearyProcesses(t *testing.T) {
 		}
 	})
 
+	t.Run("warns when Linux reports the executable inode as deleted after a same-path replace", func(t *testing.T) {
+		current := writeExecutable(t, t.TempDir(), "traceary")
+		osExecutableFunc = func() (string, error) { return current, nil }
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return []tracearyProcessSnapshot{{
+				PID:        8800,
+				Executable: current,
+				Args:       []string{current, "hook", "session", "claude", "start"},
+				StartedAt:  now.Add(-2 * 24 * time.Hour),
+				Unlinked:   true,
+			}}, nil
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusWarn {
+			t.Fatalf("status = %q, want warn; msg=%q", got.Status, got.Message)
+		}
+		if !strings.Contains(got.Message, "pid=8800") || !strings.Contains(got.Message, "stale-binary") {
+			t.Fatalf("message = %q", got.Message)
+		}
+		if !strings.Contains(got.Message, "version=unknown") {
+			t.Fatalf("unlinked inode must not inherit the replacement binary version, got %q", got.Message)
+		}
+	})
+
 	t.Run("warns when process listing fails", func(t *testing.T) {
 		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
 			return nil, errors.New("ps: unavailable")

--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -184,3 +184,26 @@ func SetDetectRepoContextFunc(f func(context.Context) (string, error)) {
 func ResetDetectRepoContextFunc() {
 	storeDetectRepoContextFunc(detectRepoContext)
 }
+
+// TracearyProcessSnapshot is the ps-level process view doctor classifies.
+type TracearyProcessSnapshot = tracearyProcessSnapshot
+
+// SetListTracearyProcessSnapshotsForTest replaces the process enumerator
+// used by the stale-processes doctor check.
+func SetListTracearyProcessSnapshotsForTest(f func() ([]TracearyProcessSnapshot, error)) {
+	storeListTracearyProcessSnapshotsFunc(f)
+}
+
+// SetEmptyTracearyProcessSnapshotsForTest makes the stale-processes check
+// hermetic so operator-machine leftovers cannot change doctor snapshots.
+func SetEmptyTracearyProcessSnapshotsForTest() {
+	storeListTracearyProcessSnapshotsFunc(func() ([]tracearyProcessSnapshot, error) {
+		return nil, nil
+	})
+}
+
+// ResetListTracearyProcessSnapshotsForTest restores an empty enumerator so
+// subsequent tests stay hermetic.
+func ResetListTracearyProcessSnapshotsForTest() {
+	SetEmptyTracearyProcessSnapshotsForTest()
+}

--- a/presentation/cli/main_test.go
+++ b/presentation/cli/main_test.go
@@ -60,6 +60,10 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "configure isolated Traceary CLI hook state: %v\n", err)
 		os.Exit(1)
 	}
+	storeListTracearyProcessSnapshotsFunc(func() ([]tracearyProcessSnapshot, error) {
+		return nil, nil
+	})
+
 	if dbPath := strings.TrimSpace(os.Getenv(testDBPathEnvKey)); dbPath != "" {
 		if err := os.Setenv(dbPathEnvKey, dbPath); err != nil {
 			fmt.Fprintf(os.Stderr, "configure isolated Traceary CLI database: %v\n", err)

--- a/presentation/cli/test_seams.go
+++ b/presentation/cli/test_seams.go
@@ -22,6 +22,7 @@ type (
 	resolveHookTranscriptSessionIDFn = func([]byte, string) (types.SessionID, error)
 	afterInspectGrokTranscriptHookFn = func()
 	detectRepoContextFn              = func(context.Context) (string, error)
+	listTracearyProcessSnapshotsFn   = func() ([]tracearyProcessSnapshot, error)
 )
 
 var (
@@ -35,6 +36,7 @@ var (
 	resolveHookTranscriptSessionIDSlot atomic.Pointer[resolveHookTranscriptSessionIDFn]
 	afterInspectGrokTranscriptHookSlot atomic.Pointer[afterInspectGrokTranscriptHookFn]
 	detectRepoContextSlot              atomic.Pointer[detectRepoContextFn]
+	listTracearyProcessSnapshotsSlot   atomic.Pointer[listTracearyProcessSnapshotsFn]
 )
 
 func init() {
@@ -47,6 +49,7 @@ func init() {
 	storeAntigravityParentPIDFunc(os.Getppid)
 	storeResolveHookTranscriptSessionIDFunc(resolveHookSessionID)
 	storeDetectRepoContextFunc(detectRepoContext)
+	storeListTracearyProcessSnapshotsFunc(defaultListTracearyProcessSnapshots)
 }
 
 func storeUserHomeDirFunc(f userHomeDirFn) {
@@ -143,4 +146,12 @@ func storeDetectRepoContextFunc(f detectRepoContextFn) {
 
 func detectRepoContextFunc(ctx context.Context) (string, error) {
 	return (*detectRepoContextSlot.Load())(ctx)
+}
+
+func storeListTracearyProcessSnapshotsFunc(f listTracearyProcessSnapshotsFn) {
+	listTracearyProcessSnapshotsSlot.Store(&f)
+}
+
+func listTracearyProcessSnapshotsFunc() ([]tracearyProcessSnapshot, error) {
+	return (*listTracearyProcessSnapshotsSlot.Load())()
 }

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -65,6 +65,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "stale-processes",
+      "status": "pass",
+      "severity": "PASS",
+      "section": "Environment",
+      "message": "no stale Traceary binaries or retired mcp-server processes are running (store-independent)",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "config",
       "status": "pass",
       "severity": "PASS",
@@ -295,6 +305,16 @@
           "severity": "PASS",
           "section": "Environment",
           "message": "PATH resolves traceary to /tmp/traceary-json-golden-bin/traceary (directory: /tmp/traceary-json-golden-bin) (store-independent)",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
+          "name": "stale-processes",
+          "status": "pass",
+          "severity": "PASS",
+          "section": "Environment",
+          "message": "no stale Traceary binaries or retired mcp-server processes are running (store-independent)",
           "hint": "",
           "fix_command": "",
           "auto_fix_available": false
@@ -587,7 +607,7 @@
     }
   ],
   "summary": {
-    "pass": 27,
+    "pass": 28,
     "warn": 1,
     "fail": 0
   },


### PR DESCRIPTION
## Summary

Doctor now detects long-running processes whose executable is a superseded Traceary binary or the retired `mcp-server` surface.

- New `stale-processes` check (Environment, store-independent) after `path`
- Runs on both the full doctor path and metadata-only large-store path
- WARNs with pid, version, age, and reap guidance; PASS when none
- Version comes from Homebrew Cellar path or `debug/buildinfo.ReadFile` — the target binary is never executed
- Additive stdout contract snapshot in this PR
- `docs/release/post-upgrade-plugins.md` (+ ja) documents stale processes

## Test plan

- [x] `go test ./presentation/cli/` (includes synthetic stale pid WARN and empty-list PASS, plus golden snapshot)
- [x] `go test ./...` (one unrelated sqlite backfill flake retried green)
- [x] `go build ./...`
- [x] `go tool golangci-lint run`

Closes #2155

Leaves parent #2188 open.