### PR TITLE
fix: retro-hide stored pre-v0.43 echo candidates on hygiene scan

### DIFF
--- a/.ai/spec/2152.md
+++ b/.ai/spec/2152.md
@@ -1,0 +1,30 @@
+# #2152 Retro-hide pre-v0.43 echo candidates
+
+Parent: #2188. Closes only #2152.
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Apply the #2112 shape detector (instruction echo, mid-sentence fragment, payload echo) plus the #2020 structural-non-prose drop set to **already stored** candidates.
+- Surface hits as existing `low_quality_candidate` on `memory admin hygiene scan`.
+- Bulk resolve via existing `memory inbox cleanup` (dry-run first, `--apply` rejects). `memory inbox restore` recovers.
+- Non-echo candidates in the same date range stay. No new command. JSON keys unchanged.
+
+### Conceptual model
+| Concept | Behavior | Constraint |
+|---|---|---|
+| Stored echo | classifyExtractionNoise (+ structural non-prose) on candidate fact | never exec extraction rewrite |
+| remember-intent | flag only `hidesDespiteRememberIntent` (payload echo) | real remember-intent facts stay |
+| compact-summary | same as extracted | still reject, not auto-accept |
+| extracted-hidden | opt-in `--include-hidden` | default scan matches visible inbox |
+
+### Responsibility
+- Source list: `application/types` helper used by SQLite scan + stub.
+- Classification: existing `classifyExtractionNoise` / `isStructurallyNonProseFact`.
+- Scan/apply match: `memory_hygiene.go` candidate phase.
+- Bulk reject: unchanged `memory inbox cleanup`.
+
+### Behavior tests
+- Scan lists JSON payload, instruction echo, hunk header, markdown heading; durable fact in the same timestamp is absent.
+- remember-intent payload echo flagged; remember-intent durable fact not.
+- Cleanup dry-run lists echo ids without Reject; apply rejects; restore recovers one.

--- a/application/types/memory_hygiene.go
+++ b/application/types/memory_hygiene.go
@@ -45,14 +45,42 @@ const (
 	MemoryHygieneSuggestionValidityOverlapSupersede MemoryHygieneSuggestionKind = "validity_overlap_supersede"
 	// MemoryHygieneSuggestionLowQualityCandidate flags a status=candidate
 	// memory whose fact text matches the deterministic low-quality
-	// classifier (#857). The apply path rejects the candidate so the
+	// classifier (#857, #2112). The apply path rejects the candidate so the
 	// inbox view stays focused on durable signals; accepted memories are
-	// never touched. The suggestion only fires for status=candidate, and
+	// never touched. The suggestion only fires for status=candidate.
 	// extracted-hidden rows are inspected only when the caller opts in
 	// via MemoryHygieneScanCriteria.IncludeHiddenCandidates so the
-	// default scan stays predictable.
+	// default scan stays predictable. remember-intent rows are inspected
+	// only for noise that extraction hides despite remember-intent
+	// (payload echo). compact-summary uses the same classifier as extracted.
 	MemoryHygieneSuggestionLowQualityCandidate MemoryHygieneSuggestionKind = "low_quality_candidate"
 )
+
+// HygieneCandidateNoiseSources is the candidate source set the hygiene
+// scan's candidate-rows phase walks. extracted-hidden is opt-in so the
+// default matches the visible inbox.
+func HygieneCandidateNoiseSources(includeHidden bool) []domtypes.MemorySource {
+	sources := []domtypes.MemorySource{
+		domtypes.MemorySourceExtracted,
+		domtypes.MemorySourceRememberIntent,
+		domtypes.MemorySourceCompactSummary,
+	}
+	if includeHidden {
+		sources = append(sources, domtypes.MemorySourceExtractedHidden)
+	}
+	return sources
+}
+
+// IsHygieneCandidateNoiseSource reports whether a stored candidate source
+// is eligible for the low-quality / echo noise pass.
+func IsHygieneCandidateNoiseSource(source domtypes.MemorySource, includeHidden bool) bool {
+	for _, candidate := range HygieneCandidateNoiseSources(includeHidden) {
+		if source == candidate {
+			return true
+		}
+	}
+	return false
+}
 
 // MemoryHygieneScanCriteria carries the inputs the hygiene scanner
 // consumes. Scopes default to every scope when empty; the staleness

