### PR TITLE
fix: add age floor to doctor stale-binary findings

### DIFF
--- a/presentation/cli/doctor_stale_processes.go
+++ b/presentation/cli/doctor_stale_processes.go
@@ -25,6 +25,18 @@ const (
 	doctorRetiredMCPServerCommand = "mcp-server"
 	linuxProcClockTicksPerSecond  = 100
 	linuxProcStatStartTimeField   = 20
+	// doctorStaleBinaryAgeFloor is the minimum process age before a
+	// stale-binary finding is reported. Hook invocations spawn short-lived
+	// `traceary hook ...` children whose version can read as unknown
+	// (unlinked inode after a same-path upgrade, or a failed build-info
+	// inspect); without a floor those children WARN at a few seconds of age
+	// and PASS on the next run, which is additive noise with misleading reap
+	// guidance. The floor is pinned in minutes — well above any hook
+	// duration — so hook children stay PASS while genuinely long-running
+	// stale binaries (the #2155 lease-safety case) still WARN. Processes
+	// with an unknown start time are not filtered: hiding them could mask
+	// real leftovers.
+	doctorStaleBinaryAgeFloor = 15 * time.Minute
 )
 
 var cellarTracearyVersionPattern = regexp.MustCompile(`(?i)[/\\]Cellar[/\\]traceary[/\\]([^/\\]+)[/\\]`)
@@ -119,21 +131,25 @@ func classifyStaleTracearyProcesses(snapshots []tracearyProcessSnapshot, current
 		if !retired && (sameRunningBinary || versionsMatch(version, current)) {
 			continue
 		}
-		reason := "stale-binary"
 		if retired {
-			reason = "retired-mcp-server"
+			// Retired mcp-server findings have no age floor: they are the
+			// lease-safety case from #2155 and must surface even when young.
+			findings = append(findings, staleTracearyProcessFinding{
+				PID:     snapshot.PID,
+				Version: reportedVersion(version),
+				Age:     formatProcessAge(snapshot.StartedAt, now),
+				Reason:  "retired-mcp-server",
+				Exe:     exe,
+			})
+		} else if snapshot.StartedAt.IsZero() || now.IsZero() || now.Sub(snapshot.StartedAt) >= doctorStaleBinaryAgeFloor {
+			findings = append(findings, staleTracearyProcessFinding{
+				PID:     snapshot.PID,
+				Version: reportedVersion(version),
+				Age:     formatProcessAge(snapshot.StartedAt, now),
+				Reason:  "stale-binary",
+				Exe:     exe,
+			})
 		}
-		reportedVersion := version
-		if reportedVersion == "" {
-			reportedVersion = "unknown"
-		}
-		findings = append(findings, staleTracearyProcessFinding{
-			PID:     snapshot.PID,
-			Version: reportedVersion,
-			Age:     formatProcessAge(snapshot.StartedAt, now),
-			Reason:  reason,
-			Exe:     exe,
-		})
 		if len(findings) >= doctorStaleProcessScanLimit {
 			break
 		}
@@ -167,6 +183,15 @@ func processInvokesRetiredMCPServer(args []string) bool {
 		}
 	}
 	return false
