### PR TITLE
fix: align doctor plugin update hints with post-upgrade docs

### DIFF
--- a/docs/operations/large-store-doctor.ja.md
+++ b/docs/operations/large-store-doctor.ja.md
@@ -52,4 +52,4 @@ dead-letter と orphan `*.tmp` を prune します。spool replay は event 書�
 
 store-independent な check（hook spool、hook-state residue、SessionEnd cancellation marker、plugin cache、`path` / `config`）は出力行に `store-independent` と書きます。SQLite store ではなく host file を見ます。store-scoped な check（capacity、memory activation、projection）は `DB_PATH` の store を見ます。
 
-doctor が `--db-path` または `TRACEARY_DB_PATH` 付きで走ったとき、store を対象とする hint（`traceary doctor`、`traceary store`、`traceary memory`）には `--db-path` が付きます。そのまま実行しても検査した store に届きます。host-only なコマンド（`claude plugins update`、`which -a traceary`）は変えません。既定の home store では `--db-path` を足しません。
+doctor が `--db-path` または `TRACEARY_DB_PATH` 付きで走ったとき、store を対象とする hint（`traceary doctor`、`traceary store`、`traceary memory`）には `--db-path` が付きます。そのまま実行しても検査した store に届きます。host-only なコマンド（`claude plugin update`、`which -a traceary`）は変えません。既定の home store では `--db-path` を足しません。

--- a/docs/operations/large-store-doctor.md
+++ b/docs/operations/large-store-doctor.md
@@ -55,4 +55,4 @@ and `--fix --dry-run` opens nothing.
 
 Store-independent checks (hook spool, hook-state residue, SessionEnd cancellation markers, plugin cache, `path` / `config`) say `store-independent` on the output line. They inspect host files, not the SQLite store. Store-scoped checks (capacity, memory activation, projection) inspect the store at `DB_PATH`.
 
-When doctor ran with `--db-path` or `TRACEARY_DB_PATH`, store-addressed hint commands (`traceary doctor`, `traceary store`, `traceary memory`) include `--db-path` so executing them verbatim hits the same store. Host-only commands (`claude plugins update`, `which -a traceary`) are left unchanged. The default home store does not inject `--db-path`.
+When doctor ran with `--db-path` or `TRACEARY_DB_PATH`, store-addressed hint commands (`traceary doctor`, `traceary store`, `traceary memory`) include `--db-path` so executing them verbatim hits the same store. Host-only commands (`claude plugin update`, `which -a traceary`) are left unchanged. The default home store does not inject `--db-path`.

