### PR TITLE
fix: replace rejected Codex exec -a never in runtime smoke probe

### DIFF
--- a/scripts/smoke_test_integrations.sh
+++ b/scripts/smoke_test_integrations.sh
@@ -77,7 +77,7 @@ run_codex() {
     return 0
   }
 
-  codex exec -C "${ROOT_DIR}" -a never -s workspace-write 'In one sentence, name the Traceary slash command or skill exposed by the current repository plugin bundle.'
+  codex exec -C "${ROOT_DIR}" -s read-only 'In one sentence, name the Traceary slash command or skill exposed by the current repository plugin bundle.'
   echo 'ok: codex runtime probe completed'
 }
 


### PR DESCRIPTION
## Summary

Opt-in Codex runtime smoke probe no longer passes `-a never` (current Codex CLI rejects it). Uses `codex exec -s read-only`. Probe stays behind `TRACEARY_ENABLE_CODEX_RUNTIME_SMOKE=1` and still skips when `codex` is missing.

Closes #2213