+}
+
+// reportedVersion renders an empty inspected version as "unknown" for
+// report output; the raw empty string never leaves the classifier.
+func reportedVersion(version string) string {
+	if version == "" {
+		return "unknown"
+	}
+	return version
 }
 
 func versionsMatch(processVersion, currentVersion string) bool {

--- a/presentation/cli/doctor_stale_processes_test.go
+++ b/presentation/cli/doctor_stale_processes_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -124,6 +125,93 @@ func TestInspectStaleTracearyProcesses(t *testing.T) {
 		}
 		if !strings.Contains(got.Message, "version=unknown") {
 			t.Fatalf("unlinked inode must not inherit the replacement binary version, got %q", got.Message)
+		}
+	})
+
+	t.Run("passes for a hook-duration child with unknown version below the age floor", func(t *testing.T) {
+		current := writeExecutable(t, t.TempDir(), "traceary")
+		osExecutableFunc = func() (string, error) { return current, nil }
+		// A different-inode binary with no readable build info inspects as
+		// version=unknown; at 4s of age it is a hook-duration child, not a
+		// stale long-runner.
+		other := filepath.Join(t.TempDir(), "traceary")
+		if err := os.WriteFile(other, []byte("not a go binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return []tracearyProcessSnapshot{{
+				PID:        9100,
+				Executable: other,
+				Args:       []string{other, "hook", "session", "claude", "start"},
+				StartedAt:  now.Add(-4 * time.Second),
+			}}, nil
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusPass {
+			t.Fatalf("status = %q, want pass; msg=%q", got.Status, got.Message)
+		}
+	})
+
+	t.Run("passes for a young unlinked inode below the age floor", func(t *testing.T) {
+		current := writeExecutable(t, t.TempDir(), "traceary")
+		osExecutableFunc = func() (string, error) { return current, nil }
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return []tracearyProcessSnapshot{{
+				PID:        9200,
+				Executable: current,
+				Args:       []string{current, "hook", "session", "claude", "start"},
+				StartedAt:  now.Add(-4 * time.Second),
+				Unlinked:   true,
+			}}, nil
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusPass {
+			t.Fatalf("status = %q, want pass; msg=%q", got.Status, got.Message)
+		}
+	})
+
+	t.Run("warns for an old-binary long-runner above the age floor", func(t *testing.T) {
+		osExecutableFunc = func() (string, error) {
+			return "/opt/homebrew/opt/traceary/bin/traceary", nil
+		}
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return []tracearyProcessSnapshot{{
+				PID:        7767,
+				Executable: "/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary",
+				Args:       []string{"/opt/homebrew/Cellar/traceary/0.33.0/bin/traceary", "serve"},
+				StartedAt:  now.Add(-2 * time.Hour),
+			}}, nil
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusWarn {
+			t.Fatalf("status = %q, want warn; msg=%q", got.Status, got.Message)
+		}
+		if !strings.Contains(got.Message, "pid=7767") || !strings.Contains(got.Message, "version=0.33.0") {
+			t.Fatalf("message should name pid and version, got %q", got.Message)
+		}
+		if !strings.Contains(got.Message, "age=2h") || !strings.Contains(got.Message, "stale-binary") {
+			t.Fatalf("message should name age and stale-binary reason, got %q", got.Message)
+		}
+	})
+
+	t.Run("warns for a young retired mcp-server with no age floor", func(t *testing.T) {
+		osExecutableFunc = func() (string, error) {
+			return "/opt/homebrew/opt/traceary/bin/traceary", nil
+		}
+		SetListTracearyProcessSnapshotsForTest(func() ([]tracearyProcessSnapshot, error) {
+			return []tracearyProcessSnapshot{{
+				PID:        9300,
+				Executable: "/opt/homebrew/Cellar/traceary/0.44.1/bin/traceary",
+				Args:       []string{"/opt/homebrew/Cellar/traceary/0.44.1/bin/traceary", "mcp-server"},
+				StartedAt:  now.Add(-4 * time.Second),
+			}}, nil
+		})
+		got := inspectStaleTracearyProcesses("0.44.1", now)
+		if got.Status != doctorStatusWarn {
+			t.Fatalf("status = %q, want warn; msg=%q", got.Status, got.Message)
+		}
+		if !strings.Contains(got.Message, "pid=9300") || !strings.Contains(got.Message, "retired-mcp-server") {
+			t.Fatalf("message = %q", got.Message)
 		}
 	})
 


### PR DESCRIPTION
## Summary

`stale-processes` no longer WARNs on hook-duration children.

- `stale-binary` (including `version=unknown`) requires process age ≥ 15 minutes.
- Retired `mcp-server` has no age floor (lease-safety leftover from #2155).
- Unknown start time is not hidden.

Additive check only; no `--fix` kill.

## Test plan

- [x] 4s unknown-version / unlinked hook child → PASS
- [x] 2h Cellar 0.33.0 long-runner → WARN pid/version/age/stale-binary
- [x] 4s retired mcp-server → WARN
- [x] `go test ./presentation/cli/ -count=1`
- [x] `go tool golangci-lint run ./presentation/cli/`

Closes #2211