--- a/presentation/cli/doctor_config_inspect.go
+++ b/presentation/cli/doctor_config_inspect.go
@@ -41,8 +41,8 @@ func (c *RootCLI) inspectClaudePluginCacheStatus() *doctorCheck {
 	staleSegment, multiSegment := "", ""
 	if status.Stale() {
 		staleSegment = localizef(
-			"claude plugin cache %s is older than the marketplace manifest (cached %s, marketplace %s at %s). `brew upgrade traceary` does not refresh the plugin cache; run `claude plugins update %s` to activate the newer hooks",
-			"claude plugin cache %s は marketplace manifest より古いバージョンです (cached %s, marketplace %s at %s)。`brew upgrade traceary` では plugin cache は更新されません。新しい hook を有効にするには `claude plugins update %s` を実行してください",
+			"claude plugin cache %s is older than the marketplace manifest (cached %s, marketplace %s at %s). `brew upgrade traceary` does not refresh the plugin cache; run `claude plugin update %s` to activate the newer hooks",
+			"claude plugin cache %s は marketplace manifest より古いバージョンです (cached %s, marketplace %s at %s)。`brew upgrade traceary` では plugin cache は更新されません。新しい hook を有効にするには `claude plugin update %s` を実行してください",
 			status.CachePath, status.CachedVersion, status.MarketplaceVersion, status.MarketplacePath, detection.PluginKey,
 		)
 	}
@@ -705,8 +705,8 @@ func missingClientHookCoverageCheck(client, checkName, outputPath, projectDir st
 		fixCommand = fmt.Sprintf("traceary hooks install --client %s --global --upgrade", client)
 		if client == "gemini" {
 			hint = localizef(
-				"refresh the user-level Gemini settings with `%s`; if you use the Gemini extension package instead, run `gemini extensions update traceary`",
-				"`%s` で user-level Gemini settings を更新してください。Gemini extension package を使っている場合は `gemini extensions update traceary` を実行してください",
+				"refresh the user-level Gemini settings with `%s`; if you use the Gemini extension package instead, rerun `./scripts/install-gemini-extension.sh` from a matching release tag checkout (recovery: `gemini extensions install --consent integrations/gemini-extension`)",
+				"`%s` で user-level Gemini settings を更新してください。Gemini extension package を使っている場合は、一致する release tag の checkout から `./scripts/install-gemini-extension.sh` を再実行してください (recovery: `gemini extensions install --consent integrations/gemini-extension`)",
 				fixCommand,
 			)
 		} else {

--- a/presentation/cli/doctor_event_coverage.go
+++ b/presentation/cli/doctor_event_coverage.go
@@ -277,9 +277,9 @@ func (c *RootCLI) inspectInstalledClaudePluginHookCoverage(pluginKey string) ins
 
 func claudePluginUpdateCommand(pluginKey string) string {
 	if pluginKey == "" {
-		return "claude plugins update"
+		return "claude plugin update traceary@traceary-plugins"
 	}
-	return "claude plugins update " + pluginKey
+	return "claude plugin update " + pluginKey
 }
 
 // inspectClaudePluginCacheStatus compares the cached Traceary Claude
@@ -287,7 +287,7 @@ func claudePluginUpdateCommand(pluginKey string) string {
 // registered from. A stale cache is the exact failure mode v0.8.0
 // dogfooding revealed: `brew upgrade traceary` does not refresh the
 // plugin cache, so new hooks (#606 transcript / #605 matcher expansion)
-// stay dark until the operator runs `claude plugins update`. The check
+// stay dark until the operator runs `claude plugin update`. The check
 // returns nil when the plugin is not active or when either side cannot
 // be resolved (reported indirectly by the existing claude-config check).
 

--- a/presentation/cli/doctor_plugin_test.go
+++ b/presentation/cli/doctor_plugin_test.go
@@ -100,7 +100,7 @@ func TestRootCLI_Doctor_ClaudePluginInteractions(t *testing.T) {
 		if !strings.Contains(claudeCfg.Message, filepath.Join(cacheDir, "hooks", "hooks.json")) {
 			t.Fatalf("claude-config message = %q; want cached hooks path", claudeCfg.Message)
 		}
-		if !strings.Contains(claudeCfg.Hint, "marketplace") || !strings.Contains(claudeCfg.FixCommand, "claude plugins update traceary@traceary-plugins") {
+		if !strings.Contains(claudeCfg.Hint, "marketplace") || !strings.Contains(claudeCfg.FixCommand, "claude plugin update traceary@traceary-plugins") {
 			t.Fatalf("claude-config hint/fix = %q / %q; want no marketplace fallback and plugin update", claudeCfg.Hint, claudeCfg.FixCommand)
 		}
 	})

--- a/presentation/cli/doctor_plugin_version.go
+++ b/presentation/cli/doctor_plugin_version.go
@@ -39,9 +39,9 @@ func (c *RootCLI) detectPluginInstalls() []doctorPluginInstall {
 	installs := []doctorPluginInstall{}
 	if detection := c.detectClaudeTracearyPluginForCLI(); detection.Active {
 		if status := c.pluginCacheStatusForDetection(home, detection.PluginKey); status.CachedVersion != "" {
-			installs = append(installs, doctorPluginInstall{Client: "claude", ManifestPath: fmt.Sprintf("claude plugin cache %s", detection.PluginKey), InstalledVersion: status.CachedVersion, UpdateHint: "claude plugins update " + detection.PluginKey})
+			installs = append(installs, doctorPluginInstall{Client: "claude", ManifestPath: fmt.Sprintf("claude plugin cache %s", detection.PluginKey), InstalledVersion: status.CachedVersion, UpdateHint: claudePluginUpdateCommand(detection.PluginKey)})
 		} else if status.MarketplacePath != "" {
-			installs = append(installs, doctorPluginInstall{Client: "claude", ManifestPath: status.MarketplacePath, UpdateHint: "claude plugins update " + detection.PluginKey})
+			installs = append(installs, doctorPluginInstall{Client: "claude", ManifestPath: status.MarketplacePath, UpdateHint: claudePluginUpdateCommand(detection.PluginKey)})
 		}
 	}
 	installs = append(installs, detectManifestInstalls(
@@ -58,7 +58,7 @@ func (c *RootCLI) detectPluginInstalls() []doctorPluginInstall {
 	agyHint := "cd <traceary-repository> && agy plugin install integrations/antigravity-plugin"
 	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "config", "plugins", "traceary", "plugin.json"), "antigravity", agyHint)...)
 	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "antigravity-cli", "plugins", "traceary", "plugin.json"), "antigravity", agyHint)...)
-	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "extensions", "traceary", "gemini-extension.json"), "gemini", "gemini extensions update traceary")...)
+	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "extensions", "traceary", "gemini-extension.json"), "gemini", "./scripts/install-gemini-extension.sh  # from a matching release tag checkout (recovery: gemini extensions install --consent integrations/gemini-extension)")...)
 	// Grok clones the whole repository into a hash-named directory under
 	// installed-plugins and selects the package with a #subdir selector; the
 	// manifest stays at its in-repo path inside that clone, so the glob must

