### PR TITLE
fix: page inbox until --limit quality matches instead of first-N intersection

### DIFF
--- a/.ai/spec/2210.md
+++ b/.ai/spec/2210.md
@@ -1,0 +1,47 @@
+# Issue 2210: inbox cleanup `--quality low --limit N` must select up to N hygiene hits
+
+Engine: grok 4.6 medium  
+Date: 2026-08-21  
+Parent: #2208  
+PR: `Closes #2210` only
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — changes which candidate IDs `cleanup` / `list --quality` return. JSON field names frozen. No auto-accept.
+
+### Requirement summary
+- Purpose: leftover of #2152. Hygiene scan listed 158 `low_quality_candidate`; `memory inbox cleanup --quality low --limit 20` and `list --quality low --limit 5` returned 0 because selection is `List(limit=N)` then intersect hygiene IDs.
+- Expected: `--quality low --limit N` means **up to N hygiene-matching candidates** (still remember-intent priority among matches). Dry-run default; `--apply` reject-only; `restore` still works.
+- Out: unbounded whole-store scan as the only fix; auto-accept; new commands; synthesizing session_ended; live home store with repo-built binary.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint |
+|---|---|---|---|
+| Hygiene ID set | bounded `memory.Scan` suggestions of kind low-quality | membership test | keep existing scan row_limit; do not raise it as the only fix |
+| Cleanup/list `--limit` | page size **after** quality filter | stop when N matches collected | not before filter |
+| Remember-intent priority | query order | preserved among matches | do not replace with hygiene-scan order |
+| Dry-run | default | list matched, no Reject | |
+
+### Responsibility assignment
+| Responsibility | Owner | Not owner |
+|---|---|---|
+| Fetch candidates then filter until N matches | `loadMemoryInboxCleanupCandidates` and inbox list loop in `runMemoryInboxList` | datasource schema |
+| Hygiene ID set | existing `loadLowQualityCandidateIDs` | new command |
+| Reject | existing `memory.Reject` | |
+
+Implementation: list with a larger fetch window or loop pages until `len(items)==limit` or list exhausted, then quality-filter. Do not scan unbounded. Prefer: request List with limit that is enough to fill N matches without loading the whole inbox — e.g. page through with the existing limit/offset until N matches or no more rows. Pin a safety cap equal to the hygiene scan bound if looping.
+
+`list --quality low --limit N` must use the same rule as cleanup (shared helper). JSON `matched` may become non-empty; field names unchanged.
+
+### Behavior tests
+| Given | When | Then |
+|---|---|---|
+| First inbox rows are non-hygiene; later rows match hygiene | cleanup `--quality low --limit 20 --dry-run` | lists hygiene IDs, not 0 |
+| Same | `--apply` then restore one id | only hygiene candidates rejected; restore works |
+| Remember-intent non-hygiene in window | cleanup | untouched |
+| `list --quality low --limit 5` | same fixture | up to 5 hygiene hits |
+
+### TDD
+Red: fixture where first N are normal and hygiene ids sit later. Green: shared selector. Refactor: one helper for list+cleanup.
+
+Rollback: revert PR; candidates stay in inbox.

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -277,29 +277,22 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 	// sort would only re-order the current page and could let a prioritized
 	// row that lives just past the page boundary stay hidden until later pages
 	// (#856/#857).