--- a/application/types/memory_hygiene_scan_test.go
+++ b/application/types/memory_hygiene_scan_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
 )
 
 func TestMemoryHygieneScanBudgetFrom_ZeroValueUsesFiniteDefaults(t *testing.T) {
@@ -86,5 +89,41 @@ func TestMemoryHygieneScanBudgetFrom_PreservesExplicitLimits(t *testing.T) {
 			budget.MaxComparisons(),
 			budget.MaxDuration(),
 		)
+	}
+}
+
+func TestHygieneCandidateNoiseSources_HiddenIsOptIn(t *testing.T) {
+	t.Parallel()
+
+	wantVisible := []domtypes.MemorySource{
+		domtypes.MemorySourceExtracted,
+		domtypes.MemorySourceRememberIntent,
+		domtypes.MemorySourceCompactSummary,
+	}
+	if diff := cmp.Diff(wantVisible, apptypes.HygieneCandidateNoiseSources(false)); diff != "" {
+		t.Fatalf("HygieneCandidateNoiseSources(false) mismatch (-want +got):\n%s", diff)
+	}
+	wantHidden := append(append([]domtypes.MemorySource(nil), wantVisible...), domtypes.MemorySourceExtractedHidden)
+	if diff := cmp.Diff(wantHidden, apptypes.HygieneCandidateNoiseSources(true)); diff != "" {
+		t.Fatalf("HygieneCandidateNoiseSources(true) mismatch (-want +got):\n%s", diff)
+	}
+
+	cases := []struct {
+		source  domtypes.MemorySource
+		hidden  bool
+		want    bool
+	}{
+		{source: domtypes.MemorySourceExtracted, hidden: false, want: true},
+		{source: domtypes.MemorySourceRememberIntent, hidden: false, want: true},
+		{source: domtypes.MemorySourceCompactSummary, hidden: false, want: true},
+		{source: domtypes.MemorySourceExtractedHidden, hidden: false, want: false},
+		{source: domtypes.MemorySourceExtractedHidden, hidden: true, want: true},
+		{source: domtypes.MemorySourceManual, hidden: true, want: false},
+	}
+	for _, tc := range cases {
+		if got := apptypes.IsHygieneCandidateNoiseSource(tc.source, tc.hidden); got != tc.want {
+			t.Fatalf("IsHygieneCandidateNoiseSource(%q, includeHidden=%v) = %v, want %v",
+				tc.source, tc.hidden, got, tc.want)
+		}
 	}
 }

