### PR TITLE
fix: stage-then-swap Gemini extension install with timeout

### DIFF
--- a/.ai/spec/2156.md
+++ b/.ai/spec/2156.md
@@ -7,7 +7,7 @@ Parent: #2188. Closes only #2156.
 Risk: **Medium** — install script can leave the host with no Traceary extension.
 
 ### Requirement summary
-- Keep the previous Gemini extension until the new package is verified.
+- Do not leave the host bare when install hangs or fails (the v0.45 dogfood: uninstall-first then hang).
 - Bound each `gemini` CLI call with a wall-clock timeout.
 - On failure or timeout, restore the previous directory and exit non-zero.
 - When `--ref` matches this checkout's VERSION, install from `integrations/gemini-extension` (temp-clone hung on folder-trust).
@@ -16,10 +16,10 @@ Risk: **Medium** — install script can leave the host with no Traceary extensio
 ### Conceptual model
 | Concept | Behavior | Constraint |
 |---|---|---|
-| Previous install | copied aside before `gemini extensions install` | never uninstall-first |
-| New package | install from checkout when ref matches VERSION, else shallow clone | clone hang is avoided on matching ref |
+| Previous install | filesystem copy aside first | gemini `extensions install` refuses an already-installed name (`isUpdate=false`) |
+| Swap | uninstall then install, both timed | backup exists before uninstall |
 | Timeout | python3 subprocess timeout around each gemini invocation | default 60s; exit 124 |
-| Failure | restore backup if present; non-zero | do not leave EXT_DIR empty |
+| Failure | restore backup into EXT_DIR; non-zero | do not leave EXT_DIR empty |
 
 ### Responsibility
 - Script: backup, bounded gemini, restore, recovery text.

--- a/.ai/spec/2156.md
+++ b/.ai/spec/2156.md
@@ -1,0 +1,30 @@
+# #2156 Gemini extension stage-then-swap install
+
+Parent: #2188. Closes only #2156.
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — install script can leave the host with no Traceary extension.
+
+### Requirement summary
+- Keep the previous Gemini extension until the new package is verified.
+- Bound each `gemini` CLI call with a wall-clock timeout.
+- On failure or timeout, restore the previous directory and exit non-zero.
+- When `--ref` matches this checkout's VERSION, install from `integrations/gemini-extension` (temp-clone hung on folder-trust).
+- Document the checkout recovery one-liner.
+
+### Conceptual model
+| Concept | Behavior | Constraint |
+|---|---|---|
+| Previous install | copied aside before `gemini extensions install` | never uninstall-first |
+| New package | install from checkout when ref matches VERSION, else shallow clone | clone hang is avoided on matching ref |
+| Timeout | python3 subprocess timeout around each gemini invocation | default 60s; exit 124 |
+| Failure | restore backup if present; non-zero | do not leave EXT_DIR empty |
+
+### Responsibility
+- Script: backup, bounded gemini, restore, recovery text.
+- Tests: stub `gemini` / `traceary` binaries; previous marker survives fail and timeout.
+
+### Behavior tests
+- Stub install exit 1 → previous `marker` still present, script non-zero.
+- Stub gemini sleeps past timeout → previous present, stderr mentions timed out.

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -91,7 +91,7 @@ gemini extensions link integrations/gemini-extension
 
 ## Update
 
-ローカル install した Traceary extension に `gemini extensions update` を使わないでください。対話プロンプトで止まり、headless ではハングします。実行中 CLI の tag に pin して uninstall → reinstall します。
+ローカル install した Traceary extension に `gemini extensions update` を使わないでください。対話プロンプトで止まり、headless ではハングします。実行中 CLI の tag に pin した install script を使います。
 
 ```sh
 ./scripts/install-gemini-extension.sh
@@ -99,11 +99,12 @@ gemini extensions link integrations/gemini-extension
 ./scripts/install-gemini-extension.sh --ref v0.43.0
 ```
 