-	criteriaBuilder := apptypes.NewMemoryListCriteriaBuilder(input.limit).
-		Offset(input.offset).
-		Scopes(scopes).
-		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}).
-		MemoryTypes(memoryTypes).
-		Sources(listSources).
-		RememberIntentPriority(true)
-	criteriaBuilder = applyMemoryInboxAgeFilters(criteriaBuilder, input.olderThan, input.newerThan, time.Now())
-	criteria := criteriaBuilder.Build()
-	summaries, err := c.memory.List(ctx, criteria)
-	if err != nil {
-		return xerrors.Errorf("%s: %w", Localize("failed to list memory review queue candidates", "メモリ候補の確認キューの一覧取得に失敗しました"), err)
+	//
+	// --limit applies AFTER the quality filter: the shared selector pages the
+	// queue until limit matching candidates are collected (or the queue is
+	// exhausted / the fetch row cap is hit), so quality matches that live
+	// beyond the first page stay reachable (#2210).
+	filters := memoryInboxCandidateFilters{
+		scopes:      scopes,
+		memoryTypes: memoryTypes,
+		sources:     listSources,
+		olderThan:   input.olderThan,
+		newerThan:   input.newerThan,
+		now:         time.Now(),
 	}
-
-	items := make([]apptypes.MemoryDetails, 0, len(summaries))
-	for _, summary := range summaries {
-		details, err := c.memory.Show(ctx, summary.MemoryID())
-		if err != nil {
-			return xerrors.Errorf("failed to load memory %s: %w", summary.MemoryID().String(), err)
-		}
-		if memoryInboxDetailsMatchesQuality(details, quality, lowQualityIDs) {
-			items = append(items, details)
-		}
+	items, err := c.loadMemoryInboxQualityMatchedDetails(ctx, filters, quality, lowQualityIDs, input.limit, input.offset)
+	if err != nil {
+		return err
 	}
 	if err := writeMemoryInboxList(output, items, input.asJSON); err != nil {
 		return err
@@ -307,7 +300,7 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 	if input.asJSON {
 		return nil
 	}
-	return c.writeMemoryInboxListPoolSummary(ctx, output, criteriaBuilder, countSources, len(items), quality)
+	return c.writeMemoryInboxListPoolSummary(ctx, output, filters.newCriteriaBuilder(input.limit, input.offset), countSources, len(items), quality)
 }
 
 func (c *RootCLI) runMemoryInboxShow(ctx context.Context, output io.Writer, input memoryInboxShowCommandInput) error {
@@ -416,25 +409,110 @@ func (c *RootCLI) loadMemoryInboxCleanupCandidates(ctx context.Context, input me
 		return nil, err
 	}
 	sources = applyExtractedHiddenDefault(sources, input.includeHidden)
-	criteriaBuilder := apptypes.NewMemoryListCriteriaBuilder(input.limit).
-		Scopes(scopes).
-		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}).
-		MemoryTypes(memoryTypes).
-		Sources(sources).
-		RememberIntentPriority(true)
-	criteriaBuilder = applyMemoryInboxAgeFilters(criteriaBuilder, input.olderThan, input.newerThan, now)
-	summaries, err := c.memory.List(ctx, criteriaBuilder.Build())
-	if err != nil {
-		return nil, xerrors.Errorf("%s: %w", Localize("failed to list cleanup memory candidates", "cleanup 対象メモリ候補の一覧取得に失敗しました"), err)
+	filters := memoryInboxCandidateFilters{
+		scopes:      scopes,
+		memoryTypes: memoryTypes,
+		sources:     sources,
+		olderThan:   input.olderThan,
+		newerThan:   input.newerThan,
+		now:         now,
 	}
-	items := make([]apptypes.MemoryDetails, 0, len(summaries))
-	for _, summary := range summaries {
-		details, err := c.memory.Show(ctx, summary.MemoryID())
-		if err != nil {
-			return nil, xerrors.Errorf("failed to load memory %s: %w", summary.MemoryID().String(), err)
-		}
-		if memoryInboxDetailsMatchesQuality(details, quality, lowQualityIDs) {
+	items, err := c.loadMemoryInboxQualityMatchedDetails(ctx, filters, quality, lowQualityIDs, input.limit, 0)
+	if err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// memoryInboxCandidateFilters captures the review-queue filters shared by
+// `memory inbox list` and `memory inbox cleanup` so both surfaces page the
+// same candidate set in the same remember-intent-priority order (#2210).
+type memoryInboxCandidateFilters struct {
+	scopes      []domtypes.MemoryScope
+	memoryTypes []domtypes.MemoryType
+	sources     []domtypes.MemorySource
+	olderThan   time.Duration
+	newerThan   time.Duration
+	now         time.Time
+}
+
+func (f memoryInboxCandidateFilters) newCriteriaBuilder(limit, offset int) *apptypes.MemoryListCriteriaBuilder {
+	builder := apptypes.NewMemoryListCriteriaBuilder(limit).
+		Offset(offset).
+		Scopes(f.scopes).
+		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}).
+		MemoryTypes(f.memoryTypes).
+		Sources(f.sources).
+		RememberIntentPriority(true)
+	return applyMemoryInboxAgeFilters(builder, f.olderThan, f.newerThan, f.now)
+}
+
+// memoryInboxQualityFetchRowCap bounds how many review-queue rows the
+// quality-filtered paging loop may scan while collecting up to --limit
+// matches. It mirrors the memory hygiene scan source-row ceiling
+// (defaultMemoryHygieneMaxRows in application/types) so a quality filter can
+// never turn list/cleanup into an unbounded whole-store scan (#2210).
+const memoryInboxQualityFetchRowCap = 2_000
+
+// loadMemoryInboxQualityMatchedDetails resolves --limit as "up to limit
+// candidates matching the quality filter" instead of "first limit rows, then
+// filter" (#2210). With --quality any there is no post-filter, so a single
+// bounded page preserves the historical contract. With low/normal the helper
+// pages the queue in remember-intent-priority order until limit matches are
+// collected, the queue is exhausted, or memoryInboxQualityFetchRowCap rows
+// have been scanned. Shared by `memory inbox list --quality` and
+// `memory inbox cleanup --quality`.
+func (c *RootCLI) loadMemoryInboxQualityMatchedDetails(ctx context.Context, filters memoryInboxCandidateFilters, quality memoryInboxQuality, lowQualityIDs map[string]struct{}, limit, offset int) ([]apptypes.MemoryDetails, error) {
+	loadDetails := func(summaries []apptypes.MemorySummary) ([]apptypes.MemoryDetails, error) {
+		items := make([]apptypes.MemoryDetails, 0, len(summaries))
+		for _, summary := range summaries {
+			details, err := c.memory.Show(ctx, summary.MemoryID())
+			if err != nil {
+				return nil, xerrors.Errorf("failed to load memory %s: %w", summary.MemoryID().String(), err)
+			}
 			items = append(items, details)
+		}
+		return items, nil
+	}
+	if quality == memoryInboxQualityAny {
+		summaries, err := c.memory.List(ctx, filters.newCriteriaBuilder(limit, offset).Build())
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to list memory review queue candidates", "メモリ候補の確認キューの一覧取得に失敗しました"), err)
+		}
+		return loadDetails(summaries)
+	}
+	items := make([]apptypes.MemoryDetails, 0, limit)
+	scanned := 0
+	for len(items) < limit {
+		pageLimit := limit - len(items)
+		if remaining := memoryInboxQualityFetchRowCap - scanned; remaining < pageLimit {
+			pageLimit = remaining
+		}
+		if pageLimit < 1 {
+			break
+		}
+		summaries, err := c.memory.List(ctx, filters.newCriteriaBuilder(pageLimit, offset+scanned).Build())
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to list memory review queue candidates", "メモリ候補の確認キューの一覧取得に失敗しました"), err)
+		}
+		if len(summaries) == 0 {
+			break
+		}
+		page, err := loadDetails(summaries)
+		if err != nil {
+			return nil, err
+		}
+		for _, details := range page {
+			if memoryInboxDetailsMatchesQuality(details, quality, lowQualityIDs) {
+				items = append(items, details)
+				if len(items) >= limit {
+					break
+				}
+			}
+		}
+		scanned += len(summaries)
+		if len(summaries) < pageLimit {
+			break
 		}
 	}
 	return items, nil

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -684,6 +685,175 @@ func TestMemoryInboxCleanup_DoesNotModifyAcceptedMemories(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "cleanup only modifies memory candidates") {
 		t.Fatalf("accepted safety failure missing from output:\n%s", stdout.String())
+	}
+}
+
+// pagedMemoryListFunc adapts a static summary slice into a List stub that
+// honours criteria Limit/Offset so tests can exercise the quality-filter
+// paging loop (#2210).
+func pagedMemoryListFunc(summaries []apptypes.MemorySummary) func(context.Context, apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	return func(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+		if criteria.Offset() >= len(summaries) {
+			return nil, nil
+		}
+		end := criteria.Offset() + criteria.Limit()
+		if end > len(summaries) {
+			end = len(summaries)
+		}
+		return summaries[criteria.Offset():end], nil
+	}
+}
+
+// newInboxHygienePagingStub builds the #2210 regression fixture: the first
+// inbox rows are non-hygiene (a remember-intent keep and a manual keep) and
+// the hygiene-matching candidates sit beyond the first --limit page. List
+// honours Limit/Offset, so the quality-filter paging loop must walk past the
+// first page to reach the matches instead of returning 0.
+func newInboxHygienePagingStub(t *testing.T) *memoryInboxRestoreStub {
+	t.Helper()
+	keepRemember := buildInboxCandidateDetails(t, "memory-keep-remember", "prefer table-driven tests", domtypes.MemorySourceRememberIntent)
+	keepManual := buildInboxCandidateDetails(t, "memory-keep-manual", "keep CI green", domtypes.MemorySourceManual)
+	hygiene1 := buildInboxCandidateDetails(t, "memory-hygiene-1", "git status", domtypes.MemorySourceExtracted)
+	hygiene2 := buildInboxCandidateDetails(t, "memory-hygiene-2", "gh pr checks", domtypes.MemorySourceExtracted)
+	hygiene3 := buildInboxCandidateDetails(t, "memory-hygiene-3", "go build ./...", domtypes.MemorySourceExtracted)
+	summaries := []apptypes.MemorySummary{
+		keepRemember.Summary(),
+		keepManual.Summary(),
+		hygiene1.Summary(),
+		hygiene2.Summary(),
+		hygiene3.Summary(),
+	}
+	return &memoryInboxRestoreStub{
+		memoryUsecaseStub: memoryUsecaseStub{
+			listResult: summaries,
+			listFunc:   pagedMemoryListFunc(summaries),
+			showDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+				keepRemember.Summary().MemoryID(): keepRemember,
+				keepManual.Summary().MemoryID():   keepManual,
+				hygiene1.Summary().MemoryID():     hygiene1,
+				hygiene2.Summary().MemoryID():     hygiene2,
+				hygiene3.Summary().MemoryID():     hygiene3,
+			},
+			scanResult: apptypes.MemoryHygieneScanResult{
+				LowQualityCandidateCount: 3,
+				Suggestions: []apptypes.MemoryHygieneSuggestion{
+					{MemoryID: hygiene1.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+					{MemoryID: hygiene2.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+					{MemoryID: hygiene3.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+				},
+			},
+		},
+	}
+}
+
+func TestMemoryInboxQualityFilter_PagesPastNonHygieneRows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args func(dbPath string) []string
+	}{
+		{
+			name: "cleanup dry-run lists hygiene ids beyond the first page",
+			args: func(dbPath string) []string {
+				return []string{"memory", "inbox", "cleanup", "--quality", "low", "--limit", "2", "--db-path", dbPath}
+			},
+		},
+		{
+			name: "inbox list returns up to limit hygiene hits",
+			args: func(dbPath string) []string {
+				return []string{"memory", "inbox", "list", "--quality", "low", "--limit", "2", "--db-path", dbPath}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			memoryStub := newInboxHygienePagingStub(t)
+			root := cli.NewRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithMemory(memoryStub),
+			)
+			cmd := root.Command()
+			stdout := &bytes.Buffer{}
+			cmd.SetOut(stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tt.args(t.TempDir() + "/t.db"))
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if memoryStub.rejectCallCount != 0 {
+				t.Fatalf("no --apply run must not call Reject, got %d call(s)", memoryStub.rejectCallCount)
+			}
+			out := stdout.String()
+			for _, want := range []string{"memory-hygiene-1", "memory-hygiene-2"} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("hygiene id %s missing from quality-filtered output:\n%s", want, out)
+				}
+			}
+			if strings.Contains(out, "memory-hygiene-3") {
+				t.Fatalf("--limit 2 must stop at 2 quality matches:\n%s", out)
+			}
+			for _, keep := range []string{"memory-keep-remember", "memory-keep-manual"} {
+				if strings.Contains(out, keep) {
+					t.Fatalf("non-hygiene row %s leaked into quality-filtered output:\n%s", keep, out)
+				}
+			}
+		})
+	}
+}
+
+func TestMemoryInboxCleanup_ApplyRejectsOnlyHygieneMatchesAndRestoreRecovers(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := newInboxHygienePagingStub(t)
+	rejected1 := buildInboxMemoryDetails(t, "memory-hygiene-1", "git status", domtypes.MemoryStatusRejected, domtypes.MemorySourceExtracted)
+	rejected2 := buildInboxMemoryDetails(t, "memory-hygiene-2", "gh pr checks", domtypes.MemoryStatusRejected, domtypes.MemorySourceExtracted)
+	memoryStub.rejectDetailsByID = map[domtypes.MemoryID]apptypes.MemoryDetails{
+		rejected1.Summary().MemoryID(): rejected1,
+		rejected2.Summary().MemoryID(): rejected2,
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "cleanup", "--apply", "--quality", "low", "--limit", "2", "--db-path", t.TempDir() + "/t.db"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if memoryStub.rejectCallCount != 2 {
+		t.Fatalf("apply rejected %d candidate(s), want exactly the 2 hygiene matches", memoryStub.rejectCallCount)
+	}
+	out := stdout.String()
+	for _, want := range []string{"memory-hygiene-1", "memory-hygiene-2"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rejected hygiene id %s missing from output:\n%s", want, out)
+		}
+	}
+	for _, keep := range []string{"memory-keep-remember", "memory-keep-manual"} {
+		if strings.Contains(out, keep) {
+			t.Fatalf("non-hygiene row %s must stay untouched by apply:\n%s", keep, out)
+		}
+	}
+
+	// `memory inbox restore` must still recover one of the rejected ids.
+	restoreCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	restoreCmd.SetOut(&bytes.Buffer{})
+	restoreCmd.SetErr(&bytes.Buffer{})
+	restoreCmd.SetArgs([]string{"memory", "inbox", "restore", "--db-path", t.TempDir() + "/t.db", "--ids", "memory-hygiene-1"})
+	if err := restoreCmd.Execute(); err != nil {
+		t.Fatalf("restore execute: %v", err)
+	}
+	if len(memoryStub.restored) != 1 || memoryStub.restored[0].String() != "memory-hygiene-1" {
+		t.Fatalf("restored ids = %v, want [memory-hygiene-1]", memoryStub.restored)
 	}
 }
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -495,6 +495,7 @@ func (s *bundleUsecaseStub) Import(_ context.Context, _ usecase.BundleImportOpti
 type memoryUsecaseStub struct {
 	listResult          []apptypes.MemorySummary
 	listErr             error
+	listFunc            func(context.Context, apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error)
 	staleResult         apptypes.StaleMemoryListResult
 	staleErr            error
 	searchResult        []apptypes.MemorySummary
@@ -673,8 +674,11 @@ func (s *memoryUsecaseStub) SetValidity(_ context.Context, memoryID types.Memory
 	return s.setValidityDetails, s.setValidityErr
 }
 
-func (s *memoryUsecaseStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+func (s *memoryUsecaseStub) List(ctx context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
 	s.listCriteria = criteria
+	if s.listFunc != nil {
+		return s.listFunc(ctx, criteria)
+	}
 	return s.listResult, s.listErr
 }
 


### PR DESCRIPTION
## Summary

`memory inbox cleanup --quality low --limit N` (and `list --quality low`) listed the first N inbox rows then intersected hygiene IDs, so a 158-hit hygiene scan still yielded 0 matches when the first N were remember-intent / non-echo.

A shared selector now pages the review queue in remember-intent order until N quality matches, exhaustion, or the 2000-row hygiene-scan ceiling. Dry-run stays default; `--apply` is reject-only; JSON field names unchanged.

Design: grok 4.6 medium. Implementation: kimi k3.

## Test plan

- [x] `go test ./presentation/cli/ -count=1`
- [x] `go tool golangci-lint run ./presentation/cli/`

Closes #2210