### PR TITLE
fix: drain hook spool on large-store doctor --fix after requeue

### DIFF
--- a/.ai/spec/2207.md
+++ b/.ai/spec/2207.md
@@ -1,0 +1,79 @@
+# Issue 2207: large-store doctor `--fix` must drain hook-spool after requeue
+
+Engine: grok 4.6 medium  
+Date: 2026-08-21  
+Parent: #2208  
+PR: `Closes #2207` only (never #2208 / #2205)
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — changes operator-visible `doctor --fix` contract on ≥2 GiB stores (SQLite may open for spool replay). Counter **names** stay frozen.
+
+### Requirement summary
+- 目的: live ≥2 GiB store の `doctor --fix` が transient dead-letter を pending に戻したあと、同じ invocation で spool replay まで行い、organic hook に 870 件を押し付けない。
+- 現状: `inspectHookSpoolFilesystemMetadata` の `--fix` は `fixHookSpoolDeadLettersFilesystem`（requeue + 14d prune のみ）。`drainHookSpoolRecordsUntil` は full-doctor `inspectHookSpoolDiagnosticsFromScan` だけが呼ぶ。
+- 期待する振る舞い:
+  - metadata-only **inspect** は従来どおりディレクトリ件数のみ（payload body を message/hint に出さない、dbstat を歩かない）。
+  - `--fix --dry-run` は SQLite を開かず、full path と同じく drain 予定件数を Action に含める。
+  - `--fix` は requeue → `drainHookSpoolRecordsUntil`（既存 45s wall / round 200）→ prune。spool replay は event 書き込みのみ。InspectCapacity / dbstat / event-body walk はしない。
+  - non-transient dead-letter は skip のまま。JSON metric 既存キーは残し、drain 用キー（`replayed` / `failed` / `unreadable` / `remaining`）を full path と揃えて加算してよい。
+- 非対象: 13 GiB を capacity/dbstat で開くこと。non-transient の自動削除。Grok plugin reload（#2209）。`session_ended` 合成。spool JSON フィールド名の変更。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Metadata-only inspect | store file ≥2 GiB | dirent counts + byte sizes | no payload decode in check text; no SQLite |
+| Large-store `--fix` | same check, operator asked fix | requeue transient + drain pending + prune 14d | drain uses existing wall/round; no dbstat |
+| Dry-run | `--fix --dry-run` | count planned requeue/drain/prune | no file moves, no SQLite |
+| Full-doctor `--fix` | store <2 GiB | already requeue+drain | reuse the same fixer; do not fork a third loop |
+| Non-transient dead | last_error class | skip | unchanged |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Inspect counts | `inspectHookSpoolFilesystemStats` | unchanged | |
+| Large-store check wiring | `(*RootCLI).inspectHookSpoolFilesystemMetadata` | StructuredFixFunc が RootCLI drain を呼ぶ必要がある。今日の package-level func では呼べない | package-level `fixHookSpoolDeadLettersFilesystem` は dry-run/requeue/prune の部品として残してよい |
+| Shared `--fix` body | extract `(*RootCLI).fixHookSpoolRequeueThenDrain` used by full-scan and metadata-only | 1 loop, 1 wall, 1 metric map | 経路ごとに drain をコピーしない |
+| Replay | existing `drainHookSpoolRecordsUntil` → `replayHookSpoolRecord` | 変更しない | 新しい replay 実装を作らない |
+| Capacity / dbstat | skippedStoreCapacityCheck / InspectCapacity | この PR から呼ばない | large-store skip 契約 |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `inspectHookSpoolFilesystemMetadata` | `runDoctor` large-store path (`doctor.go`) | becomes RootCLI method; check name stays `hook-spool` | inspect errors → FAIL as today |
+| `StructuredFixFunc` | `runDoctor --fix` | dry-run: no SQLite; apply: drain may open SQLite via hook replay `db_path` | wrapcheck; wall timeout reports `remaining` |
+| Hint / Action strings | operators, tests | Hint must no longer claim “without opening SQLite” for `--fix` | English + ja Localize |
+| Metric keys | doctor JSON `fixes[]` | keep `requeued`, `skipped_nontransient`, `pruned_dead`, `dead_remaining`, `pruned_tmp`; add drain keys matching full path | do not rename |
+
+`doctor.go` comment that large-store path “does not open spool payloads” applies to **inspect**, not to `--fix`. Update that comment so `--fix` spool replay is an allowed SQLite open.
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Inspect still metadata-only | pending+dead files with secret payload | `inspectHookSpoolFilesystemMetadata` | WARN counts; secret not in Message/Hint; AutoFix available | unit (existing, keep) |
+| Dry-run names drain, no I/O | transient dead + pending | StructuredFixFunc(dryRun=true) | Action contains drain wording; dead/pending files unchanged; no SQLite | unit |
+| Apply requeues and drains | 1 transient dead (deadline class) + 1 pending prompt; RootCLI with throwaway db | StructuredFixFunc(false) | dead gone; pending count falls (replayed or remaining reported); Action has `replayed=` | unit |
+| Non-transient skipped | non-transient last_error dead letter | `--fix` | `skipped_nontransient>=1`; file remains in dead/ | unit |
+| Existing test replacement | `TestInspectHookSpoolFilesystemMetadata_FixRequeuesWithoutDrain` | rewrite | expect drain, not requeue-only | unit |
+| Docs | large-store-doctor.md + ja | `--fix` may open SQLite for spool replay only | bilingual | docs |
+| No dbstat | large-store `--fix` fixture | run fixer | InspectCapacity / dbstat not invoked (no new call sites from this fixer) | unit / grep in PR |
+
+### TDD plan
+| Behavior | Red | Green | Refactor |
+|---|---|---|---|
+| Dry-run drain wording | fail current filesystem fixer Action | shared fixer dry-run text | |
+| Apply drain | rewrite FixRequeuesWithoutDrain | RootCLI method + drainHookSpoolRecordsUntil | extract shared fixer with full-scan path |
+| Hint | string assert | update Localize | |
+| Docs | | large-store-doctor.md(+ja) | |
+
+### Risks / rollback
+- 手続き化リスク: metadata-only と full で StructuredFix を二重実装しない。共有は `fixHookSpoolRequeueThenDrain`。
+- SQLite on large store: replay writes events through existing hook handlers; still no dbstat. If store is locked, drain reports failed/remaining like full path — do not retry-loop past 45s.
+- Live home store: tests use `t.TempDir` db + hook state dir; never point a repo-built binary at `~/.config/traceary/traceary.db`.
+- rollback: revert PR; spool files remain durable; operators can still organic-drain.
+
+Binding decisions (do not bikeshed):
+1. Pin option 2 (drain on `--fix`), not “don’t requeue”.
+2. Reuse `hookSpoolDeadRequeueDoctorWall` (45s) and `hookSpoolDoctorDrainRoundLimit` (200).
+3. `inspectHookSpoolFilesystemMetadata` becomes a RootCLI method; `doctor.go` calls `c.inspectHookSpoolFilesystemMetadata()`.
+4. Existing `fixHookSpoolDeadLettersFilesystem` may remain as the requeue/prune helper used by the shared fixer, or be inlined — do not leave a public `--fix` path that requeues without drain.

--- a/docs/operations/large-store-doctor.ja.md
+++ b/docs/operations/large-store-doctor.ja.md
@@ -36,15 +36,19 @@ hook route）は引き続き bounded report から除外されます。
   read command を使用してください。raw event body、prompt/response payload、credential、
   identifier list を incident report にコピーしないでください。
 
-この mode の既定コマンドは data を変更しません。`--fix` は small store では従来どおり
-ですが、metadata-only の結果から retention 操作には進みません。
+この mode の既定コマンドは data を変更しません。`--fix` は report を
+metadata-only のまま保ちつつ hook spool に作用します。transient dead-letter を
+再キューし、spool replay で未処理 record を drain し、14 日より古い
+dead-letter と orphan `*.tmp` を prune します。spool replay は event 書き込みの
+ためだけに SQLite を開くことがあります。dbstat、event body、store 容量は
+読みません。`--fix --dry-run` は何も開きません。
 
 ## 2 つの doctor mode と check のスコープ
 
 | Mode | いつ | Store アクセス | `hook-spool` の単位 |
 |---|---|---|---|
 | **Full** | store file が無い、または 2 GiB 未満 | store-scoped check のために SQLite を開く | 選択中 `--client` 向けの **decoded records**。比較用に `filesystem pending files (store-independent)=N` も同じ行に出す |
-| **Metadata-only** | regular store file が 2 GiB 以上（`mode: "metadata_only_large_store"`） | filesystem metadata と O(1) の `mode=ro` page/projection 読み | **files**（`metadata-only, store-independent`）。`pending=` はディレクトリエントリ数であり decoded record 数ではない |
+| **Metadata-only** | regular store file が 2 GiB 以上（`mode: "metadata_only_large_store"`） | filesystem metadata と O(1) の `mode=ro` page/projection 読み。`--fix` は hook spool replay のためだけに追加で SQLite を開くことがある | **files**（`metadata-only, store-independent`）。`pending=` はディレクトリエントリ数であり decoded record 数ではない |
 
 store-independent な check（hook spool、hook-state residue、SessionEnd cancellation marker、plugin cache、`path` / `config`）は出力行に `store-independent` と書きます。SQLite store ではなく host file を見ます。store-scoped な check（capacity、memory activation、projection）は `DB_PATH` の store を見ます。
 

--- a/docs/operations/large-store-doctor.md
+++ b/docs/operations/large-store-doctor.md
@@ -39,16 +39,19 @@ excluded from the bounded report.
   prompt/response payloads, credentials, or identifier lists into incident
   reports.
 
-The default command never changes data in this mode. `--fix` retains its normal
-meaning for small stores, but does not turn the metadata-only outcome into a
-retention operation.
+The default command never changes data in this mode. `--fix` keeps the report
+metadata-only but acts on the hook spool: it requeues transient dead letters,
+drains pending records through spool replay, and prunes dead-letter files and
+orphan `*.tmp` leftovers older than 14 days. Spool replay may open SQLite for
+event writes only — it never walks dbstat, event bodies, or store capacity —
+and `--fix --dry-run` opens nothing.
 
 ## Two doctor modes and check scoping
 
 | Mode | When | Store access | `hook-spool` unit |
 |---|---|---|---|
 | **Full** | store file missing, or smaller than 2 GiB | opens SQLite for store-scoped checks | **decoded records** for the selected `--client` filter, plus `filesystem pending files (store-independent)=N` so the number can be compared with a metadata-only run |
-| **Metadata-only** | regular store file ≥ 2 GiB (`mode: "metadata_only_large_store"`) | filesystem metadata plus the O(1) `mode=ro` page/projection read | **files** labeled `metadata-only, store-independent` (`pending=` is a directory entry count, not decoded records) |
+| **Metadata-only** | regular store file ≥ 2 GiB (`mode: "metadata_only_large_store"`) | filesystem metadata plus the O(1) `mode=ro` page/projection read; `--fix` may additionally open SQLite for hook-spool replay only | **files** labeled `metadata-only, store-independent` (`pending=` is a directory entry count, not decoded records) |
 
 Store-independent checks (hook spool, hook-state residue, SessionEnd cancellation markers, plugin cache, `path` / `config`) say `store-independent` on the output line. They inspect host files, not the SQLite store. Store-scoped checks (capacity, memory activation, projection) inspect the store at `DB_PATH`.
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -381,8 +381,10 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		// walk dbstat, or inspect client state here: those operations can
 		// block behind a live writer and some inspect event bodies/payloads.
 		// Hook spool is still reported via directory entry counts and byte
-		// sizes only (pending / stale inflight / dead-letter).
-		report.Checks = append(report.Checks, inspectHookSpoolFilesystemMetadata())
+		// sizes only (pending / stale inflight / dead-letter). --fix on this
+		// check is allowed to open SQLite for spool replay only (requeue +
+		// drain + prune); inspect and --fix --dry-run stay filesystem-only.
+		report.Checks = append(report.Checks, c.inspectHookSpoolFilesystemMetadata())
 		if c.workspaceIdentity != nil {
 			report.Checks = append(report.Checks, skippedWorkspaceAliasesCheck())
 		}

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -1250,8 +1250,11 @@ func pruneHookSpoolOrphanTmpFiles(now time.Time, dryRun bool) (pruned, remaining
 
 // inspectHookSpoolFilesystemMetadata builds a doctor check from directory
 // metadata only (entry counts + byte sizes). Safe on the large-store early
-// path: no SQLite open. Fix reads last_error envelope fields only.
-func inspectHookSpoolFilesystemMetadata() doctorCheck {
+// path: inspect opens no SQLite. --fix requeues transient dead letters by
+// reading last_error envelope fields only, then drains pending records via
+// the shared fixer; that spool replay may open SQLite (never dbstat or
+// capacity), while --fix --dry-run performs no file moves and opens nothing.
+func (c *RootCLI) inspectHookSpoolFilesystemMetadata() doctorCheck {
 	const name = "hook-spool"
 	stats, err := inspectHookSpoolFilesystemStats(time.Now().UTC())
 	if err != nil {
@@ -1287,25 +1290,36 @@ func inspectHookSpoolFilesystemMetadata() doctorCheck {
 			formatByteSize(stats.DeadBytes),
 		),
 		Hint: Localize(
-			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations. `traceary doctor --fix` requeues transient dead letters and prunes dead-letter files and orphan *.tmp leftovers older than 14 days without opening SQLite.",
-			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook で drain されます。`traceary doctor --fix` は SQLite を開かず transient dead-letter を再キューし、14 日より古い dead-letter と orphan *.tmp を prune します。",
+			"metadata-only counts from the hook spool directory (no payload bodies). Pending records drain on later hook invocations. `traceary doctor --fix` requeues transient dead letters, drains pending records (spool replay may open SQLite; `--fix --dry-run` does not), and prunes dead-letter files and orphan *.tmp leftovers older than 14 days.",
+			"hook spool ディレクトリのメタデータのみの件数です（payload body は読みません）。未処理 record は後続 hook で drain されます。`traceary doctor --fix` は transient dead-letter を再キューし、未処理 record を drain し（spool replay は SQLite を開くことがあります。`--fix --dry-run` は開きません）、14 日より古い dead-letter と orphan *.tmp を prune します。",
 		),
 	}
 	if status == doctorStatusWarn {
 		check.FixCommand = "traceary doctor --fix"
 		check.AutoFixAvailable = true
 		check.StructuredFixFunc = func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
-			return fixHookSpoolDeadLettersFilesystem(ctx, time.Now().UTC(), dryRun)
+			return c.fixHookSpoolRequeueThenDrain(ctx, time.Now().UTC(), dryRun)
 		}
 		check.FixFunc = func(ctx context.Context, dryRun bool) (string, error) {
-			result, err := fixHookSpoolDeadLettersFilesystem(ctx, time.Now().UTC(), dryRun)
+			result, err := c.fixHookSpoolRequeueThenDrain(ctx, time.Now().UTC(), dryRun)
 			return result.Action, err
 		}
 	}
 	return check
 }
 
-func fixHookSpoolDeadLettersFilesystem(ctx context.Context, now time.Time, dryRun bool) (doctorFixResult, error) {
+// fixHookSpoolRequeueThenDrain is the shared doctor --fix body for both the
+// full-scan and the large-store metadata-only hook-spool checks: requeue
+// transient dead letters, drain pending records through the existing spool
+// replay, then prune aged dead-letter and orphan tmp files. Dry-run performs
+// no file moves and does not open SQLite. Apply may open SQLite only for
+// spool replay via drainHookSpoolRecordsUntil / replayHookSpoolRecord — never
+// dbstat or store capacity.
+func (c *RootCLI) fixHookSpoolRequeueThenDrain(ctx context.Context, now time.Time, dryRun bool) (doctorFixResult, error) {
+	pending, err := countHookSpoolPendingPaths(now)
+	if err != nil {
+		return doctorFixResult{}, err
+	}
 	requeued, skippedNontransient, _, err := requeueHookSpoolDeadLettersUntil(ctx, now, dryRun)
 	if err != nil {
 		return doctorFixResult{}, err
@@ -1320,20 +1334,29 @@ func fixHookSpoolDeadLettersFilesystem(ctx context.Context, now time.Time, dryRu
 	}
 	if dryRun {
 		return doctorFixResult{Action: localizef(
-			"would requeue %d transient dead-letter(s), skip %d non-transient, prune %d aged dead-letter file(s), and prune %d orphan tmp file(s)",
-			"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、古い dead-letter %d 件と orphan tmp %d 件を prune します",
+			"would requeue %d transient dead-letter(s), skip %d non-transient, drain up to %d pending hook spool record(s), prune %d aged dead-letter file(s), and prune %d orphan tmp file(s)",
+			"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、未処理 hook spool record 最大 %d 件を drain し、古い dead-letter %d 件と orphan tmp %d 件を prune します",
 			requeued,
 			skippedNontransient,
+			pending+requeued,
 			pruned,
 			prunedTmp,
 		)}, nil
 	}
+	result := c.drainHookSpoolRecordsUntil(ctx, pending+requeued)
+	if result.Err != nil {
+		return doctorFixResult{}, result.Err
+	}
 	return doctorFixResult{
 		Action: localizef(
-			"requeued=%d skipped_nontransient=%d pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
-			"requeued=%d skipped_nontransient=%d pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
+			"drained hook spool: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
+			"hook spool を drain しました: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
 			requeued,
 			skippedNontransient,
+			result.Replayed,
+			result.Failed,
+			result.Unreadable,
+			result.Remaining,
 			pruned,
 			deadRemaining,
 			prunedTmp,
@@ -1341,6 +1364,10 @@ func fixHookSpoolDeadLettersFilesystem(ctx context.Context, now time.Time, dryRu
 		Metrics: map[string]int{
 			"requeued":             requeued,
 			"skipped_nontransient": skippedNontransient,
+			"replayed":             result.Replayed,
+			"failed":               result.Failed,
+			"remaining":            result.Remaining,
+			"unreadable":           result.Unreadable,
 			"pruned_dead":          pruned,
 			"dead_remaining":       deadRemaining,
 			"pruned_tmp":           prunedTmp,
@@ -1443,64 +1470,7 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		}
 	}
 	structuredFix := func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
-		now := time.Now().UTC()
-		pending, err := countHookSpoolPendingPaths(now)
-		if err != nil {
-			return doctorFixResult{}, err
-		}
-		requeued, skippedNontransient, _, err := requeueHookSpoolDeadLettersUntil(ctx, now, dryRun)
-		if err != nil {
-			return doctorFixResult{}, err
-		}
-		pruned, deadRemaining, err := pruneHookSpoolDeadLetters(now, dryRun)
-		if err != nil {
-			return doctorFixResult{}, err
-		}
-		prunedTmp, _, err := pruneHookSpoolOrphanTmpFiles(now, dryRun)
-		if err != nil {
-			return doctorFixResult{}, err
-		}
-		if dryRun {
-			return doctorFixResult{Action: localizef(
-				"would requeue %d transient dead-letter(s), skip %d non-transient, drain up to %d pending hook spool record(s), prune %d aged dead-letter file(s), and prune %d orphan tmp file(s)",
-				"transient dead-letter %d 件を再キューし、非 transient %d 件をスキップし、未処理 hook spool record 最大 %d 件を drain し、古い dead-letter %d 件と orphan tmp %d 件を prune します",
-				requeued,
-				skippedNontransient,
-				pending+requeued,
-				pruned,
-				prunedTmp,
-			)}, nil
-		}
-		result := c.drainHookSpoolRecordsUntil(ctx, pending+requeued)
-		if result.Err != nil {
-			return doctorFixResult{}, result.Err
-		}
-		return doctorFixResult{
-			Action: localizef(
-				"drained hook spool: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
-				"hook spool を drain しました: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
-				requeued,
-				skippedNontransient,
-				result.Replayed,
-				result.Failed,
-				result.Unreadable,
-				result.Remaining,
-				pruned,
-				deadRemaining,
-				prunedTmp,
-			),
-			Metrics: map[string]int{
-				"requeued":             requeued,
-				"skipped_nontransient": skippedNontransient,
-				"replayed":             result.Replayed,
-				"failed":               result.Failed,
-				"remaining":            result.Remaining,
-				"unreadable":           result.Unreadable,
-				"pruned_dead":          pruned,
-				"dead_remaining":       deadRemaining,
-				"pruned_tmp":           prunedTmp,
-			},
-		}, nil
+		return c.fixHookSpoolRequeueThenDrain(ctx, time.Now().UTC(), dryRun)
 	}
 	latest := "-"
 	if len(records) > 0 {

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1617,7 +1617,7 @@ func TestInspectHookSpoolFilesystemMetadata_CountsWithoutReadingPayloads(t *test
 		t.Fatalf("byte sizes must be positive: %+v", stats)
 	}
 
-	check := inspectHookSpoolFilesystemMetadata()
+	check := (&RootCLI{}).inspectHookSpoolFilesystemMetadata()
 	if check.Status != doctorStatusWarn {
 		t.Fatalf("status=%q, want warn", check.Status)
 	}
@@ -1878,7 +1878,7 @@ func TestRequeueHookSpoolDeadLettersUntil_StopsWhenWallClockExpires(t *testing.T
 	}
 }
 
-func TestFixHookSpoolDeadLettersFilesystem_DryRunPreviewsFullDrain(t *testing.T) {
+func TestFixHookSpoolRequeueThenDrain_DryRunPreviewsFullDrain(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)
 	deadDir := filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
@@ -1889,64 +1889,146 @@ func TestFixHookSpoolDeadLettersFilesystem_DryRunPreviewsFullDrain(t *testing.T)
 	for i := 0; i < total; i++ {
 		writeTransientDeadLetter(t, deadDir, fmt.Sprintf("t-%04d.json", i))
 	}
-	result, err := fixHookSpoolDeadLettersFilesystem(context.Background(), time.Now().UTC(), true)
+	result, err := (&RootCLI{}).fixHookSpoolRequeueThenDrain(context.Background(), time.Now().UTC(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(result.Action, fmt.Sprintf("would requeue %d transient", total)) {
 		t.Fatalf("dry-run action=%q, want full planned count %d", result.Action, total)
 	}
+	if !strings.Contains(result.Action, fmt.Sprintf("drain up to %d pending hook spool record(s)", total)) {
+		t.Fatalf("dry-run action=%q, want drain plan for %d requeued records", result.Action, total)
+	}
 	if entries, err := os.ReadDir(deadDir); err != nil || len(entries) != total {
 		t.Fatalf("dry-run must leave files, n=%d err=%v", len(entries), err)
 	}
 }
 
-func TestInspectHookSpoolFilesystemMetadata_FixRequeuesWithoutDrain(t *testing.T) {
-	stateDir := t.TempDir()
-	t.Setenv(hookStateDirEnvKey, stateDir)
-	deadDir := filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
-	if err := os.MkdirAll(deadDir, 0o700); err != nil {
-		t.Fatal(err)
+func TestInspectHookSpoolFilesystemMetadata_FixRequeuesAndDrains(t *testing.T) {
+	writeDeadLetter := func(t *testing.T, deadDir, name, payload, lastError string) {
+		t.Helper()
+		record := hookSpoolRecord{
+			SchemaVersion: hookSpoolSchemaVersion,
+			Command:       "prompt",
+			Client:        "claude",
+			Payload:       payload,
+			CreatedAt:     time.Now().UTC(),
+			AttemptCount:  hookSpoolRetryLimit,
+			LastError:     lastError,
+		}
+		encoded, err := json.Marshal(record)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(deadDir, name), append(encoded, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
-	record := hookSpoolRecord{
-		SchemaVersion: hookSpoolSchemaVersion,
-		Command:       "audit",
-		Client:        "claude",
-		Payload:       `{"sentinel":"PRIVATE-BODY"}`,
-		CreatedAt:     time.Now().UTC(),
-		AttemptCount:  hookSpoolRetryLimit,
-		LastError:     "failed to ping SQLite DB: context deadline exceeded",
+	persistPending := func(t *testing.T, prompt string) {
+		t.Helper()
+		if _, err := persistHookSpoolRecord(hookSpoolRecord{
+			SchemaVersion: hookSpoolSchemaVersion,
+			Command:       "prompt",
+			Client:        "claude",
+			Payload:       fmt.Sprintf(`{"prompt":%q,"session_id":"s-fix","cwd":"/tmp"}`, prompt),
+			CreatedAt:     time.Now().UTC().Add(-time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
 	}
-	encoded, err := json.Marshal(record)
-	if err != nil {
-		t.Fatal(err)
+	setupSpool := func(t *testing.T) (stateDir, deadDir string) {
+		t.Helper()
+		stateDir = t.TempDir()
+		t.Setenv(hookStateDirEnvKey, stateDir)
+		deadDir = filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
+		if err := os.MkdirAll(deadDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		return stateDir, deadDir
 	}
-	if err := os.WriteFile(filepath.Join(deadDir, "deadline.json"), append(encoded, '\n'), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := persistHookSpoolRecord(hookSpoolRecord{
-		SchemaVersion: hookSpoolSchemaVersion,
-		Command:       "prompt",
-		Client:        "claude",
-		Payload:       `{}`,
-		CreatedAt:     time.Now().UTC(),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	check := inspectHookSpoolFilesystemMetadata()
-	if !check.AutoFixAvailable || check.StructuredFixFunc == nil {
-		t.Fatal("expected filesystem auto-fix")
-	}
-	result, err := check.StructuredFixFunc(context.Background(), false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Metrics["requeued"] != 1 || strings.Contains(result.Action, "PRIVATE-BODY") {
-		t.Fatalf("result=%+v", result)
-	}
-	if _, err := os.Stat(filepath.Join(deadDir, "deadline.json")); !os.IsNotExist(err) {
-		t.Fatalf("dead letter must be requeued, stat err=%v", err)
-	}
+
+	t.Run("dry-run names drain and leaves files unchanged", func(t *testing.T) {
+		_, deadDir := setupSpool(t)
+		writeDeadLetter(t, deadDir, "deadline.json", `{"prompt":"PRIVATE-BODY","session_id":"s-dead","cwd":"/tmp"}`, "failed to ping SQLite DB: context deadline exceeded")
+		persistPending(t, "pending-prompt")
+
+		check := (&RootCLI{}).inspectHookSpoolFilesystemMetadata()
+		if !check.AutoFixAvailable || check.StructuredFixFunc == nil {
+			t.Fatal("expected filesystem auto-fix")
+		}
+		result, err := check.StructuredFixFunc(context.Background(), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(result.Action, "drain up to 2 pending hook spool record(s)") {
+			t.Fatalf("dry-run action=%q, want drain plan for pending+requeued", result.Action)
+		}
+		if strings.Contains(result.Action, "PRIVATE-BODY") {
+			t.Fatalf("dry-run action leaked payload body: %q", result.Action)
+		}
+		if entries, err := os.ReadDir(deadDir); err != nil || len(entries) != 1 {
+			t.Fatalf("dry-run must leave dead letters, n=%d err=%v", len(entries), err)
+		}
+		if pending, err := countHookSpoolPendingPaths(time.Now().UTC()); err != nil || pending != 1 {
+			t.Fatalf("dry-run must leave pending files, pending=%d err=%v", pending, err)
+		}
+	})
+
+	t.Run("apply requeues transient dead letters and drains pending", func(t *testing.T) {
+		_, deadDir := setupSpool(t)
+		writeDeadLetter(t, deadDir, "deadline.json", `{"prompt":"PRIVATE-BODY","session_id":"s-dead","cwd":"/tmp"}`, "failed to ping SQLite DB: context deadline exceeded")
+		persistPending(t, "pending-prompt")
+
+		eventStub := &spoolEventUsecaseStub{}
+		root := NewRootCLI(
+			WithStoreManagement(&spoolStoreManagementStub{}),
+			WithEvent(eventStub),
+		)
+		check := root.inspectHookSpoolFilesystemMetadata()
+		if !check.AutoFixAvailable || check.StructuredFixFunc == nil {
+			t.Fatal("expected filesystem auto-fix")
+		}
+		result, err := check.StructuredFixFunc(context.Background(), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Metrics["requeued"] != 1 {
+			t.Fatalf("requeued=%d, want 1", result.Metrics["requeued"])
+		}
+		if result.Metrics["replayed"] != 2 || !strings.Contains(result.Action, "replayed=2") {
+			t.Fatalf("result=%+v, want replayed=2 (pending + requeued)", result)
+		}
+		if strings.Contains(result.Action, "PRIVATE-BODY") {
+			t.Fatalf("action leaked payload body: %q", result.Action)
+		}
+		if _, err := os.Stat(filepath.Join(deadDir, "deadline.json")); !os.IsNotExist(err) {
+			t.Fatalf("dead letter must be requeued, stat err=%v", err)
+		}
+		if pending, err := countHookSpoolRecordPaths(); err != nil || pending != 0 {
+			t.Fatalf("drain must empty the spool, pending=%d err=%v", pending, err)
+		}
+		if eventStub.logCalls != 2 {
+			t.Fatalf("logCalls=%d, want 2", eventStub.logCalls)
+		}
+	})
+
+	t.Run("apply skips non-transient dead letters", func(t *testing.T) {
+		_, deadDir := setupSpool(t)
+		writeDeadLetter(t, deadDir, "poison.json", `{"prompt":"x","session_id":"s-poison","cwd":"/tmp"}`, "invalid Claude usage JSON event")
+
+		// A single dead letter is below the WARN threshold, so drive the
+		// shared fixer directly instead of via the check.
+		result, err := (&RootCLI{}).fixHookSpoolRequeueThenDrain(context.Background(), time.Now().UTC(), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Metrics["skipped_nontransient"] != 1 || result.Metrics["requeued"] != 0 {
+			t.Fatalf("metrics=%v, want skipped_nontransient=1 requeued=0", result.Metrics)
+		}
+		if _, err := os.Stat(filepath.Join(deadDir, "poison.json")); err != nil {
+			t.Fatalf("non-transient dead letter must stay in dead/, stat err=%v", err)
+		}
+	})
 }
 
 func TestPruneHookSpoolDeadLetters_RemovesAgedFilesOnlyOnFix(t *testing.T) {
@@ -2405,7 +2487,7 @@ func TestInspectHookSpoolFilesystemStats_CountsAgedTmpAsStaleInflight(t *testing
 		t.Fatalf("stale bytes=%d, want aged tmp size", stats.StaleInflightBytes)
 	}
 
-	check := inspectHookSpoolFilesystemMetadata()
+	check := (&RootCLI{}).inspectHookSpoolFilesystemMetadata()
 	if check.Status != doctorStatusWarn {
 		t.Fatalf("status=%q, want warn", check.Status)
 	}
@@ -2458,7 +2540,7 @@ func TestPruneHookSpoolOrphanTmpFiles_RemovesAgedFilesOnlyOnFix(t *testing.T) {
 		t.Fatalf("1h tmp must be kept until 14d: %v", err)
 	}
 
-	check := inspectHookSpoolFilesystemMetadata()
+	check := (&RootCLI{}).inspectHookSpoolFilesystemMetadata()
 	if !check.AutoFixAvailable || check.StructuredFixFunc == nil {
 		t.Fatal("stale tmp must expose doctor --fix")
 	}
@@ -2471,7 +2553,7 @@ func TestPruneHookSpoolOrphanTmpFiles_RemovesAgedFilesOnlyOnFix(t *testing.T) {
 	}
 }
 
-func TestFixHookSpoolDeadLettersFilesystem_PrunesRetentionAgedTmp(t *testing.T) {
+func TestFixHookSpoolRequeueThenDrain_PrunesRetentionAgedTmp(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)
 	spoolDir := filepath.Join(stateDir, "spool")
@@ -2487,7 +2569,7 @@ func TestFixHookSpoolDeadLettersFilesystem_PrunesRetentionAgedTmp(t *testing.T) 
 		t.Fatalf("stats=%+v, want stale_inflight=2", stats)
 	}
 
-	result, err := fixHookSpoolDeadLettersFilesystem(context.Background(), time.Now().UTC(), true)
+	result, err := (&RootCLI{}).fixHookSpoolRequeueThenDrain(context.Background(), time.Now().UTC(), true)
 	if err != nil {
 		t.Fatalf("dry-run fix: %v", err)
 	}
@@ -2498,7 +2580,7 @@ func TestFixHookSpoolDeadLettersFilesystem_PrunesRetentionAgedTmp(t *testing.T) 
 		t.Fatalf("dry-run must keep july tmp: %v", err)
 	}
 
-	result, err = fixHookSpoolDeadLettersFilesystem(context.Background(), time.Now().UTC(), false)
+	result, err = (&RootCLI{}).fixHookSpoolRequeueThenDrain(context.Background(), time.Now().UTC(), false)
 	if err != nil {
 		t.Fatalf("fix: %v", err)
 	}


### PR DESCRIPTION
## Summary

Large-store (`metadata_only_large_store`) `doctor --fix` requeued transient hook-spool dead letters but never drained pending records, leaving a requeue-scale backlog for organic hooks (#2151 leftover).

`--fix` now shares the full-doctor fixer: requeue + `drainHookSpoolRecordsUntil` + prune. Inspect stays directory-metadata only. `--fix --dry-run` still opens no SQLite. Apply may open SQLite for spool replay only (no dbstat).

Design: grok 4.6 medium (`.ai/spec/2207.md`, issue comment). Implementation: kimi k3.

## Test plan

- [x] `go test ./presentation/cli/ -count=1`
- [x] `go tool golangci-lint run ./presentation/cli/`
- [x] `TestInspectHookSpoolFilesystemMetadata_FixRequeuesAndDrains` (dry-run / apply drain / non-transient skip)

Closes #2207