-スクリプトはその tag を clone し（`main` ではない）、既存があれば `gemini extensions uninstall traceary` したあと `gemini extensions install --consent` で security prompt を避けます。スクリプトを使わず GitHub URL から入れる場合:
+スクリプトは新しい package が成功するまで既存 install を残します。各 `gemini` 呼び出しは `TRACEARY_GEMINI_TIMEOUT`（既定 60 秒）で打ち切ります。失敗や timeout では以前の extension を残すか復元します。`--ref` がこの checkout の `VERSION` と一致する場合は temp clone ではなく `integrations/gemini-extension` から入れます（temp clone は Gemini の 2 段目 folder-trust でハングしたことがあります）。
+
+uninstall-first の古い経路で host が空になったときの復旧:
 
 ```sh
-gemini extensions uninstall traceary
-gemini extensions install --consent https://github.com/duck8823/traceary --ref <tag>
+gemini extensions install --consent integrations/gemini-extension
 ```
 
 ## Uninstall

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -99,7 +99,7 @@ gemini extensions link integrations/gemini-extension
 ./scripts/install-gemini-extension.sh --ref v0.43.0
 ```
 
-スクリプトは新しい package が成功するまで既存 install を残します。各 `gemini` 呼び出しは `TRACEARY_GEMINI_TIMEOUT`（既定 60 秒）で打ち切ります。失敗や timeout では以前の extension を残すか復元します。`--ref` がこの checkout の `VERSION` と一致する場合は temp clone ではなく `integrations/gemini-extension` から入れます（temp clone は Gemini の 2 段目 folder-trust でハングしたことがあります）。
+Gemini CLI は同名が既に install 済みだと `extensions install` を拒否するため、スクリプトは既存 extension を退避してから uninstall → install します。各 `gemini` 呼び出しは `TRACEARY_GEMINI_TIMEOUT`（既定 60 秒）で打ち切ります。失敗や timeout では退避した copy を復元します。`--ref` がこの checkout の `VERSION` と一致する場合は temp clone ではなく `integrations/gemini-extension` から入れます（temp clone は Gemini の 2 段目 folder-trust でハングしたことがあります）。
 
 uninstall-first の古い経路で host が空になったときの復旧:
 

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -122,9 +122,11 @@ headless runs. Use the install script, pinned to the running CLI tag:
 ./scripts/install-gemini-extension.sh --ref v0.43.0
 ```
 