--- a/presentation/cli/doctor_plugin_version_test.go
+++ b/presentation/cli/doctor_plugin_version_test.go
@@ -154,7 +154,7 @@ func TestInspectPluginVersionReleaseTaggedBuildMatch(t *testing.T) {
 	if err := os.WriteFile(manifest, []byte(`{"name":"traceary","version":"0.10.0"}`), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
-	install := doctorPluginInstall{Client: "gemini", ManifestPath: manifest, UpdateHint: "gemini extensions update traceary"}
+	install := doctorPluginInstall{Client: "gemini", ManifestPath: manifest, UpdateHint: "./scripts/install-gemini-extension.sh"}
 
 	got := inspectPluginVersion(install, "0.10.0")
 	if got.Status != doctorStatusPass {

--- a/presentation/cli/doctor_scope_test.go
+++ b/presentation/cli/doctor_scope_test.go
@@ -20,7 +20,7 @@ func TestWithDoctorInspectedDBPath(t *testing.T) {
 		{name: "already has db-path", command: "traceary doctor --fix --db-path /other.db", want: "traceary doctor --fix --db-path /other.db"},
 		{name: "memory activate", command: "traceary memory admin activate --target claude --apply", want: "traceary memory admin activate --target claude --apply --db-path " + quoted},
 		{name: "store compact", command: "traceary store compact", want: "traceary store compact --db-path " + quoted},
-		{name: "host-only command", command: "claude plugins update traceary@traceary-plugins", want: "claude plugins update traceary@traceary-plugins"},
+		{name: "host-only command", command: "claude plugin update traceary@traceary-plugins", want: "claude plugin update traceary@traceary-plugins"},
 		{name: "which", command: "which -a traceary", want: "which -a traceary"},
 	}
 	for _, tc := range cases {
@@ -43,12 +43,12 @@ func TestWithDoctorInspectedDBPath_EmptyStore(t *testing.T) {
 
 func TestRewriteBacktickedStoreCommands(t *testing.T) {
 	t.Parallel()
-	input := "preview with `traceary doctor --fix --dry-run`, then `claude plugins update x`"
+	input := "preview with `traceary doctor --fix --dry-run`, then `claude plugin update x`"
 	got := rewriteBacktickedStoreCommands(input, "/store/custom.db")
 	if !strings.Contains(got, "`traceary doctor --fix --dry-run --db-path "+shellQuote("/store/custom.db")+"`") {
 		t.Fatalf("did not rewrite doctor command: %q", got)
 	}
-	if !strings.Contains(got, "`claude plugins update x`") {
+	if !strings.Contains(got, "`claude plugin update x`") {
 		t.Fatalf("rewrote host command: %q", got)
 	}
 }
@@ -72,7 +72,7 @@ func TestAnnotateDoctorScopeAndDBPathHints(t *testing.T) {
 			{
 				Name:       "claude-plugin-cache",
 				Message:    "plugin cache is current",
-				FixCommand: "claude plugins update traceary",
+				FixCommand: "claude plugin update traceary@traceary-plugins",
 			},
 		},
 	}
@@ -98,7 +98,7 @@ func TestAnnotateDoctorScopeAndDBPathHints(t *testing.T) {
 	}
 
 	cache := report.Checks[2]
-	if cache.FixCommand != "claude plugins update traceary" {
+	if cache.FixCommand != "claude plugin update traceary@traceary-plugins" {
 		t.Fatalf("host FixCommand rewritten: %q", cache.FixCommand)
 	}
 	if !strings.Contains(cache.Message, doctorStoreIndependentLabel) {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -1853,7 +1853,7 @@ func TestRootCLI_DoctorClaudeCoverage(t *testing.T) {
 		if check.Status != "warn" {
 			t.Fatalf("claude-event-coverage status = %q, want warn (message=%q)", check.Status, check.Message)
 		}
-		if !strings.Contains(check.Hint, "plugin-managed") || !strings.Contains(check.FixCommand, "claude plugins update traceary@traceary-plugins") {
+		if !strings.Contains(check.Hint, "plugin-managed") || !strings.Contains(check.FixCommand, "claude plugin update traceary@traceary-plugins") {
 			t.Fatalf("claude-event-coverage remediation = hint %q fix %q; want plugin update", check.Hint, check.FixCommand)
 		}
 		if strings.Contains(check.FixCommand, "traceary doctor") {
@@ -1905,7 +1905,7 @@ func TestRootCLI_DoctorClaudeCoverage(t *testing.T) {
 		if strings.Contains(coverage.FixCommand, "traceary doctor") {
 			t.Fatalf("claude-event-coverage remediation = hint %q fix %q; want plugin/double-registration path, not settings fix", coverage.Hint, coverage.FixCommand)
 		}
-		if !strings.Contains(coverage.FixCommand, "claude plugins update traceary@traceary-plugins") {
+		if !strings.Contains(coverage.FixCommand, "claude plugin update traceary@traceary-plugins") {
 			t.Fatalf("claude-event-coverage FixCommand = %q; want plugin update", coverage.FixCommand)
 		}
 	})
@@ -1942,7 +1942,7 @@ func TestRootCLI_DoctorClaudeCoverage(t *testing.T) {
 		if claudeCfg.Status != "warn" {
 			t.Fatalf("claude-config status = %q, want warn (message=%q)", claudeCfg.Status, claudeCfg.Message)
 		}
-		if !strings.Contains(claudeCfg.Message, "installed plugin hook config") || !strings.Contains(claudeCfg.FixCommand, "claude plugins update traceary@traceary-plugins") {
+		if !strings.Contains(claudeCfg.Message, "installed plugin hook config") || !strings.Contains(claudeCfg.FixCommand, "claude plugin update traceary@traceary-plugins") {
 			t.Fatalf("claude-config message/fix = %q / %q; want plugin cache remediation", claudeCfg.Message, claudeCfg.FixCommand)
 		}
 		coverage := statusByName(report, "claude-event-coverage")


### PR DESCRIPTION
## Summary

Doctor `FixCommand` / update hints now match `docs/release/post-upgrade-plugins.md`:

- Claude: `claude plugin update traceary@traceary-plugins` (not `claude plugins update`)
- Gemini local: `scripts/install-gemini-extension.sh` (not `gemini extensions update traceary`)

Host-only commands still do not get `--db-path`.

Closes #2214