### PR TITLE
feat: warn on leftover Claude local plugin installs in deleted worktrees

### DIFF
--- a/.ai/spec/2212.md
+++ b/.ai/spec/2212.md
@@ -1,0 +1,143 @@
+# Issue 2212: doctor does not surface leftover Claude `--scope local` installs in deleted worktrees
+
+Engine: grok 4.6 medium  
+Date: 2026-08-21  
+Parent: #2208  
+PR: `Closes #2212` only (never #2208 / #2205)
+
+Implementer: **kimi k3**. Tests must call the shipped doctor inspect function, not a copy. Isolated fixtures only. Never point a repo-built binary at the live home store (`~/.config/traceary/traceary.db`). Never rewrite Claude inventory.
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — operator-visible doctor stdout (new additive check). No schema. No Claude config writes. Host-inventory read only.
+
+### Requirement summary
+- Purpose: after `claude plugin update --scope local` (current project only), operators still have enabled **local** Traceary rows in Claude’s `installed_plugins.json` whose **project directories are gone** (v0.45.0 dogfood: 22 leftover Grok worktrees). `claude-plugin-version` / `claude-plugin-cache` look at the **user cache** and PASS at 0.45.0 without mentioning leftovers.
+- Current (repo, `presentation/cli` + `infrastructure/filesystem`):
+  - `DetectClaudeTracearyPluginIn` reads `~/.claude/settings.json` `enabledPlugins` (user-scope identity).
+  - `inspectClaudePluginCacheStatus` (`claude-plugin-cache`) and `inspectPluginVersionChecks` (`claude-plugin-version`) read `~/.claude/plugins/cache/…` via `PluginCacheInspector`.
+  - **Nothing** reads `~/.claude/plugins/installed_plugins.json`.
+- Expected:
+  1. Doctor counts **enabled local** Traceary installs whose `projectPath` directory no longer exists. **WARN** with **count ≥ 1** and a **bounded sample** of those paths. **Do not** auto-delete or disable.
+  2. Hint points at inspecting Claude `installed_plugins.json` and disabling leftover **local** installs in Claude. **Do not** invent a Traceary command that rewrites Claude’s inventory. `doctor --fix` must not write Claude config.
+  3. User-cache 0.45.0 **PASS stays PASS**. Leftovers are an **additive WARN** on a different check.
+- Out of scope:
+  - Auto-removing / disabling Claude local plugins.
+  - Walking `~/.grok/worktrees` (or any host worktree root). Read Claude’s inventory only; `Stat` only the `projectPath` values it lists.
+  - Treating **stale version on an existing directory** as leftover (that is a different problem than a deleted worktree).
+  - Synthesizing `session_ended`.
+  - Live home store with a repo-built binary.
+  - Rewriting `claude-plugin-cache` / `claude-plugin-version` messages so a healthy user cache is no longer PASS.
+
+### Why not fold into an existing check
+
+Read the current Claude plugin-identity family before adding a sibling:
+
+| Check | Owner today | Why it cannot absorb leftovers |
+|---|---|---|
+| `claude-plugin-version` | `inspectPluginVersionChecks` → user cache version vs running binary | Acceptance requires 0.45.0 cache **PASS**. Folding leftovers here would turn PASS into WARN. |
+| `claude-plugin-cache` | `inspectClaudePluginCacheStatus` | Same: cache vs marketplace. Must remain PASS when cache is current. |
+| `claude-config` | `inspectClaudeOrConfigFile` | Current **project** `settings.json` vs plugin-managed hooks. Leftovers are **other projects’** inventory rows. |
+| `DetectClaudeTracearyPluginIn` | `~/.claude/settings.json` `enabledPlugins` | User-scope on/off only. Live leftovers exist even when user-scope is healthy. |
+
+**Pin:** extend the **same inspect family and wiring sites**, not those check names. Add **one additive check** next to `inspectClaudePluginCacheStatus`.
+
+Check name: **`claude-plugin-local-leftovers`**.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Claude plugin inventory | `~/.claude/plugins/installed_plugins.json` (`version` + `plugins` map) | read-only parse | never write; never walk worktree trees |
+| Traceary plugin key | map key `traceary@<marketplace>` | same prefix rule as settings.json (`traceary@`) | ignore other plugins |
+| Local install row | `scope == "local"` + `projectPath` | candidate for leftover | `scope == "user"` / `"project"` are never leftovers |
+| Enabled | JSON `enabled: false` → skip; **omitted `enabled` → enabled** | live 0.45.0 inventory has **no** `enabled` field on Traceary rows | do not require a field Claude does not write |
+| Leftover | enabled local + `projectPath` non-empty + directory **missing** (not exist, or exists but not a dir) | count + sample | `Stat` that path only |
+| Present local install | enabled local + `projectPath` is an existing directory | not a leftover, even if `version` is old (0.39/0.40/0.41) | no false WARN for the current repo’s local row |
+| User cache identity | cache dir `…/cache/traceary-plugins/traceary/0.45.0` | existing version/cache checks | leftover WARN must not change those PASS results |
+| Sample | leftover `projectPath` list | stable sort, first **5**, plus remainder count | do not dump 22 paths |
+
+Observed live shape (operator home, 2026-08-21; do not hard-code these paths in production):
+
+```json
+{
+  "version": <int>,
+  "plugins": {
+    "traceary@traceary-plugins": [
+      { "scope": "user", "installPath": "~/.claude/plugins/cache/…/0.45.0", "version": "0.45.0" },
+      { "scope": "local", "projectPath": "<repo or worktree>", "installPath": "…/cache/…/<ver>", "version": "<ver>" }
+    ]
+  }
+}
+```
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Parse inventory + classify leftover paths | `infrastructure/filesystem` next to `DetectClaudeTracearyPluginIn` (new list function + adapter method on `application.ClaudePluginDetector`) | same host-config layer as settings.json; presentation must not own Claude JSON | `PluginCacheInspector` (cache **versions**, not inventory rows). Do not glob `~/.grok/worktrees`. |
+| Doctor check + English/ja message/hint | `inspectClaudePluginLocalLeftovers` beside `inspectClaudePluginCacheStatus` in `doctor_config_inspect.go` | additive WARN; reuse `userHomeDirFunc` | `inspectClaudeOrConfigFile` / version checks |
+| Wiring | `targetClient == "claude"` in `doctor.go` **and** `appendFilesystemHostDoctorChecks` (`doctor_filesystem_host.go`), immediately after cache check | large-store doctor must still see leftovers (store-independent) | store Initialize / dbstat |
+| Store-independent label | `doctorCheckIsStoreIndependent` — add `claude-plugin-local-leftovers` | new name does not match existing `-plugin-version` / `plugin-cache` suffixes | |
+| `--fix` | none (`AutoFixAvailable=false`, no `FixFunc` / `StructuredFixFunc`) | issue forbids Claude writes | do not attach `attachDoctorConfigFix` to this check |
+| Docs (optional, same PR if golden/docs drift) | one sentence in `docs/release/post-upgrade-plugins.md` + `.ja.md` that doctor WARNs leftover **local** inventory rows | operators following `--scope local` update still miss deleted worktrees | new Traceary subcommand |
+
+Do **not** grow `ClaudePluginDetection` with leftover fields. Detection stays “is user-scope plugin active?”. Leftovers are a list.
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `~/.claude/plugins/installed_plugins.json` | filesystem list helper | JSON `plugins["traceary@…"][]` with `scope`, `projectPath`, optional `enabled` | missing file → omit check (`nil`). Unreadable / invalid JSON → **WARN** (not FAIL), no sample, hint to inspect the file. wrap with `xerrors` only if the helper returns an error the inspect function surfaces in Message |
+| `application.ClaudePluginDetector` | `RootCLI.pluginDetector` | add **one** list method, e.g. leftover local Traceary `projectPath`s for `home` | tests inject HOME via `userHomeDirFunc`; nil detector → omit |
+| `inspectClaudePluginLocalLeftovers() *doctorCheck` | full doctor + filesystem-host doctor | shipped function tests call | `nil` when there is nothing to report (missing file). When file exists and leftover count is 0 → **PASS** (proves no false WARN). Count > 0 → **WARN** |
+| `claude-plugin-cache` / `claude-plugin-version` | existing tests / post-upgrade docs | unchanged predicates | fixture with cache 0.45.0 + leftover local row: cache/version **PASS**, leftovers **WARN** |
+| Hint / FixCommand | operators | Hint: inspect `installed_plugins.json`; disable leftover local Traceary installs **in Claude** (`claude plugin disable … --scope local` only works inside a live project — for **missing** dirs, tell the operator to remove those **local** rows from Claude’s inventory themselves). **FixCommand empty**. No `traceary …` rewrite command | English + ja `Localize` / `localizef` |
+| `doctor --fix` | `runDoctor` fix loop | leftover check has no fixer | inventory file bytes unchanged even if other checks fix |
+
+Sample bound **5**. Message must include the integer count (tests assert `count ≥ 1` / the fixture’s N) and at least one missing `projectPath`.
+
+### Behavior tests
+Tests drive **shipped** `inspectClaudePluginLocalLeftovers` (and the filesystem classifier). Table-driven English names. Temp `HOME` + `userHomeDirFunc`. Do not read the developer’s real `~/.claude`.
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Leftover WARNs | `installed_plugins.json` with `traceary@traceary-plugins` `scope=local`, omitted `enabled`, `projectPath` = missing dir | shipped inspect | status WARN; message count ≥ 1; sample contains that path; `AutoFixAvailable=false`; FixCommand empty | unit |
+| Present project no false WARN | same file also has `scope=local` `projectPath` = existing temp project + user-scope 0.45.0 cache dirs so version/cache PASS | inspect leftovers + cache + version | leftovers does **not** include the existing path (PASS if it is the only local row; WARN count excludes it if others are missing). `claude-plugin-cache` / `claude-plugin-version` still PASS | unit / doctor CLI |
+| Disabled skipped | local row `enabled: false` + missing `projectPath` | inspect | not counted | unit |
+| User scope skipped | `scope=user` only (no `projectPath` or cache installPath) | inspect | omit or PASS, never WARN leftover | unit |
+| Non-Traceary ignored | other plugin keys with local missing paths | inspect | not counted | unit |
+| Missing inventory | no `installed_plugins.json` | inspect | `nil` / omit; other Claude checks unchanged | unit |
+| Invalid JSON | garbage file | inspect | WARN, not FAIL; no Claude write | unit |
+| Bounded sample | 7 leftover paths | inspect | message has count 7 and ≤5 paths | unit |
+| `--fix` does not write Claude | leftover fixture | `doctor --fix --client claude` (or call fix loop on the leftover check) | `installed_plugins.json` bytes identical; leftover check has no FixFunc | CLI / unit |
+| Large-store path | leftover fixture on filesystem-host doctor | `appendFilesystemHostDoctorChecks` | leftover WARN still present | unit |
+| Store-independent | leftover WARN message after `annotateDoctorScopeAndDBPathHints` | label `store-independent`; host hint commands not given `--db-path` | unit |
+| No worktree walk | classifier | only `Stat(projectPath)` from inventory | grep: no `filepath.Walk` of `~/.grok/worktrees` | review / grep |
+
+Fixture JSON must match Claude’s map-of-arrays shape (`plugins.<key>[]`), not a guessed schema.
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| Classify leftover paths | filesystem test with missing vs present `projectPath` | `List…` in `claude_plugin_detector.go` + adapter | keep settings.json detection untouched |
+| Doctor WARN / PASS / omit | `inspectClaudePluginLocalLeftovers` tests in `doctor_*_internal_test.go` or next to cache tests | inspect in `doctor_config_inspect.go`; wire after cache in `doctor.go` + `doctor_filesystem_host.go` | do not fork a third Claude inspect file unless `doctor_config_inspect.go` exceeds the 800-line split rule |
+| Cache still PASS | fixture: marketplace+cache 0.45.0 **and** one missing local row | assert both checks independently | |
+| `--fix` no write | bytes equal | no FixFunc on leftover check | |
+| Scope label | `doctor_scope.go` + `doctor_scope_test.go` | add check name to the store-independent switch | |
+
+If `testdata/doctor/default.golden.json` changes because a new PASS appears on default HOME, update the golden **in the same PR**. Prefer omit-when-missing-file so empty CI homes do not force a new PASS.
+
+### Risks / rollback
+- 手続き化リスク: do not duplicate inventory JSON parsing in presentation and infrastructure. One filesystem owner, one doctor inspect.
+- premature abstraction: no generic “host leftover inventory” framework for Codex/Grok. Claude-only.
+- migration / compatibility: check **name** is new; existing JSON field names on doctor reports stay frozen. Cache/version check names and PASS semantics stay frozen.
+- False WARN risk: `Stat` after `filepath.Clean`; do not require `EvalSymlinks` unless tests show aliasing. Empty `projectPath` is not leftover.
+- `--fix` safety: leftover check must not be passed to `attachDoctorConfigFix`.
+- rollback trigger: revert the PR; Claude inventory unchanged because this PR never writes it.
+
+Binding decisions (do not bikeshed):
+1. Additive check `claude-plugin-local-leftovers`. Do **not** change `claude-plugin-cache` / `claude-plugin-version` status.
+2. Enabled = not `enabled: false` (omitted counts as enabled).
+3. Leftover = `scope=="local"` + missing/non-dir `projectPath`. Do not glob worktrees.
+4. Sample cap **5**. Count is the full leftover total.
+5. No AutoFix. Hint names `installed_plugins.json` + Claude-side disable/remove of leftover **local** rows. No Traceary rewrite command.
+6. Implementer **kimi k3**. Tests call shipped inspect/classifier. Throwaway HOME/DB only.
+7. PR body: `Closes #2212`. Leaves parent **#2208** open. No GitHub close keyword next to #2208 or #2205.

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Added
+- **doctor が削除済み worktree の Claude `--scope local` leftover install を報告 (#2212)** — additive かつ store-independent な `claude-plugin-local-leftovers` check が `~/.claude/plugins/installed_plugins.json` だけを読み、project ディレクトリが消えた enabled な local Traceary 行の件数と上限付きサンプルを WARN します。auto-fix なし。Claude の inventory は書き換えず、user cache の `claude-plugin-cache` / `claude-plugin-version` は PASS のままです。親 #2208 は open のままにします。
+
 ## [v0.45.0] - 2026-08-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Added
+- **Doctor surfaces leftover Claude `--scope local` installs in deleted worktrees (#2212)** — the additive store-independent `claude-plugin-local-leftovers` check reads only `~/.claude/plugins/installed_plugins.json` and WARNs with a count plus a bounded sample of enabled local Traceary rows whose project directory is gone. No auto-fix; Claude's inventory is never rewritten, and the user-cache `claude-plugin-cache` / `claude-plugin-version` checks stay PASS. Leaves parent #2208 open.
+
 ## [v0.45.0] - 2026-08-20
 
 ### Fixed

--- a/application/claude_plugin_detector.go
+++ b/application/claude_plugin_detector.go
@@ -6,6 +6,11 @@ package application
 // direct infrastructure imports.
 type ClaudePluginDetector interface {
 	DetectClaudeTracearyPluginIn(home string) ClaudePluginDetection
+	// ListClaudeLocalPluginLeftovers scans Claude's installed plugin
+	// inventory under home and returns the enabled local-scope Traceary
+	// installs whose project directory no longer exists. A missing
+	// inventory file returns an error matching os.IsNotExist.
+	ListClaudeLocalPluginLeftovers(home string) (ClaudeLocalLeftoverScan, error)
 }
 
 // ClaudePluginDetection reports whether the Traceary Claude Code
@@ -19,4 +24,16 @@ type ClaudePluginDetection struct {
 	// PluginKey is the enabledPlugins key that matched, e.g.
 	// "traceary@traceary-plugins". Empty when Active is false.
 	PluginKey string
+}
+
+// ClaudeLocalLeftoverScan reports the enabled, local-scope Traceary
+// plugin rows in Claude's installed plugin inventory whose project
+// directory no longer exists on disk.
+type ClaudeLocalLeftoverScan struct {
+	// InventoryPath is the installed_plugins.json file that was read.
+	InventoryPath string
+	// LeftoverPaths lists the projectPath values of enabled local
+	// Traceary installs whose directory is missing (or is not a
+	// directory), sorted for stable diagnostics.
+	LeftoverPaths []string
 }

--- a/docs/release/post-upgrade-plugins.ja.md
+++ b/docs/release/post-upgrade-plugins.ja.md
@@ -44,6 +44,8 @@ release 済みバイナリを更新するたびに、次を実行してくださ
 
 doctor が正確な非対話コマンドを `FixCommand` に出す場合は、そちらを優先してください。ホスト CLI のフラグを推測で追加してはいけません。
 
+`--scope local` install に関する補足: Claude の `~/.claude/plugins/installed_plugins.json` にある local install の行は、指していた project ディレクトリが削除されても残ります。doctor はこれらの行を additive な `claude-plugin-local-leftovers` WARN（件数と欠落 path の上限付きサンプル）として報告します。user cache の `claude-plugin-cache` / `claude-plugin-version` は `pass` のままです。Traceary は Claude の inventory を書き換えません。`installed_plugins.json` を確認し、leftover の local 行は Claude 側で自分で削除してください。
+
 ## 古いプロセス
 
 Homebrew / `go install` の更新は PATH 上のバイナリを置き換えますが、**すでに動いているプロセスは古い実行ファイルのまま**です。2026-08-18 の dogfood では、置き換わった Cellar バイナリ（0.32–0.34）上の `traceary mcp-server` が長時間残っていました。MCP は v0.35.0 で引退しており、これらのプロセスは store-lease プロトコルより前のものです。stale なホスト session が compact 中にそれらへリクエストすると、排他制御なしで書き込めます。

--- a/docs/release/post-upgrade-plugins.md
+++ b/docs/release/post-upgrade-plugins.md
@@ -44,6 +44,8 @@ After every released binary upgrade:
 
 Prefer the `FixCommand` printed by doctor when it provides an exact non-interactive command. Do not invent host CLI flags.
 
+Note on `--scope local` installs: a local install row in Claude's `~/.claude/plugins/installed_plugins.json` survives the deletion of the project directory it points at. Doctor reports those rows as the additive `claude-plugin-local-leftovers` WARN (count plus a bounded sample of the missing paths); the user-cache `claude-plugin-cache` / `claude-plugin-version` checks stay `pass`. Traceary never rewrites Claude's inventory — inspect `installed_plugins.json` and remove the leftover local rows in Claude yourself.
+
 ## Stale processes
 
 Homebrew / `go install` upgrades replace the on-PATH binary, but **already-running processes keep the old executable**. The 2026-08-18 dogfood found long-lived `traceary mcp-server` processes on superseded Cellar binaries (0.32–0.34). MCP was retired in v0.35.0; those processes predate the store-lease protocol, so a stale host session that talks to them mid-compact can write without exclusive access.

--- a/infrastructure/filesystem/claude_plugin_detector_adapter.go
+++ b/infrastructure/filesystem/claude_plugin_detector_adapter.go
@@ -21,3 +21,16 @@ func (a *ClaudePluginDetectorAdapter) DetectClaudeTracearyPluginIn(home string) 
 		PluginKey:    detection.PluginKey,
 	}
 }
+
+// ListClaudeLocalPluginLeftovers adapts the filesystem-level inventory
+// scan to the application-level ClaudeLocalLeftoverScan shape.
+func (a *ClaudePluginDetectorAdapter) ListClaudeLocalPluginLeftovers(home string) (application.ClaudeLocalLeftoverScan, error) {
+	scan, err := ListClaudeLocalPluginLeftovers(home)
+	if err != nil {
+		return application.ClaudeLocalLeftoverScan{InventoryPath: scan.InventoryPath}, err
+	}
+	return application.ClaudeLocalLeftoverScan{
+		InventoryPath: scan.InventoryPath,
+		LeftoverPaths: scan.LeftoverPaths,
+	}, nil
+}

--- a/infrastructure/filesystem/claude_plugin_inventory.go
+++ b/infrastructure/filesystem/claude_plugin_inventory.go
@@ -1,0 +1,80 @@
+package filesystem
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ClaudeLocalLeftoverScan reports the enabled, local-scope Traceary plugin
+// rows in Claude's installed plugin inventory whose project directory no
+// longer exists on disk (for example, deleted worktrees).
+type ClaudeLocalLeftoverScan struct {
+	// InventoryPath is the installed_plugins.json file that was read.
+	InventoryPath string
+	// LeftoverPaths lists the projectPath values of enabled local Traceary
+	// installs whose directory is missing (or exists but is not a
+	// directory), sorted for stable diagnostics.
+	LeftoverPaths []string
+}
+
+// ListClaudeLocalPluginLeftovers reads
+// ~/.claude/plugins/installed_plugins.json (for the given home) and
+// returns the enabled local-scope Traceary rows whose projectPath
+// directory no longer exists. The inventory is parsed read-only and only
+// the projectPath values it lists are statted — no worktree trees are
+// walked. A missing inventory file returns an error matching
+// os.IsNotExist so callers can omit the diagnostic entirely; an
+// unreadable or malformed file returns a non-nil error so the caller can
+// surface a WARN.
+func ListClaudeLocalPluginLeftovers(home string) (ClaudeLocalLeftoverScan, error) {
+	inventoryPath := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
+	scan := ClaudeLocalLeftoverScan{InventoryPath: inventoryPath}
+	content, err := os.ReadFile(inventoryPath)
+	if err != nil {
+		return scan, fmt.Errorf("failed to read %s: %w", inventoryPath, err)
+	}
+
+	var inventory struct {
+		Plugins map[string][]struct {
+			Scope       string `json:"scope"`
+			ProjectPath string `json:"projectPath"`
+			Enabled     *bool  `json:"enabled"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(content, &inventory); err != nil {
+		return scan, fmt.Errorf("failed to parse %s: %w", inventoryPath, err)
+	}
+
+	for key, rows := range inventory.Plugins {
+		// The plugin key is `<plugin>@<marketplace>`; Traceary's canonical
+		// plugin name is `traceary`, so match any marketplace that hosts
+		// it (same prefix rule as settings.json detection).
+		if !strings.HasPrefix(key, "traceary@") {
+			continue
+		}
+		for _, row := range rows {
+			if row.Scope != "local" {
+				continue
+			}
+			// Claude omits `enabled` on enabled rows; only an explicit
+			// `enabled: false` disables an install.
+			if row.Enabled != nil && !*row.Enabled {
+				continue
+			}
+			projectPath := strings.TrimSpace(row.ProjectPath)
+			if projectPath == "" {
+				continue
+			}
+			if info, statErr := os.Stat(filepath.Clean(projectPath)); statErr == nil && info.IsDir() {
+				continue
+			}
+			scan.LeftoverPaths = append(scan.LeftoverPaths, projectPath)
+		}
+	}
+	sort.Strings(scan.LeftoverPaths)
+	return scan, nil
+}

--- a/infrastructure/filesystem/claude_plugin_inventory_test.go
+++ b/infrastructure/filesystem/claude_plugin_inventory_test.go
@@ -1,0 +1,141 @@
+package filesystem
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// writeClaudePluginInventory writes an installed_plugins.json fixture with
+// the given body into the test home and returns its path.
+func writeClaudePluginInventory(t *testing.T, home, body string) string {
+	t.Helper()
+	path := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
+}
+
+func TestListClaudeLocalPluginLeftovers_MissingInventory(t *testing.T) {
+	t.Parallel()
+
+	scan, err := ListClaudeLocalPluginLeftovers(t.TempDir())
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("error = %v; want fs.ErrNotExist", err)
+	}
+	if len(scan.LeftoverPaths) != 0 {
+		t.Fatalf("LeftoverPaths = %v; want empty", scan.LeftoverPaths)
+	}
+}
+
+func TestListClaudeLocalPluginLeftovers_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	inventoryPath := writeClaudePluginInventory(t, home, `{not json`)
+
+	scan, err := ListClaudeLocalPluginLeftovers(home)
+	if err == nil {
+		t.Fatal("error = nil; want parse error")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("error = %v; must not look like a missing file", err)
+	}
+	if scan.InventoryPath != inventoryPath {
+		t.Fatalf("InventoryPath = %q; want %q", scan.InventoryPath, inventoryPath)
+	}
+}
+
+func TestListClaudeLocalPluginLeftovers_ClassifiesRows(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	existingProject := t.TempDir()
+	filePath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	missingA := filepath.Join(home, "gone-a")
+	missingB := filepath.Join(home, "gone-b")
+	disabledMissing := filepath.Join(home, "gone-disabled")
+
+	inventory := fmt.Sprintf(`{
+  "version": 2,
+  "plugins": {
+    "traceary@traceary-plugins": [
+      { "scope": "user", "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.45.0", "version": "0.45.0" },
+      { "scope": "local", "projectPath": "%s", "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.45.0", "version": "0.45.0" },
+      { "scope": "local", "projectPath": "%s", "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.41.0", "version": "0.41.0" },
+      { "scope": "local", "projectPath": "%s", "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.40.0", "version": "0.40.0" },
+      { "scope": "local", "projectPath": "%s", "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.39.0", "version": "0.39.0" },
+      { "scope": "local", "projectPath": "%s", "enabled": false, "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.39.0", "version": "0.39.0" },
+      { "scope": "local", "projectPath": "   ", "installPath": "x", "version": "0.39.0" },
+      { "scope": "project", "projectPath": "%s", "installPath": "x", "version": "0.39.0" }
+    ],
+    "other-plugin@some-marketplace": [
+      { "scope": "local", "projectPath": "%s", "installPath": "y", "version": "1.0.0" }
+    ]
+  }
+}`,
+		home, existingProject, home,
+		missingB, home,
+		missingA, home,
+		filePath, home,
+		disabledMissing, home,
+		missingA,
+		filepath.Join(home, "gone-other"),
+	)
+	writeClaudePluginInventory(t, home, inventory)
+
+	scan, err := ListClaudeLocalPluginLeftovers(home)
+	if err != nil {
+		t.Fatalf("error = %v; want nil", err)
+	}
+
+	// Leftovers: missingA, missingB, and the path that exists but is a
+	// file. The existing project, the disabled row, the empty projectPath,
+	// the project-scope row, and the non-Traceary plugin are all excluded.
+	want := []string{filePath, missingA, missingB}
+	sort.Strings(want)
+	if len(scan.LeftoverPaths) != len(want) {
+		t.Fatalf("LeftoverPaths = %v; want %v", scan.LeftoverPaths, want)
+	}
+	for i, path := range want {
+		if scan.LeftoverPaths[i] != path {
+			t.Fatalf("LeftoverPaths[%d] = %q; want %q (sorted)", i, scan.LeftoverPaths[i], path)
+		}
+	}
+}
+
+func TestListClaudeLocalPluginLeftovers_NoLeftoversWhenAllPresent(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	existingProject := t.TempDir()
+	inventory := fmt.Sprintf(`{
+  "version": 2,
+  "plugins": {
+    "traceary@traceary-plugins": [
+      { "scope": "user", "installPath": "x", "version": "0.45.0" },
+      { "scope": "local", "projectPath": "%s", "installPath": "y", "version": "0.45.0" }
+    ]
+  }
+}`, existingProject)
+	writeClaudePluginInventory(t, home, inventory)
+
+	scan, err := ListClaudeLocalPluginLeftovers(home)
+	if err != nil {
+		t.Fatalf("error = %v; want nil", err)
+	}
+	if len(scan.LeftoverPaths) != 0 {
+		t.Fatalf("LeftoverPaths = %v; want empty", scan.LeftoverPaths)
+	}
+}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -572,6 +572,9 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			if cacheCheck := c.inspectClaudePluginCacheStatus(); cacheCheck != nil {
 				report.Checks = append(report.Checks, *cacheCheck)
 			}
+			if leftoversCheck := c.inspectClaudePluginLocalLeftovers(); leftoversCheck != nil {
+				report.Checks = append(report.Checks, *leftoversCheck)
+			}
 		}
 
 		report.Checks = append(report.Checks, inspectHostCapabilityGaps(targetClient, outputPath)...)

--- a/presentation/cli/doctor_claude_local_leftovers_test.go
+++ b/presentation/cli/doctor_claude_local_leftovers_test.go
@@ -1,0 +1,316 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/infrastructure/filesystem"
+)
+
+// stubClaudePluginDetector implements application.ClaudePluginDetector
+// with canned results so inspect-level tests do not touch the real home.
+type stubClaudePluginDetector struct {
+	scan    application.ClaudeLocalLeftoverScan
+	scanErr error
+}
+
+func (s stubClaudePluginDetector) DetectClaudeTracearyPluginIn(string) application.ClaudePluginDetection {
+	return application.ClaudePluginDetection{}
+}
+
+func (s stubClaudePluginDetector) ListClaudeLocalPluginLeftovers(string) (application.ClaudeLocalLeftoverScan, error) {
+	return s.scan, s.scanErr
+}
+
+func TestInspectClaudePluginLocalLeftoversWarnsWithCountAndSample(t *testing.T) {
+	missing := []string{filepath.Join(t.TempDir(), "gone-a"), filepath.Join(t.TempDir(), "gone-b")}
+	cli := &RootCLI{pluginDetector: stubClaudePluginDetector{
+		scan: application.ClaudeLocalLeftoverScan{
+			InventoryPath: "/home/test/.claude/plugins/installed_plugins.json",
+			LeftoverPaths: missing,
+		},
+	}}
+
+	check := cli.inspectClaudePluginLocalLeftovers()
+	if check == nil {
+		t.Fatal("check = nil; want WARN check")
+	}
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status = %q, want warn", check.Status)
+	}
+	if check.Name != "claude-plugin-local-leftovers" {
+		t.Fatalf("name = %q", check.Name)
+	}
+	if !strings.Contains(check.Message, "2") {
+		t.Fatalf("message = %q, want leftover count 2", check.Message)
+	}
+	for _, path := range missing {
+		if !strings.Contains(check.Message, path) {
+			t.Fatalf("message = %q, want sample path %q", check.Message, path)
+		}
+	}
+	if !strings.Contains(check.Hint, "installed_plugins.json") {
+		t.Fatalf("hint = %q, want it to name installed_plugins.json", check.Hint)
+	}
+	if check.AutoFixAvailable {
+		t.Fatal("AutoFixAvailable = true, want false")
+	}
+	if check.FixCommand != "" {
+		t.Fatalf("FixCommand = %q, want empty", check.FixCommand)
+	}
+	if check.FixFunc != nil || check.StructuredFixFunc != nil {
+		t.Fatal("leftover check must not carry a fixer (doctor --fix must not write Claude config)")
+	}
+}
+
+func TestInspectClaudePluginLocalLeftoversPassesWhenNoneLeftover(t *testing.T) {
+	cli := &RootCLI{pluginDetector: stubClaudePluginDetector{
+		scan: application.ClaudeLocalLeftoverScan{
+			InventoryPath: "/home/test/.claude/plugins/installed_plugins.json",
+		},
+	}}
+
+	check := cli.inspectClaudePluginLocalLeftovers()
+	if check == nil {
+		t.Fatal("check = nil; want PASS check when inventory exists with no leftovers")
+	}
+	if check.Status != doctorStatusPass {
+		t.Fatalf("status = %q, want pass", check.Status)
+	}
+}
+
+func TestInspectClaudePluginLocalLeftoversOmitsWhenInventoryMissing(t *testing.T) {
+	cli := &RootCLI{pluginDetector: stubClaudePluginDetector{
+		scanErr: fmt.Errorf("read: %w", fs.ErrNotExist),
+	}}
+
+	if check := cli.inspectClaudePluginLocalLeftovers(); check != nil {
+		t.Fatalf("check = %+v, want nil when installed_plugins.json is absent", check)
+	}
+}
+
+func TestInspectClaudePluginLocalLeftoversWarnsNotFailsOnUnreadableInventory(t *testing.T) {
+	cli := &RootCLI{pluginDetector: stubClaudePluginDetector{
+		scan:    application.ClaudeLocalLeftoverScan{InventoryPath: "/home/test/.claude/plugins/installed_plugins.json"},
+		scanErr: errors.New("invalid character 'x'"),
+	}}
+
+	check := cli.inspectClaudePluginLocalLeftovers()
+	if check == nil {
+		t.Fatal("check = nil; want WARN check for unreadable inventory")
+	}
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status = %q, want warn (not fail)", check.Status)
+	}
+	if check.FixFunc != nil || check.StructuredFixFunc != nil {
+		t.Fatal("unreadable-inventory WARN must not carry a fixer")
+	}
+}
+
+func TestInspectClaudePluginLocalLeftoversBoundsSample(t *testing.T) {
+	base := t.TempDir()
+	leftovers := make([]string, 0, 7)
+	for i := 0; i < 7; i++ {
+		leftovers = append(leftovers, filepath.Join(base, fmt.Sprintf("gone-%d", i)))
+	}
+	cli := &RootCLI{pluginDetector: stubClaudePluginDetector{
+		scan: application.ClaudeLocalLeftoverScan{
+			InventoryPath: "/home/test/.claude/plugins/installed_plugins.json",
+			LeftoverPaths: leftovers,
+		},
+	}}
+
+	check := cli.inspectClaudePluginLocalLeftovers()
+	if check == nil || check.Status != doctorStatusWarn {
+		t.Fatalf("check = %+v, want WARN", check)
+	}
+	if !strings.Contains(check.Message, "7") {
+		t.Fatalf("message = %q, want full count 7", check.Message)
+	}
+	if !strings.Contains(check.Message, "and 2 more") {
+		t.Fatalf("message = %q, want remainder summary", check.Message)
+	}
+	printed := 0
+	for _, path := range leftovers {
+		if strings.Contains(check.Message, path) {
+			printed++
+		}
+	}
+	if printed > claudeLocalLeftoverSampleLimit {
+		t.Fatalf("message prints %d paths, want at most %d: %q", printed, claudeLocalLeftoverSampleLimit, check.Message)
+	}
+}
+
+func TestInspectClaudePluginLocalLeftoversIsStoreIndependent(t *testing.T) {
+	t.Parallel()
+	if !doctorCheckIsStoreIndependent("claude-plugin-local-leftovers") {
+		t.Fatal("claude-plugin-local-leftovers must be labeled store-independent")
+	}
+
+	report := &doctorReport{
+		Checks: []doctorCheck{{
+			Name:    "claude-plugin-local-leftovers",
+			Status:  doctorStatusWarn,
+			Message: "claude plugin inventory lists 1 enabled local Traceary install(s)",
+		}},
+	}
+	annotateDoctorScopeAndDBPathHints(report)
+	if !strings.Contains(report.Checks[0].Message, doctorStoreIndependentLabel) {
+		t.Fatalf("message = %q, want store-independent label", report.Checks[0].Message)
+	}
+}
+
+// writeClaudePluginInventoryFixture writes an installed_plugins.json with
+// the given rows body into the test home.
+func writeClaudePluginInventoryFixture(t *testing.T, home, body string) {
+	t.Helper()
+	path := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+// TestInspectClaudePluginLocalLeftoversRealInventory drives the shipped
+// inspect function through the real filesystem adapter against a temp-HOME
+// fixture: an existing local project must not be flagged, and the user
+// cache checks must stay PASS while leftovers WARN.
+func TestInspectClaudePluginLocalLeftoversRealInventory(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	existingProject := t.TempDir()
+	missingProject := filepath.Join(home, "deleted-worktree")
+	writeClaudePluginInventoryFixture(t, home, fmt.Sprintf(`{
+  "version": 2,
+  "plugins": {
+    "traceary@traceary-plugins": [
+      { "scope": "user", "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.45.0", "version": "0.45.0" },
+      { "scope": "local", "projectPath": "%s", "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.45.0", "version": "0.45.0" },
+      { "scope": "local", "projectPath": "%s", "installPath": "%s/.claude/plugins/cache/traceary-plugins/traceary/0.41.0", "version": "0.41.0" }
+    ]
+  }
+}`, home, existingProject, home, missingProject, home))
+
+	// User-scope plugin detection + a current 0.45.0 cache so the existing
+	// cache/version checks stay PASS.
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"enabledPlugins": {"traceary@traceary-plugins": true}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	cacheDir := filepath.Join(home, ".claude", "plugins", "cache", "traceary-plugins", "traceary", "0.45.0")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	manifestPath := filepath.Join(home, ".claude", "plugins", "marketplaces", "traceary-plugins", "integrations", "claude-plugin", ".claude-plugin", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(manifestPath, []byte(`{"name":"traceary","version":"0.45.0"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cli := &RootCLI{
+		pluginDetector:       filesystem.NewClaudePluginDetectorAdapter(),
+		pluginCacheInspector: filesystem.NewPluginCacheInspector(),
+	}
+
+	leftovers := cli.inspectClaudePluginLocalLeftovers()
+	if leftovers == nil || leftovers.Status != doctorStatusWarn {
+		t.Fatalf("leftovers check = %+v, want WARN", leftovers)
+	}
+	if !strings.Contains(leftovers.Message, "1 enabled local") {
+		t.Fatalf("message = %q, want count 1 (existing project excluded)", leftovers.Message)
+	}
+	if !strings.Contains(leftovers.Message, missingProject) {
+		t.Fatalf("message = %q, want missing path %q", leftovers.Message, missingProject)
+	}
+	if strings.Contains(leftovers.Message, existingProject) {
+		t.Fatalf("message = %q, must not flag the existing project %q", leftovers.Message, existingProject)
+	}
+
+	cache := cli.inspectClaudePluginCacheStatus()
+	if cache == nil || cache.Status != doctorStatusPass {
+		t.Fatalf("claude-plugin-cache = %+v, want PASS (leftovers must not flip it)", cache)
+	}
+
+	versionPass := false
+	for _, check := range cli.inspectPluginVersionChecks("0.45.0") {
+		if check.Name == "claude-plugin-version" && check.Status == doctorStatusPass {
+			versionPass = true
+		}
+	}
+	if !versionPass {
+		t.Fatal("claude-plugin-version must stay PASS on a current user cache")
+	}
+}
+
+// TestFilesystemHostDoctorIncludesLocalLeftovers proves the bounded
+// (large-store) doctor path also reports leftover local installs and that
+// the emitted check carries no fixer, so `doctor --fix` cannot rewrite
+// Claude's inventory.
+func TestFilesystemHostDoctorIncludesLocalLeftovers(t *testing.T) {
+	home := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) { return home, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	missingProject := filepath.Join(home, "deleted-worktree")
+	writeClaudePluginInventoryFixture(t, home, fmt.Sprintf(`{
+  "version": 2,
+  "plugins": {
+    "traceary@traceary-plugins": [
+      { "scope": "local", "projectPath": "%s", "installPath": "x", "version": "0.41.0" }
+    ]
+  }
+}`, missingProject))
+	inventoryBytes, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	cli := NewRootCLI(
+		WithHooksOrchestrator(filesystem.NewHooksOrchestrator(map[string]application.HooksClientHandler{
+			"claude": filesystem.NewClaudeHooksHandler(),
+		})),
+		WithHooksInspector(filesystem.NewHooksInspector()),
+		WithPluginCacheInspector(filesystem.NewPluginCacheInspector()),
+		WithClaudePluginDetector(filesystem.NewClaudePluginDetectorAdapter()),
+	)
+
+	report := &doctorReport{}
+	cli.appendFilesystemHostDoctorChecks(context.Background(), report, []string{"claude"}, t.TempDir(), "")
+
+	var leftover *doctorCheck
+	for i := range report.Checks {
+		if report.Checks[i].Name == "claude-plugin-local-leftovers" {
+			leftover = &report.Checks[i]
+		}
+	}
+	if leftover == nil {
+		t.Fatalf("filesystem-host doctor checks = %+v, want claude-plugin-local-leftovers", report.Checks)
+	}
+	if leftover.Status != doctorStatusWarn {
+		t.Fatalf("status = %q, want warn", leftover.Status)
+	}
+	if leftover.FixFunc != nil || leftover.StructuredFixFunc != nil || leftover.FixCommand != "" || leftover.AutoFixAvailable {
+		t.Fatalf("leftover check must not be fixable: %+v", leftover)
+	}
+
+	after, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(after) != string(inventoryBytes) {
+		t.Fatal("doctor must not modify Claude's installed_plugins.json")
+	}
+}

--- a/presentation/cli/doctor_config_inspect.go
+++ b/presentation/cli/doctor_config_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -76,6 +77,84 @@ func (c *RootCLI) inspectClaudePluginCacheStatus() *doctorCheck {
 			"claude plugin cache matches the marketplace manifest (cached %s, marketplace %s)",
 			"claude plugin cache は marketplace manifest と一致しています (cached %s, marketplace %s)",
 			status.CachedVersion, status.MarketplaceVersion,
+		),
+	}
+}
+
+// claudeLocalLeftoverSampleLimit bounds how many missing projectPath
+// values the leftover WARN message prints; the remainder is summarized
+// as a count so a pile of deleted worktrees does not flood the report.
+const claudeLocalLeftoverSampleLimit = 5
+
+// inspectClaudePluginLocalLeftovers surfaces enabled local-scope Traceary
+// installs in Claude's installed_plugins.json whose project directory no
+// longer exists (deleted worktrees). The check is additive: it never
+// changes the claude-plugin-cache / claude-plugin-version results, has no
+// auto-fix, and never writes Claude's inventory — removing the leftover
+// rows is the operator's call inside Claude.
+func (c *RootCLI) inspectClaudePluginLocalLeftovers() *doctorCheck {
+	if c == nil || c.pluginDetector == nil {
+		return nil
+	}
+	home, err := userHomeDirFunc()
+	if err != nil {
+		return nil
+	}
+	scan, err := c.pluginDetector.ListClaudeLocalPluginLeftovers(home)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return &doctorCheck{
+			Name:   "claude-plugin-local-leftovers",
+			Status: doctorStatusWarn,
+			Hint: localizef(
+				"inspect %s and repair the file so doctor can audit leftover local installs; Traceary never rewrites Claude's inventory",
+				"%s を確認してファイルを修復し、doctor が leftover local install を監査できるようにしてください。Traceary が Claude の inventory を書き換えることはありません",
+				scan.InventoryPath,
+			),
+			Message: localizef(
+				"claude plugin inventory could not be read, so leftover local Traceary installs cannot be audited: %s (%v)",
+				"claude plugin inventory を読み取れないため leftover local Traceary install を監査できません: %s (%v)",
+				scan.InventoryPath,
+				err,
+			),
+		}
+	}
+	if len(scan.LeftoverPaths) == 0 {
+		return &doctorCheck{
+			Name:   "claude-plugin-local-leftovers",
+			Status: doctorStatusPass,
+			Message: localizef(
+				"no leftover local Traceary installs in the claude plugin inventory: %s",
+				"claude plugin inventory に leftover local Traceary install はありません: %s",
+				scan.InventoryPath,
+			),
+		}
+	}
+	sample := scan.LeftoverPaths
+	remainder := 0
+	if len(sample) > claudeLocalLeftoverSampleLimit {
+		remainder = len(sample) - claudeLocalLeftoverSampleLimit
+		sample = sample[:claudeLocalLeftoverSampleLimit]
+	}
+	sampleText := strings.Join(sample, ", ")
+	if remainder > 0 {
+		sampleText = localizef("%s, and %d more", "%s ほか %d 件", sampleText, remainder)
+	}
+	return &doctorCheck{
+		Name:   "claude-plugin-local-leftovers",
+		Status: doctorStatusWarn,
+		Hint: localizef(
+			"inspect %s and remove the leftover local Traceary rows from Claude's inventory yourself (`claude plugin disable --scope local` only works inside a live project directory); Traceary never rewrites Claude's inventory",
+			"%s を確認し、leftover の local Traceary 行を Claude の inventory から自分で削除してください (`claude plugin disable --scope local` は生存している project 内でのみ動作します)。Traceary が Claude の inventory を書き換えることはありません",
+			scan.InventoryPath,
+		),
+		Message: localizef(
+			"claude plugin inventory lists %d enabled local Traceary install(s) whose project directory no longer exists: %s",
+			"claude plugin inventory に project ディレクトリが消えた enabled な local Traceary install が %d 件あります: %s",
+			len(scan.LeftoverPaths),
+			sampleText,
 		),
 	}
 }

--- a/presentation/cli/doctor_filesystem_host.go
+++ b/presentation/cli/doctor_filesystem_host.go
@@ -62,6 +62,9 @@ func (c *RootCLI) appendFilesystemHostDoctorChecks(
 			if cacheCheck := c.inspectClaudePluginCacheStatus(); cacheCheck != nil {
 				report.Checks = append(report.Checks, *cacheCheck)
 			}
+			if leftoversCheck := c.inspectClaudePluginLocalLeftovers(); leftoversCheck != nil {
+				report.Checks = append(report.Checks, *leftoversCheck)
+			}
 		}
 		if globalCheck := c.inspectGlobalConfigForClient(targetClient); globalCheck != nil {
 			report.Checks = append(report.Checks, *globalCheck)

--- a/presentation/cli/doctor_scope.go
+++ b/presentation/cli/doctor_scope.go
@@ -15,7 +15,7 @@ func doctorCheckIsStoreIndependent(name string) bool {
 	switch strings.TrimSpace(name) {
 	case "path", "config", "version", "project-dir", "stale-processes",
 		"hook-spool", "hook-state-residue", "hook-memory-extract", "hook-grok-transcript",
-		"claude-hook-cancellations", "claude-plugin-cache":
+		"claude-hook-cancellations", "claude-plugin-cache", "claude-plugin-local-leftovers":
 		return true
 	}
 	if strings.HasSuffix(name, "-plugin") || strings.HasSuffix(name, "-plugin-version") || strings.HasSuffix(name, "-inspect") {


### PR DESCRIPTION
## Summary

Additive store-independent doctor check `claude-plugin-local-leftovers`:

- Reads only `~/.claude/plugins/installed_plugins.json`
- WARNs with count + bounded sample (5) of enabled local Traceary rows whose `projectPath` directory is gone
- No auto-fix; does not rewrite Claude inventory
- `claude-plugin-cache` / `claude-plugin-version` stay PASS on a current user cache
- Wired in full doctor and filesystem-host (large-store) doctor

Design: grok 4.6 medium (`.ai/spec/2212.md`). Implementation: kimi k3.

## Test plan

- [x] missing-dir local row → WARN count ≥ 1
- [x] present project path not counted
- [x] disabled / user-scope / non-Traceary ignored
- [x] `--fix` does not write inventory
- [x] `go test ./presentation/cli/ ./infrastructure/filesystem/ ./application/ -count=1`
- [x] `go tool golangci-lint run`

Closes #2212