--- a/application/types/memory_hygiene_scan_test.go
+++ b/application/types/memory_hygiene_scan_test.go
@@ -109,9 +109,9 @@ func TestHygieneCandidateNoiseSources_HiddenIsOptIn(t *testing.T) {
 	}
 
 	cases := []struct {
-		source  domtypes.MemorySource
-		hidden  bool
-		want    bool
+		source domtypes.MemorySource
+		hidden bool
+		want   bool
 	}{
 		{source: domtypes.MemorySourceExtracted, hidden: false, want: true},
 		{source: domtypes.MemorySourceRememberIntent, hidden: false, want: true},

--- a/application/usecase/memory_extraction_echo_test.go
+++ b/application/usecase/memory_extraction_echo_test.go
@@ -65,6 +65,16 @@ func TestClassifyExtractionNoise_HidesInstructionEchoFragmentAndPayload(t *testi
 		{name: "short durable fact", fact: "The two-pillar target is 41 invocables", want: nil},
 		{name: "declarative numbered fact", fact: "1. Search projection generation is complete", want: nil},
 		{name: "declarative bullet fact", fact: "- Freelist pages are reclaimable via store compact", want: nil},
+		{
+			name: "markdown heading is structural non-prose",
+			fact: "## Durable memory commands",
+			want: []string{extractionNoiseStructuralNonProse},
+		},
+		{
+			name: "hunk header with trailing context is fragment and structural",
+			fact: "@@ -135,85 +135,85 @@ func inspect()",
+			want: []string{extractionNoiseDiffFragment, extractionNoiseStructuralNonProse},
+		},
 		{name: "lowercase complete claim", fact: "the store stays local-first after compact", want: nil},
 	}
 

--- a/application/usecase/memory_extraction_quality.go
+++ b/application/usecase/memory_extraction_quality.go
@@ -19,6 +19,7 @@ const (
 	extractionNoiseTransientPRRound     = "transient_pr_round"
 	extractionNoiseReviewFixInstruction = "review_fix_instruction"
 	extractionNoiseTransientStatus      = "transient_status"
+	extractionNoiseStructuralNonProse   = "structural_non_prose"
 )
 
 var (
@@ -216,6 +217,9 @@ func classifyExtractionNoise(fact string) []string {
 	if isPayloadEcho(trimmed) {
 		reasons = append(reasons, extractionNoisePayloadEcho)
 	}
+	if isStructurallyNonProseFact(trimmed) {
+		reasons = append(reasons, extractionNoiseStructuralNonProse)
+	}
 	if len(reasons) == 0 {
 		return nil
 	}
@@ -301,7 +305,7 @@ func isStructurallyNonProseFact(fact string) bool {
 func isFragmentLikeNoise(reasons []string) bool {
 	for _, reason := range reasons {
 		switch reason {
-		case extractionNoiseDiffHeader, extractionNoiseDiffFragment, extractionNoiseGeneratedCode:
+		case extractionNoiseDiffHeader, extractionNoiseDiffFragment, extractionNoiseGeneratedCode, extractionNoiseStructuralNonProse:
 			return true
 		}
 	}

--- a/application/usecase/memory_extraction_quality_test.go
+++ b/application/usecase/memory_extraction_quality_test.go
@@ -20,7 +20,7 @@ func TestClassifyExtractionNoise(t *testing.T) {
 		{name: "added line tab indented", fact: "+\tfunc handler(ctx context.Context) {", want: []string{"diff_fragment"}},
 		{name: "added line two-space indented", fact: "+  func main() {", want: []string{"diff_fragment"}},
 		{name: "removed line two-space indented", fact: "-  oldHelper()", want: []string{"diff_fragment"}},
-		{name: "hunk header", fact: "@@ -1,3 +1,5 @@", want: []string{"diff_header"}},
+		{name: "hunk header", fact: "@@ -1,3 +1,5 @@", want: []string{"diff_header", "structural_non_prose"}},
 		{name: "diff command header", fact: "diff --git a/foo b/foo", want: []string{"diff_header"}},
 		{name: "file header plus", fact: "+++ a/foo.go", want: []string{"diff_header"}},
 		{name: "file header minus", fact: "--- a/foo.go", want: []string{"diff_header"}},
@@ -51,7 +51,7 @@ func TestClassifyExtractionNoise(t *testing.T) {
 		// the drop alternatives are anchored to the whole line (#1169 Codex
 		// round-8 finding).
 		{name: "diff-git header then prose", fact: "diff --git a/foo b/foo output must be redacted before sharing logs", want: []string{"diff_fragment"}},
-		{name: "hunk header then prose", fact: "@@ -1,3 +1,5 @@ marks a hunk", want: []string{"diff_fragment"}},
+		{name: "hunk header then prose", fact: "@@ -1,3 +1,5 @@ marks a hunk", want: []string{"diff_fragment", "structural_non_prose"}},
 		{name: "file header then prose", fact: "--- a/foo.go is the old-file marker", want: []string{"diff_fragment"}},
 		// Genuine diff structure still drops as diff_header.
 		{name: "file header minus dev-null", fact: "--- /dev/null", want: []string{"diff_header"}},

--- a/application/usecase/memory_hygiene.go
+++ b/application/usecase/memory_hygiene.go
@@ -304,21 +304,11 @@ func (u *memoryHygieneUsecase) matchesForScanUnit(
 		}
 		return []memoryHygieneMatch{match}
 	case apptypes.MemoryHygieneScanPhaseCandidateRows:
-		reasons := classifyExtractionNoise(unit.Row.Fact())
+		reasons := storedCandidateHygieneReasons(unit.Row)
 		if len(reasons) == 0 {
 			return nil
 		}
-		return []memoryHygieneMatch{{
-			MemoryID:       unit.Row.MemoryID(),
-			Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
-			Reason:         fmt.Sprintf("low-quality extraction: %s", strings.Join(reasons, ",")),
-			rawFact:        unit.Row.Fact(),
-			Scope:          unit.Row.Scope(),
-			UpdatedAt:      unit.Row.UpdatedAt(),
-			Status:         unit.Row.Status(),
-			Source:         unit.Row.Source(),
-			QualityReasons: reasons,
-		}}
+		return []memoryHygieneMatch{lowQualityCandidateMatch(unit.Row, reasons)}
 	default:
 		return nil
 	}
@@ -473,6 +463,38 @@ func truncateMemoryHygienePreview(value string, maxBytes int) (string, bool) {
 		cut--
 	}
 	return value[:cut] + marker, true
+}
+
+func storedCandidateHygieneReasons(summary apptypes.MemorySummary) []string {
+	reasons := classifyExtractionNoise(summary.Fact())
+	if len(reasons) == 0 {
+		return nil
+	}
+	switch summary.Source() {
+	case domtypes.MemorySourceExtracted, domtypes.MemorySourceExtractedHidden, domtypes.MemorySourceCompactSummary:
+		return reasons
+	case domtypes.MemorySourceRememberIntent:
+		if hidesDespiteRememberIntent(reasons) {
+			return reasons
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func lowQualityCandidateMatch(summary apptypes.MemorySummary, reasons []string) memoryHygieneMatch {
+	return memoryHygieneMatch{
+		MemoryID:       summary.MemoryID(),
+		Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
+		Reason:         fmt.Sprintf("low-quality extraction: %s", strings.Join(reasons, ",")),
+		rawFact:        summary.Fact(),
+		Scope:          summary.Scope(),
+		UpdatedAt:      summary.UpdatedAt(),
+		Status:         summary.Status(),
+		Source:         summary.Source(),
+		QualityReasons: reasons,
+	}
 }
 
 func incrementMemoryHygieneCount(result *apptypes.MemoryHygieneScanResult, kind apptypes.MemoryHygieneSuggestionKind) {
@@ -780,23 +802,12 @@ func (u *memoryHygieneUsecase) suggestionForMemoryHygieneRevalidation(
 			}
 		}
 	case domtypes.MemoryStatusCandidate:
-		if target.Source() != domtypes.MemorySourceExtracted &&
-			(!includeHiddenCandidates || target.Source() != domtypes.MemorySourceExtractedHidden) {
+		if !apptypes.IsHygieneCandidateNoiseSource(target.Source(), includeHiddenCandidates) {
 			return apptypes.MemoryHygieneSuggestion{}, false
 		}
-		reasons := classifyExtractionNoise(target.Fact())
+		reasons := storedCandidateHygieneReasons(target)
 		if len(reasons) > 0 {
-			selectMatch(memoryHygieneMatch{
-				MemoryID:       target.MemoryID(),
-				Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
-				Reason:         fmt.Sprintf("low-quality extraction: %s", strings.Join(reasons, ",")),
-				rawFact:        target.Fact(),
-				Scope:          target.Scope(),
-				UpdatedAt:      target.UpdatedAt(),
-				Status:         target.Status(),
-				Source:         target.Source(),
-				QualityReasons: reasons,
-			})
+			selectMatch(lowQualityCandidateMatch(target, reasons))
 		}
 	}
 	if !hasSelected {

--- a/application/usecase/memory_hygiene_category_test.go
+++ b/application/usecase/memory_hygiene_category_test.go
@@ -47,6 +47,7 @@ func TestIsFragmentLikeNoise(t *testing.T) {
 		{name: "diff header is fragment-like", reasons: []string{extractionNoiseDiffHeader}, want: true},
 		{name: "diff fragment is fragment-like", reasons: []string{extractionNoiseDiffFragment}, want: true},
 		{name: "generated code is fragment-like", reasons: []string{extractionNoiseGeneratedCode}, want: true},
+		{name: "structural non-prose is fragment-like", reasons: []string{extractionNoiseStructuralNonProse}, want: true},
 		{name: "diff among other reasons is fragment-like", reasons: []string{extractionNoiseStandaloneCommand, extractionNoiseDiffFragment}, want: true},
 		{name: "standalone command is not fragment-like", reasons: []string{extractionNoiseStandaloneCommand}, want: false},
 		{name: "review conclusion is not fragment-like", reasons: []string{extractionNoiseReviewConclusion}, want: false},

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -967,6 +967,54 @@ func TestMemoryHygieneScan_LowQualityCandidatesSurfaceWithReasons(t *testing.T) 
 	}
 }
 
+func TestMemoryHygieneScan_RetroHidesPreV043EchoCandidates(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+	payloadID := "memory-a94b92a4214b2fbb29a03d353a82f884"
+	hunkID := "memory-8433a201ee57689075069e12bf38dd41"
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			candidateSummary(t, payloadID, scope, `{ "ephemeralMessage": "Remember to check for lint errors" }`, domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, hunkID, scope, "@@ -135,85 +135,85 @@ func inspect()", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "memory-heading", scope, "## Durable memory commands", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "memory-instruction", scope, "1. Always run gofmt before opening a PR", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "memory-durable", scope, "The two-pillar target is 41 invocables", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "memory-remember-echo", scope, `{"ephemeralMessage":"remember that we ship the keep list"}`, domtypes.MemorySourceRememberIntent, now),
+			candidateSummary(t, "memory-remember-keep", scope, "Prefer brew binaries against the live store", domtypes.MemorySourceRememberIntent, now),
+			candidateSummary(t, "memory-compact-echo", scope, "- Use the official brew binary against the live store", domtypes.MemorySourceCompactSummary, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: now})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	flagged := map[string]apptypes.MemoryHygieneSuggestion{}
+	for _, suggestion := range result.Suggestions {
+		if suggestion.Kind == apptypes.MemoryHygieneSuggestionLowQualityCandidate {
+			flagged[suggestion.MemoryID.String()] = suggestion
+		}
+	}
+	for _, id := range []string{payloadID, hunkID, "memory-heading", "memory-instruction", "memory-remember-echo", "memory-compact-echo"} {
+		if _, ok := flagged[id]; !ok {
+			t.Fatalf("expected %s to be flagged as low_quality_candidate, got %v", id, flagged)
+		}
+	}
+	if _, ok := flagged["memory-durable"]; ok {
+		t.Fatalf("non-echo candidate in the same date range must stay unflagged")
+	}
+	if _, ok := flagged["memory-remember-keep"]; ok {
+		t.Fatalf("remember-intent durable fact must stay unflagged")
+	}
+	if result.LowQualityCandidateCount != 6 {
+		t.Fatalf("LowQualityCandidateCount = %d, want 6", result.LowQualityCandidateCount)
+	}
+}
+
 func TestMemoryHygieneScan_HiddenCandidatesRequireOptIn(t *testing.T) {
 	t.Parallel()
 
@@ -1023,6 +1071,16 @@ type candidateApplyMemoryRepository struct {
 
 func newCandidateApplyMemoryRepository(t *testing.T, scope domtypes.MemoryScope, candidates map[string]string) *candidateApplyMemoryRepository {
 	t.Helper()
+	return newCandidateApplyMemoryRepositoryWithSource(t, scope, candidates, domtypes.MemorySourceExtracted)
+}
+
+func newCandidateApplyMemoryRepositoryWithSource(
+	t *testing.T,
+	scope domtypes.MemoryScope,
+	candidates map[string]string,
+	source domtypes.MemorySource,
+) *candidateApplyMemoryRepository {
+	t.Helper()
 	repo := &candidateApplyMemoryRepository{candidates: make(map[string]*model.Memory, len(candidates))}
 	for id, fact := range candidates {
 		evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L1")
@@ -1034,7 +1092,7 @@ func newCandidateApplyMemoryRepository(t *testing.T, scope domtypes.MemoryScope,
 			domtypes.MemoryTypePreference,
 			scope,
 			fact,
-			domtypes.MemorySourceExtracted,
+			source,
 			[]domtypes.EvidenceRef{evidence},
 			nil,
 			domtypes.None[domtypes.MemoryID](),
@@ -1085,6 +1143,40 @@ func (r *candidateApplyMemoryRepository) rejectedIDs() []string {
 		}
 	}
 	return ids
+}
+
+func TestMemoryHygieneApply_RejectsEchoCandidateAndLeavesDurable(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	echoFact := `{ "ephemeralMessage": "Remember to check for lint errors" }`
+	durableFact := "The two-pillar target is 41 invocables"
+	echo := candidateSummary(t, "memory-a94b92a4214b2fbb29a03d353a82f884", scope, echoFact, domtypes.MemorySourceExtracted, now)
+	durable := candidateSummary(t, "memory-durable-keep", scope, durableFact, domtypes.MemorySourceExtracted, now)
+	query := &stubMemoryQueryService{summaries: []apptypes.MemorySummary{echo, durable}}
+	repo := newCandidateApplyMemoryRepository(t, scope, map[string]string{
+		"memory-a94b92a4214b2fbb29a03d353a82f884": echoFact,
+		"memory-durable-keep":                     durableFact,
+	})
+	sut := usecase.NewMemoryUsecase(repo, query, nil)
+
+	result, err := sut.Apply(context.Background(), apptypes.MemoryHygieneApplyCriteria{
+		MemoryIDs: []string{"memory-a94b92a4214b2fbb29a03d353a82f884", "memory-durable-keep"},
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Applied) != 1 || result.Applied[0].MemoryID != "memory-a94b92a4214b2fbb29a03d353a82f884" {
+		t.Fatalf("Applied = %+v, want the echo id only", result.Applied)
+	}
+	if len(result.Failures) != 1 || result.Failures[0].MemoryID != "memory-durable-keep" {
+		t.Fatalf("Failures = %+v, want durable id (no current hygiene suggestion)", result.Failures)
+	}
+	if rejected := repo.rejectedIDs(); len(rejected) != 1 || rejected[0] != "memory-a94b92a4214b2fbb29a03d353a82f884" {
+		t.Fatalf("rejected ids = %v", rejected)
+	}
 }
 
 func TestMemoryHygieneApply_RejectsLowQualityCandidate(t *testing.T) {

--- a/application/usecase/memory_usecase_import_test.go
+++ b/application/usecase/memory_usecase_import_test.go
@@ -182,8 +182,8 @@ func (s *stubMemoryQueryService) ScanMemoryHygienePage(
 				continue
 			}
 			if criteria.Phase == apptypes.MemoryHygieneScanPhaseCandidateRows {
-				if summary.Status() != domtypes.MemoryStatusCandidate || (summary.Source() != domtypes.MemorySourceExtracted &&
-					(!criteria.IncludeHiddenCandidates || summary.Source() != domtypes.MemorySourceExtractedHidden)) {
+				if summary.Status() != domtypes.MemoryStatusCandidate ||
+					!apptypes.IsHygieneCandidateNoiseSource(summary.Source(), criteria.IncludeHiddenCandidates) {
 					continue
 				}
 			}

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -119,7 +119,7 @@ v0.21.0 以降、完全な構造を持つ unified-diff / git metadata のみ aut
 
 #### 候補の hygiene
 
-旧 sessions snapshot の hygiene pane は v0.42.0 で `traceary sessions` とともに削除されました（#2061）。候補 backlog の把握と掃除は `traceary memory inbox list`（テキストは `showing N of M candidates`。`--source` 未指定なら hidden も含む）と dry-run 既定の `traceary memory inbox cleanup --quality low` を使います（`--apply` で match を reject。cleanup は候補を reject するだけで、削除や auto-accept はしません）。`traceary memory admin hygiene scan` は exact な同一 scope・memory type・fact を超えた similarity ベースの重複検出を追加します。
+旧 sessions snapshot の hygiene pane は v0.42.0 で `traceary sessions` とともに削除されました（#2061）。候補 backlog の把握と掃除は `traceary memory inbox list`（テキストは `showing N of M candidates`。`--source` 未指定なら hidden も含む）と dry-run 既定の `traceary memory inbox cleanup --quality low` を使います（`--apply` で match を reject。cleanup は候補を reject するだけで、削除や auto-accept はしません）。`traceary memory admin hygiene scan` は exact な同一 scope・memory type・fact を超えた similarity ベースの重複検出を追加します。同じ scan の `low_quality_candidate` は、抽出時の echo 検出器（#2112）と structural-non-prose の drop 集合（#2020）を **すでに保存された** candidate にも適用します（compact-summary と remember-intent の payload echo を含む）。cleanup の dry-run はそれらを書き込まずに列挙し、`--apply` で reject します。cleanup は削除や auto-accept をしません。同じ日付範囲の非 echo candidate はそのままです。`traceary memory inbox restore` は expired（decay 済み）行の復元経路のままです。
 
 #### context boundary からの抽出
 

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -119,7 +119,7 @@ Since v0.21.0, only fully-formed unified-diff / git metadata is **dropped entire
 
 #### Candidate hygiene
 
-The former sessions snapshot hygiene pane was removed with `traceary sessions` in v0.42.0 (#2061). Gauge and clear the candidate backlog with `traceary memory inbox list` (text mode prints `showing N of M candidates`, including hidden unless `--source` is set) and the dry-run-first `traceary memory inbox cleanup --quality low` (add `--apply` to reject matches; cleanup only rejects candidates; it never deletes or auto-accepts). `traceary memory admin hygiene scan` adds similarity-based duplicate detection beyond exact same-scope / memory-type / fact matches.
+The former sessions snapshot hygiene pane was removed with `traceary sessions` in v0.42.0 (#2061). Gauge and clear the candidate backlog with `traceary memory inbox list` (text mode prints `showing N of M candidates`, including hidden unless `--source` is set) and the dry-run-first `traceary memory inbox cleanup --quality low` (add `--apply` to reject matches; cleanup only rejects candidates; it never deletes or auto-accepts). `traceary memory admin hygiene scan` adds similarity-based duplicate detection beyond exact same-scope / memory-type / fact matches. The same scan's `low_quality_candidate` pass applies the extraction-time echo detector (#2112) and structural-non-prose drop set (#2020) to **already stored** candidates, including compact-summary rows and remember-intent payload echoes. Dry-run cleanup lists those ids without writing; `--apply` rejects them. Cleanup never deletes or auto-accepts. Non-echo candidates in the same date range stay. `traceary memory inbox restore` still recovers expired (decayed) rows.
 
 #### Context-boundary extraction
 

--- a/infrastructure/sqlite/memory_hygiene_scan_source.go
+++ b/infrastructure/sqlite/memory_hygiene_scan_source.go
@@ -90,11 +90,14 @@ func (d *MemoryDatasource) ScanMemoryHygienePage(
 	case apptypes.MemoryHygieneScanPhaseAcceptedRows:
 		err = scanMemoryHygieneRows(ctx, tx, criteria, []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted}, nil, &result)
 	case apptypes.MemoryHygieneScanPhaseCandidateRows:
-		sources := []domtypes.MemorySource{domtypes.MemorySourceExtracted}
-		if criteria.IncludeHiddenCandidates {
-			sources = append(sources, domtypes.MemorySourceExtractedHidden)
-		}
-		err = scanMemoryHygieneRows(ctx, tx, criteria, []domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}, sources, &result)
+		err = scanMemoryHygieneRows(
+			ctx,
+			tx,
+			criteria,
+			[]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate},
+			apptypes.HygieneCandidateNoiseSources(criteria.IncludeHiddenCandidates),
+			&result,
+		)
 	case apptypes.MemoryHygieneScanPhaseExactDuplicates:
 		err = scanMemoryHygieneDuplicates(ctx, tx, criteria, &result)
 	case apptypes.MemoryHygieneScanPhaseSimilarityPairs:

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -471,6 +471,51 @@ func TestMemoryInboxList_AgeAndQualityFilters(t *testing.T) {
 	}
 }
 
+func TestMemoryInboxCleanup_DryRunListsEchoCandidatesAndSkipsDurable(t *testing.T) {
+	t.Parallel()
+
+	echo := buildInboxCandidateDetails(t, "memory-a94b92a4214b2fbb29a03d353a82f884", `{ "ephemeralMessage": "Remember to check for lint errors" }`, domtypes.MemorySourceExtracted)
+	hunk := buildInboxCandidateDetails(t, "memory-8433a201ee57689075069e12bf38dd41", "@@ -135,85 +135,85 @@ func inspect()", domtypes.MemorySourceExtracted)
+	durable := buildInboxCandidateDetails(t, "memory-durable-keep", "The two-pillar target is 41 invocables", domtypes.MemorySourceExtracted)
+	memoryStub := &memoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{echo.Summary(), hunk.Summary(), durable.Summary()},
+		showDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+			echo.Summary().MemoryID():    echo,
+			hunk.Summary().MemoryID():    hunk,
+			durable.Summary().MemoryID(): durable,
+		},
+		scanResult: apptypes.MemoryHygieneScanResult{
+			LowQualityCandidateCount: 2,
+			Suggestions: []apptypes.MemoryHygieneSuggestion{
+				{MemoryID: echo.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+				{MemoryID: hunk.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+			},
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "cleanup", "--limit", "20", "--db-path", t.TempDir() + "/t.db"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if memoryStub.rejectCallCount != 0 {
+		t.Fatalf("dry-run cleanup called Reject %d time(s), want 0", memoryStub.rejectCallCount)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "memory-a94b92a4214b2fbb29a03d353a82f884") || !strings.Contains(out, "memory-8433a201ee57689075069e12bf38dd41") {
+		t.Fatalf("dry-run missing echo ids:\n%s", out)
+	}
+	if strings.Contains(out, "memory-durable-keep") {
+		t.Fatalf("dry-run listed a non-echo candidate:\n%s", out)
+	}
+}
+
 func TestMemoryInboxCleanup_DryRunDoesNotReject(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`memory admin hygiene scan` `low_quality_candidate` now applies the extraction-time echo detector (#2112) and structural-non-prose drop set (#2020) to **already stored** candidates.

- Candidate-row sources: `extracted`, `remember-intent`, `compact-summary`; `extracted-hidden` remains opt-in
- remember-intent is flagged only for payload echo (`hidesDespiteRememberIntent`)
- Bulk resolution reuses `memory inbox cleanup` (dry-run first, `--apply` rejects). No new command, no auto-accept
- Sample ids from #2152 (`memory-a94b92a4214b2fbb29a03d353a82f884`, `memory-8433a201ee57689075069e12bf38dd41`) are listed on dry-run; a durable candidate in the same timestamp is not
- JSON keys unchanged

## Test plan

- [x] `go test ./application/usecase/ ./application/types/ ./presentation/cli/ ./infrastructure/sqlite/ -count=1`
- [x] `go test ./... -count=1`
- [x] `go build ./...`
- [x] `go tool golangci-lint run`

Closes #2152

Leaves parent #2188 open.