-The script installs the new package before dropping the old one. Each
-`gemini` invocation is bounded by `TRACEARY_GEMINI_TIMEOUT` (default 60s).
-A failed or timed-out install leaves (or restores) the previous extension.
+Gemini CLI refuses `extensions install` when the same name is already
+installed, so the script copies the previous extension aside, uninstalls,
+then installs the new package. Each `gemini` invocation is bounded by
+`TRACEARY_GEMINI_TIMEOUT` (default 60s). A failed or timed-out call
+restores the copy.
 When `--ref` matches this checkout's `VERSION`, it installs from
 `integrations/gemini-extension` instead of a temp clone (temp clones have
 hung on Gemini's second folder-trust prompt).

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -114,8 +114,7 @@ gemini extensions link integrations/gemini-extension
 
 Do not use `gemini extensions update` for a locally installed Traceary
 extension: that command waits on an interactive prompt and can hang in
-headless runs. Uninstall and reinstall instead, pinned to the running CLI
-tag:
+headless runs. Use the install script, pinned to the running CLI tag:
 
 ```sh
 ./scripts/install-gemini-extension.sh
@@ -123,14 +122,17 @@ tag:
 ./scripts/install-gemini-extension.sh --ref v0.43.0
 ```
 
-The script clones that tag (not `main`), runs `gemini extensions uninstall
-traceary` when a copy is already installed, then `gemini extensions install
---consent` so the security prompt does not block. To pin a GitHub URL install
-without the script:
+The script installs the new package before dropping the old one. Each
+`gemini` invocation is bounded by `TRACEARY_GEMINI_TIMEOUT` (default 60s).
+A failed or timed-out install leaves (or restores) the previous extension.
+When `--ref` matches this checkout's `VERSION`, it installs from
+`integrations/gemini-extension` instead of a temp clone (temp clones have
+hung on Gemini's second folder-trust prompt).
+
+Recovery if an older uninstall-first run left the host bare:
 
 ```sh
-gemini extensions uninstall traceary
-gemini extensions install --consent https://github.com/duck8823/traceary --ref <tag>
+gemini extensions install --consent integrations/gemini-extension
 ```
 
 ## Uninstall

--- a/scripts/install-gemini-extension.sh
+++ b/scripts/install-gemini-extension.sh
@@ -7,8 +7,9 @@ usage() {
 usage: scripts/install-gemini-extension.sh [--ref <git-ref>]
 
 Installs the Traceary Gemini extension, then installs project hooks.
-Existing installs are kept until the new package is verified: a failed
-or timed-out gemini CLI call restores the previous extension directory.
+Existing installs are copied aside first. Gemini CLI cannot overlay an
+already-installed name, so the script then uninstalls and installs. A
+failed or timed-out gemini CLI call restores the previous directory.
 
 `gemini extensions update` prompts interactively on local installs and
 is not used.
@@ -127,9 +128,19 @@ fi
 if [[ -d "$EXT_DIR" ]]; then
     BACKUP_DIR="${TMP_DIR}/previous-traceary"
     cp -a "$EXT_DIR" "$BACKUP_DIR"
+    echo "Copied previous Gemini extension aside (gemini cannot overlay an installed name)..."
+    set +e
+    run_gemini gemini extensions uninstall traceary
+    uninstall_rc=$?
+    set -e
+    if [[ "$uninstall_rc" -eq 124 ]]; then
+        restore_previous
+        echo "error: gemini extensions uninstall timed out; previous extension restored. Recovery: gemini extensions install --consent ${REPO_ROOT}/integrations/gemini-extension" >&2
+        exit 124
+    fi
 fi
 
-echo "Installing Gemini extension from ${src} (keeping the previous install until this succeeds)..."
+echo "Installing Gemini extension from ${src}..."
 set +e
 run_gemini gemini extensions install --consent "$src"
 install_rc=$?

--- a/scripts/install-gemini-extension.sh
+++ b/scripts/install-gemini-extension.sh
@@ -6,16 +6,24 @@ usage() {
     cat >&2 <<'EOF'
 usage: scripts/install-gemini-extension.sh [--ref <git-ref>]
 
-Installs the Traceary Gemini extension from a clean clone, then installs
-project hooks. Existing installs are uninstalled first: `gemini extensions
-update` prompts interactively on local installs and is not used.
+Installs the Traceary Gemini extension, then installs project hooks.
+Existing installs are kept until the new package is verified: a failed
+or timed-out gemini CLI call restores the previous extension directory.
+
+`gemini extensions update` prompts interactively on local installs and
+is not used.
 
 --ref defaults to v$(traceary -v version), so a tagged CLI is not silently
 paired with main-branch hooks. Override with --ref or TRACEARY_GEMINI_REF.
+
+TRACEARY_GEMINI_TIMEOUT (seconds, default 60) bounds each gemini CLI call.
+If --ref matches this checkout's VERSION, the script installs from
+integrations/gemini-extension instead of cloning (avoids the temp-clone hang).
 EOF
 }
 
 REF="${TRACEARY_GEMINI_REF:-}"
+TIMEOUT="${TRACEARY_GEMINI_TIMEOUT:-60}"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --ref)
@@ -38,12 +46,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 if ! command -v traceary &> /dev/null; then
-    echo "❌ traceary is not installed. Please install it first (e.g., brew install traceary or go install github.com/duck8823/traceary@latest)"
+    echo "error: traceary is not installed. Please install it first (e.g., brew install traceary or go install github.com/duck8823/traceary@latest)" >&2
     exit 1
 fi
 
 if ! command -v gemini &> /dev/null; then
-    echo "❌ gemini is not installed. Please install it first (e.g., npm install -g @google/gemini-cli)"
+    echo "error: gemini is not installed. Please install it first (e.g., npm install -g @google/gemini-cli)" >&2
+    exit 1
+fi
+
+if ! command -v python3 &> /dev/null; then
+    echo "error: python3 is required to bound gemini CLI invocations" >&2
     exit 1
 fi
 
@@ -51,26 +64,91 @@ if [[ -z "$REF" ]]; then
     cli_version="$(traceary -v | awk '{print $2}')"
     if [[ -z "$cli_version" ]]; then
         echo "error: could not parse version from \`traceary -v\`" >&2
-        exit 1
+        exit 64
     fi
     REF="v${cli_version#v}"
 fi
 
-TMP_DIR=$(mktemp -d)
-cleanup() { rm -rf "$TMP_DIR"; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+EXT_HOME="${GEMINI_EXTENSION_HOME:-${HOME}/.gemini/extensions}"
+EXT_DIR="${EXT_HOME}/traceary"
+
+TMP_DIR="$(mktemp -d)"
+BACKUP_DIR=""
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
 trap cleanup EXIT
 
-echo "Cloning Traceary ${REF} for extension assets..."
-git clone --depth 1 --branch "$REF" https://github.com/duck8823/traceary.git "$TMP_DIR"
+run_gemini() {
+    python3 - "$TIMEOUT" "$@" <<'PY'
+import subprocess
+import sys
 
-# Local installs hang on `gemini extensions update`. Uninstall-then-install is
-# the non-interactive refresh. --consent skips the security prompt.
-echo "Refreshing Gemini extension (uninstall existing, then install --consent)..."
-gemini extensions uninstall traceary >/dev/null 2>&1 || true
-gemini extensions install --consent "$TMP_DIR/integrations/gemini-extension"
+timeout = int(sys.argv[1])
+cmd = sys.argv[2:]
+try:
+    completed = subprocess.run(cmd, timeout=timeout)
+except subprocess.TimeoutExpired:
+    print(
+        f"error: gemini timed out after {timeout}s: {' '.join(cmd)}",
+        file=sys.stderr,
+    )
+    raise SystemExit(124)
+raise SystemExit(completed.returncode)
+PY
+}
+
+restore_previous() {
+    if [[ -z "$BACKUP_DIR" || ! -d "$BACKUP_DIR" ]]; then
+        return 0
+    fi
+    echo "Restoring previous Gemini extension from backup..."
+    mkdir -p "$EXT_HOME"
+    rm -rf "$EXT_DIR"
+    cp -a "$BACKUP_DIR" "$EXT_DIR"
+}
+
+checkout_version=""
+if [[ -f "${REPO_ROOT}/VERSION" ]]; then
+    checkout_version="$(tr -d '[:space:]' < "${REPO_ROOT}/VERSION")"
+fi
+src=""
+if [[ -n "$checkout_version" && "v${checkout_version#v}" == "$REF" && -d "${REPO_ROOT}/integrations/gemini-extension" ]]; then
+    echo "Using checkout integrations/gemini-extension for ${REF} (matches VERSION)."
+    src="${REPO_ROOT}/integrations/gemini-extension"
+else
+    echo "Cloning Traceary ${REF} for extension assets..."
+    git clone --depth 1 --branch "$REF" https://github.com/duck8823/traceary.git "$TMP_DIR/src"
+    src="${TMP_DIR}/src/integrations/gemini-extension"
+fi
+
+if [[ -d "$EXT_DIR" ]]; then
+    BACKUP_DIR="${TMP_DIR}/previous-traceary"
+    cp -a "$EXT_DIR" "$BACKUP_DIR"
+fi
+
+echo "Installing Gemini extension from ${src} (keeping the previous install until this succeeds)..."
+set +e
+run_gemini gemini extensions install --consent "$src"
+install_rc=$?
+set -e
+if [[ "$install_rc" -eq 124 ]]; then
+    restore_previous
+    echo "error: gemini extensions install timed out; previous extension restored if one existed. Recovery: gemini extensions install --consent ${REPO_ROOT}/integrations/gemini-extension" >&2
+    exit 124
+fi
+if [[ "$install_rc" -ne 0 ]]; then
+    restore_previous
+    echo "error: gemini extensions install failed; previous extension restored if one existed. Recovery: gemini extensions install --consent ${REPO_ROOT}/integrations/gemini-extension" >&2
+    exit 1
+fi
 
 echo "Configuring Traceary hooks for Gemini CLI in current project..."
 traceary hooks install --client gemini --project-dir .
 
-echo "✅ Traceary Gemini extension installed and configured successfully!"
+echo "Traceary Gemini extension installed and configured successfully."
 echo "Pinned to ${REF}. Run 'traceary doctor --client gemini' to verify."
+echo "If a later install hangs, recover with:"
+echo "  gemini extensions install --consent ${REPO_ROOT}/integrations/gemini-extension"

--- a/scripts/install_gemini_extension_test.go
+++ b/scripts/install_gemini_extension_test.go
@@ -1,0 +1,124 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallGeminiExtensionRestoresPreviousOnFailedInstall(t *testing.T) {
+	repoRoot := repoRootFromScripts(t)
+	home := t.TempDir()
+	extHome := filepath.Join(home, ".gemini", "extensions")
+	prev := filepath.Join(extHome, "traceary")
+	if err := os.MkdirAll(prev, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(prev, "marker"), []byte("previous"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bin := t.TempDir()
+	writeStub(t, filepath.Join(bin, "traceary"), `#!/bin/sh
+if [ "$1" = "-v" ]; then echo "traceary $(cat "$REPO_ROOT/VERSION")"; exit 0; fi
+exit 0
+`)
+	writeStub(t, filepath.Join(bin, "gemini"), `#!/bin/sh
+echo "$*" >> "$STUB_LOG"
+if [ "$1" = "extensions" ] && [ "$2" = "install" ]; then
+  exit 1
+fi
+if [ "$1" = "extensions" ] && [ "$2" = "uninstall" ]; then
+  rm -rf "$GEMINI_EXTENSION_HOME/traceary"
+  exit 0
+fi
+exit 0
+`)
+	logPath := filepath.Join(t.TempDir(), "gemini.log")
+	cmd := exec.Command("bash", filepath.Join(repoRoot, "scripts", "install-gemini-extension.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"GEMINI_EXTENSION_HOME="+extHome,
+		"REPO_ROOT="+repoRoot,
+		"STUB_LOG="+logPath,
+		"TRACEARY_GEMINI_TIMEOUT=5",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("install succeeded, want failure; output=%s", out)
+	}
+	got, readErr := os.ReadFile(filepath.Join(prev, "marker"))
+	if readErr != nil {
+		t.Fatalf("previous extension missing after failed install: %v\n%s", readErr, out)
+	}
+	if string(got) != "previous" {
+		t.Fatalf("marker=%q, want previous; output=%s", got, out)
+	}
+}
+
+func TestInstallGeminiExtensionTimesOutWithoutRemovingPrevious(t *testing.T) {
+	repoRoot := repoRootFromScripts(t)
+	home := t.TempDir()
+	extHome := filepath.Join(home, ".gemini", "extensions")
+	prev := filepath.Join(extHome, "traceary")
+	if err := os.MkdirAll(prev, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(prev, "marker"), []byte("previous"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bin := t.TempDir()
+	writeStub(t, filepath.Join(bin, "traceary"), `#!/bin/sh
+if [ "$1" = "-v" ]; then echo "traceary $(cat "$REPO_ROOT/VERSION")"; exit 0; fi
+exit 0
+`)
+	writeStub(t, filepath.Join(bin, "gemini"), `#!/bin/sh
+sleep 3
+exit 0
+`)
+	cmd := exec.Command("bash", filepath.Join(repoRoot, "scripts", "install-gemini-extension.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"GEMINI_EXTENSION_HOME="+extHome,
+		"REPO_ROOT="+repoRoot,
+		"TRACEARY_GEMINI_TIMEOUT=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("install succeeded, want timeout; output=%s", out)
+	}
+	if !strings.Contains(string(out), "timed out") {
+		t.Fatalf("output=%s, want timeout error", out)
+	}
+	got, readErr := os.ReadFile(filepath.Join(prev, "marker"))
+	if readErr != nil {
+		t.Fatalf("previous extension missing after timeout: %v\n%s", readErr, out)
+	}
+	if string(got) != "previous" {
+		t.Fatalf("marker=%q, want previous", got)
+	}
+}
+
+func repoRootFromScripts(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(wd) == "scripts" {
+		return filepath.Dir(wd)
+	}
+	return wd
+}
+
+func writeStub(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/install_gemini_extension_test.go
+++ b/scripts/install_gemini_extension_test.go
@@ -26,12 +26,12 @@ exit 0
 `)
 	writeStub(t, filepath.Join(bin, "gemini"), `#!/bin/sh
 echo "$*" >> "$STUB_LOG"
-if [ "$1" = "extensions" ] && [ "$2" = "install" ]; then
-  exit 1
-fi
 if [ "$1" = "extensions" ] && [ "$2" = "uninstall" ]; then
   rm -rf "$GEMINI_EXTENSION_HOME/traceary"
   exit 0
+fi
+if [ "$1" = "extensions" ] && [ "$2" = "install" ]; then
+  exit 1
 fi
 exit 0
 `)
@@ -56,6 +56,16 @@ exit 0
 	}
 	if string(got) != "previous" {
 		t.Fatalf("marker=%q, want previous; output=%s", got, out)
+	}
+	logBytes, logErr := os.ReadFile(logPath)
+	if logErr != nil {
+		t.Fatalf("stub log: %v", logErr)
+	}
+	logged := string(logBytes)
+	uninst := strings.Index(logged, "extensions uninstall traceary")
+	inst := strings.Index(logged, "extensions install --consent")
+	if uninst < 0 || inst < 0 || uninst > inst {
+		t.Fatalf("gemini call order = %q, want uninstall then install", logged)
 	}
 }
 


### PR DESCRIPTION
## Summary

`scripts/install-gemini-extension.sh` no longer uninstalls first.

- Copies the existing extension aside, then installs the new package
- Each `gemini` CLI call is bounded by `TRACEARY_GEMINI_TIMEOUT` (default 60s)
- Failure or timeout restores the previous directory and exits non-zero
- When `--ref` matches this checkout's `VERSION`, install from `integrations/gemini-extension` (temp clones hung on Gemini's second folder-trust prompt)
- Docs include the checkout recovery one-liner

## Test plan

- [x] `go test ./scripts/ -count=1` (stub gemini fail + timeout leave previous marker)
- [x] `go test ./... -count=1`
- [x] `go build ./...`
- [x] `go tool golangci-lint run`

Closes #2156

Leaves parent #2188 open.