### PR TITLE
fix: skip Gemini project hooks install to avoid tracked settings churn

### DIFF
--- a/.ai/spec/2215.md
+++ b/.ai/spec/2215.md
@@ -1,0 +1,130 @@
+# Issue 2215: Gemini install script rewrites tracked `.gemini/settings.json` with key-order-only churn
+
+Engine: grok 4.6 medium  
+Date: 2026-08-21  
+Parent: #2208  
+PR: `Closes #2215` only (never #2208 / #2205)
+
+Implementer: **kimi k3**. Script + `scripts/install_gemini_extension_test.go` only. Do not rewrite Gemini hook payload adapters. Do not commit a reformatted `.gemini/settings.json`. Do not add leftover `presentation/cli/.gemini/`. Isolated stub HOME only. Never point a repo-built binary at the live home store (`~/.config/traceary/traceary.db`). Do not synthesize `session_ended`.
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — operator-visible install script; tracked project settings.json must stay byte-stable on re-run. No schema. No adapter change.
+
+### Requirement summary
+- Purpose: v0.45.0 dogfood (#2205). `scripts/install-gemini-extension.sh` always runs `traceary hooks install --client gemini --project-dir .`. That rewrites the **tracked** repo `.gemini/settings.json` with **key-order-only** JSON churn (reverted during dogfood). The same call is cwd-dependent: running from `presentation/cli` left untracked `presentation/cli/.gemini/settings.json`.
+- Current (repo, `scripts/install-gemini-extension.sh` lines 73–76 already compute `SCRIPT_DIR` / `REPO_ROOT`; line 159–160 still ignore them for hooks):
+  - After #2156 the script’s job is stage-then-swap of `~/.gemini/extensions/traceary` (copy aside, bounded uninstall/install, restore on fail/timeout).
+  - It then **unconditionally** calls `traceary hooks install --client gemini --project-dir .`.
+  - `resolveHooksProjectDir(".")` is `filepath.Abs` of cwd (`presentation/cli/hooks.go`).
+  - `HooksOrchestrator.installWithDiff` **always** `safeWriteFile`s rendered bytes (`infrastructure/filesystem/hooks_orchestrator.go`). Merge may be semantically unchanged; the write still happens.
+  - `marshalHooks` encodes `hooks` as a Go `map` via `json.MarshalIndent` (`hooks_marshal.go`). `encoding/json` sorts map keys **alphabetically**. Tracked `.gemini/settings.json` uses Gemini `EventOrder` (`SessionStart`, `SessionEnd`, `BeforeAgent`, `AfterAgent`, `AfterTool`, `PreCompress`). Re-run → alphabetical key order only. That is the dogfood churn.
+  - Existing tests (`scripts/install_gemini_extension_test.go`) stub `traceary` as `exit 0` and set `cmd.Dir = repoRoot`, so they never observe a settings write or a nested `.gemini/`.
+- Expected:
+  1. Do **not** rewrite project `.gemini/settings.json` as an unconditional side effect of extension install. **Prefer skip** when Gemini hooks are already present. Pin `--project-dir` to the script’s repository root if a write is ever invoked. Gate any remaining write behind an explicit flag. Prefer skip / stable no-op over churn.
+  2. Never create `presentation/cli/.gemini/` (or other package-subdir settings) because cwd was not the repo root.
+  3. If leftover untracked `presentation/cli/.gemini/` is still in the checkout, **do not add it to git**.
+- Out of scope:
+  - Changing Gemini hook payload adapters.
+  - Committing a reformatted `.gemini/settings.json` “to match the tool” (alphabetical marshal).
+  - Making `marshalHooks` / `installWithDiff` globally byte-idempotent (hooks-orchestrator change; would still force a one-time tracked-file reformat if we adopted alphabetical order).
+  - Synthesizing `session_ended`.
+  - Live home store with a repo-built binary.
+  - User-level `~/.gemini/settings.json` (`--global`). This ticket is project settings + cwd.
+
+### Why skip wins over “stable rewrite”
+
+| Option | Why it is not the default in this PR |
+|---|---|
+| Pin `.` → `$REPO_ROOT` and keep calling `hooks install` | Stops nested leftover. **Does not** stop tracked-file churn: orchestrator always writes; map marshal sorts keys. |
+| Make `marshalHooks` honor `EventOrder` (Antigravity already has `marshalIndentOrdered`) | Correct long-term for `hooks install`, but it is a shared filesystem change, and matching the **tool’s current** alphabetical order would require committing a reformat — forbidden. |
+| Always `--upgrade` | Comment claims byte-level no-op when up to date; implementation still writes. Same churn. |
+| Skip when present; pin if writing; optional `--hooks` | Satisfies acceptance without touching adapters or tracked JSON. |
+
+**Pin:** change **only** `scripts/install-gemini-extension.sh` (+ its Go tests under `scripts/`). Do not edit `infrastructure/filesystem/hooks_marshal.go` or Gemini handlers in this PR.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Extension package | `GEMINI_EXTENSION_HOME` / `~/.gemini/extensions/traceary` | stage-then-swap (unchanged from #2156) | timeout + restore; not this ticket’s defect |
+| Script repo root | `SCRIPT_DIR/..` already computed | **only** legal project dir for any hooks write | never cwd, never `.` |
+| Project Gemini settings | `$REPO_ROOT/.gemini/settings.json` (tracked in this repo) | default: **do not write** | byte-identical on re-run when hooks already present |
+| Hooks already present | file exists **and** contains Traceary Gemini marker `traceary-session-start` | skip `hooks install`; print a one-line skip | do not JSON-parse the full schema in bash; do not call `traceary` for a probe |
+| Nested leftover | `$CWD/.gemini/` when `$CWD` ≠ repo root | must not be created | do not `git add` if it already exists |
+| Opt-in rewrite | `--hooks` flag | `traceary hooks install --client gemini --project-dir "$REPO_ROOT"` **without** `--force` | documented; may still churn if invoked; not the default |
+| Doctor verify | `gemini-plugin-version` / `gemini-config` | still verifiable after extension swap | hook generation refresh stays `doctor --fix`, not this script (`docs/release/post-upgrade-plugins.md`) |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Skip vs write project settings; pin project dir | `scripts/install-gemini-extension.sh` | this is the unconditional side effect | `gemini_hooks_handler.go` (payload/events). `hooks_marshal.go` (shared marshal). |
+| Detect “already present” | bash: test `-f "$REPO_ROOT/.gemini/settings.json"` and `grep -F` for `traceary-session-start` | cheap, no extra CLI, matches tracked file | new `traceary hooks status` command |
+| Extension stage-then-swap | same script, existing `run_gemini` / `restore_previous` | unchanged | |
+| Tests | `scripts/install_gemini_extension_test.go` | stub `traceary` must **log** `hooks install` argv; run with `cmd.Dir` ≠ repo root | `cmd/repo-tooling` has no install-script tests today; do not add one unless docs path strings drift |
+| Docs (same PR only if usage/docs now lie) | `usage()` in the script; one sentence in `docs/integrations/gemini-extension.md` + `.ja.md` and/or `docs/release/post-upgrade-plugins.md` + `.ja.md` | operators must know default skip and `--hooks` | do not rewrite adapter docs |
+| Leftover dir | implementer constraint: never `git add presentation/cli/.gemini` | untracked junk | do not create `.gitignore` entries unless a test needs them |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `traceary hooks install --client gemini --project-dir "$REPO_ROOT"` | script, **only** on `--hooks` | orchestrator merge + always-write + alphabetical keys | default path must not invoke this |
+| `--project-dir .` | **removed** | cwd Abs | grep the script: no `--project-dir .` |
+| `--hooks` | operators who explicitly want project settings written | usage() documents churn risk and points at `doctor --fix` for generation refresh | missing flag → skip; unknown flags still exit 64 |
+| `gemini extensions install --consent` | unchanged | #2156 backup/timeout | success path still logs uninstall-then-install; `gemini-plugin-version` remains verifiable |
+| `$REPO_ROOT/.gemini/settings.json` | skip probe (read-only) | `grep -F traceary-session-start` | file missing or marker missing + no `--hooks` → skip write, print how to install hooks / `--hooks`. Do not create the file. |
+| Nested `$PWD/.gemini/settings.json` | none | must not exist after a subdir run | test asserts `os.IsNotExist` |
+| Live `~/.config/traceary/traceary.db` | none | tests use stub `traceary` + temp `HOME` / `GEMINI_EXTENSION_HOME` | |
+
+Binding skip rule (do not bikeshed):
+1. **Default (no `--hooks`)**: never call `hooks install`. Extension swap only. Print that project hooks were skipped and name `traceary hooks install --client gemini --project-dir <repo-root>` plus `traceary doctor --fix --client gemini` for generation refresh.
+2. **`--hooks`**: call install with `--project-dir "$REPO_ROOT"` and without `--force`. Still skip the call if the marker is already present (idempotent even with the flag). If the file is missing or has no marker, write once at repo root.
+3. Pin is mandatory on every hooks install invocation: `"$REPO_ROOT"`, never `.`.
+4. Do not pass `--force` or `--upgrade` from this script.
+
+This matches post-upgrade docs: the script replaces the **extension package**; managed hook generation refresh is `doctor --fix`, not a drive-by install.
+
+### Behavior tests
+Keep existing restore-on-fail and timeout tests. Stub `traceary` must log argv (not only `-v`). Use the **real** script path so `REPO_ROOT` is the checkout; `cmd.Dir` may be a subdirectory. Do not mutate tracked `.gemini/settings.json` (skip path must not call install). Throwaway `HOME` / `GEMINI_EXTENSION_HOME`. Do not read the developer’s live store.
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Re-run no settings diff | tracked `$REPO_ROOT/.gemini/settings.json` already has `traceary-session-start`; stub logs `hooks` | `install-gemini-extension.sh` from repo root (no `--hooks`) | stub log has **no** `hooks install`; file bytes unchanged vs pre-run snapshot | unit (script) |
+| `--hooks` still no-op when present | same file + `--hooks` | script | still **no** `hooks install` (skip even with flag); bytes unchanged | unit |
+| Subdir does not nest | `cmd.Dir` = `presentation/cli` (or a temp subdir of the checkout) | script (default) | `presentation/cli/.gemini` does not exist; no `hooks install`; gemini uninstall-then-install still happens | unit |
+| `--hooks` pins repo root | settings **missing marker** in a **temp copy** of the script tree, or stub records argv without writing (prefer: stub never writes; assert argv) | `--hooks` | argv contains `--project-dir` equal to repo root (absolute), not `.`, not the cwd | unit |
+| Extension still installs | stub gemini success | default script | log has `extensions uninstall` then `extensions install --consent`; exit 0 | existing + keep |
+| Fail/timeout restore | existing tests | unchanged | previous `marker` survives | existing |
+| No leftover git add | review | `git status` | no `presentation/cli/.gemini` | review |
+
+Do **not** run the script against live `HOME` Gemini extensions. Do **not** assert doctor against the operator home DB.
+
+If a test needs a tree **without** tracked settings, copy the script into `t.TempDir()/scripts/` with a fake `VERSION` and empty-or-absent `.gemini/`, and stub `git clone` is not required when VERSION matches `--ref` — follow existing local-src branch (`integrations/gemini-extension` must exist in that fake tree or stub gemini before clone). Prefer asserting argv on the real checkout + skip, and a **separate temp tree** only for the “missing marker + `--hooks` pins repo root” case.
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| Default skip (no `hooks install`) | stub log captures `hooks install` from current script | delete/guard the unconditional call; skip notice | keep #2156 swap intact |
+| Subdir no nested `.gemini` | `cmd.Dir=presentation/cli`; fail if dir appears | pin (and skip) so install never sees cwd | |
+| `--hooks` + pin | temp tree without marker; argv has absolute `REPO_ROOT` | flag parse next to `--ref` | usage() documents skip default |
+| Existing fail/timeout | re-run current tests | no change | |
+
+Green is bash + tests only. After green: `go test ./scripts/ -count=1` and `go test ./cmd/repo-tooling/ -count=1` (no expected change). Do not run `go test ./...` against a live DB.
+
+### Risks / rollback
+- 手続き化リスク: do not “fix churn” by sorting keys in the orchestrator **and** committing the reformat. Skip in the script is the owner.
+- premature abstraction: no generic `--project-dir` helper for grok/kimi install scripts in this PR. Gemini script only.
+- migration / compatibility: operators who relied on the script to **create** project settings must pass `--hooks` or run `hooks install` themselves. First-time clone of **this** repo already has tracked settings → skip is correct.
+- False skip: marker `traceary-session-start` matches the tracked file and `GeminiHooksHandler.Build`. Do not treat user-level `~/.gemini/settings.json` as present.
+- `--hooks` churn: if someone forces install on the tracked file after removing the skip, key-order diff can return. Default skip prevents that. Document it; do not “fix” marshal here.
+- leftover: if `presentation/cli/.gemini/` exists locally, leave it untracked / delete in the worktree if the test created it; never stage it.
+- rollback trigger: revert the PR; extension swap behavior from #2156 remains on main.
+
+Binding decisions (do not bikeshed):
+1. Default: **skip** `hooks install`. Extension stage-then-swap only.
+2. Pin: any hooks install uses `--project-dir "$REPO_ROOT"` (script location), never `.`.
+3. `--hooks`: opt-in write at repo root, still skipped when `traceary-session-start` is already in `$REPO_ROOT/.gemini/settings.json`.
+4. Do not `--force`. Do not `--upgrade`.
+5. Do not change adapters, marshal, or tracked settings.json.
+6. Do not git-add `presentation/cli/.gemini/`.
+7. Implementer **kimi k3**. Tests stub binaries; throwaway HOME only.
+8. PR body: `Closes #2215`. Leaves parent **#2208** open. No GitHub close keyword next to #2208 or #2205.

--- a/scripts/install-gemini-extension.sh
+++ b/scripts/install-gemini-extension.sh
@@ -4,9 +4,15 @@ set -euo pipefail
 
 usage() {
     cat >&2 <<'EOF'
-usage: scripts/install-gemini-extension.sh [--ref <git-ref>]
+usage: scripts/install-gemini-extension.sh [--ref <git-ref>] [--hooks]
 
-Installs the Traceary Gemini extension, then installs project hooks.
+Installs the Traceary Gemini extension. Project hooks are NOT installed
+by default: when the repo's .gemini/settings.json already contains
+Traceary Gemini hooks, rewriting it would only churn JSON key order.
+Use --hooks to opt into writing project hooks at the repository root
+(still skipped when hooks are already present). To refresh managed hook
+generation, run `traceary doctor --fix --client gemini` instead.
+
 Existing installs are copied aside first. Gemini CLI cannot overlay an
 already-installed name, so the script then uninstalls and installs. A
 failed or timed-out gemini CLI call restores the previous directory.
@@ -25,6 +31,7 @@ EOF
 
 REF="${TRACEARY_GEMINI_REF:-}"
 TIMEOUT="${TRACEARY_GEMINI_TIMEOUT:-60}"
+INSTALL_HOOKS=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --ref)
@@ -34,6 +41,10 @@ while [[ $# -gt 0 ]]; do
             fi
             REF="$2"
             shift 2
+            ;;
+        --hooks)
+            INSTALL_HOOKS=1
+            shift
             ;;
         -h|--help)
             usage
@@ -156,8 +167,22 @@ if [[ "$install_rc" -ne 0 ]]; then
     exit 1
 fi
 
-echo "Configuring Traceary hooks for Gemini CLI in current project..."
-traceary hooks install --client gemini --project-dir .
+SETTINGS_JSON="${REPO_ROOT}/.gemini/settings.json"
+hooks_present=0
+if [[ -f "$SETTINGS_JSON" ]] && grep -qF "traceary-session-start" "$SETTINGS_JSON"; then
+    hooks_present=1
+fi
+
+if [[ "$hooks_present" -eq 1 ]]; then
+    echo "Project Gemini hooks already present in ${SETTINGS_JSON}; skipping 'traceary hooks install'."
+elif [[ "$INSTALL_HOOKS" -eq 1 ]]; then
+    echo "Configuring Traceary hooks for Gemini CLI in ${REPO_ROOT}..."
+    traceary hooks install --client gemini --project-dir "$REPO_ROOT"
+else
+    echo "Skipping project hooks install (no Traceary Gemini hooks in ${SETTINGS_JSON})."
+    echo "To write project hooks: scripts/install-gemini-extension.sh --hooks, or"
+    echo "  traceary hooks install --client gemini --project-dir ${REPO_ROOT}"
+fi
 
 echo "Traceary Gemini extension installed and configured successfully."
 echo "Pinned to ${REF}. Run 'traceary doctor --client gemini' to verify."

--- a/scripts/install_gemini_extension_test.go
+++ b/scripts/install_gemini_extension_test.go
@@ -114,6 +114,233 @@ exit 0
 	}
 }
 
+func TestInstallGeminiExtensionSkipsHooksInstallWhenHooksPresent(t *testing.T) {
+	repoRoot := repoRootFromScripts(t)
+	settings := filepath.Join(repoRoot, ".gemini", "settings.json")
+	before, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatalf("tracked settings: %v", err)
+	}
+	if !strings.Contains(string(before), "traceary-session-start") {
+		t.Skip("tracked .gemini/settings.json has no traceary-session-start marker")
+	}
+
+	home := t.TempDir()
+	extHome := filepath.Join(home, ".gemini", "extensions")
+	bin := t.TempDir()
+	tracearyLog := filepath.Join(t.TempDir(), "traceary.log")
+	geminiLog := filepath.Join(t.TempDir(), "gemini.log")
+	writeLoggingTracearyStub(t, bin)
+	writeStub(t, filepath.Join(bin, "gemini"), `#!/bin/sh
+echo "$*" >> "$STUB_LOG"
+exit 0
+`)
+	cmd := exec.Command("bash", filepath.Join(repoRoot, "scripts", "install-gemini-extension.sh"))
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"GEMINI_EXTENSION_HOME="+extHome,
+		"REPO_ROOT="+repoRoot,
+		"STUB_LOG="+geminiLog,
+		"STUB_TRACEARY_LOG="+tracearyLog,
+		"TRACEARY_GEMINI_TIMEOUT=5",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install failed: %v\n%s", err, out)
+	}
+	assertNoHooksInstall(t, tracearyLog, out)
+	after, readErr := os.ReadFile(settings)
+	if readErr != nil {
+		t.Fatalf("tracked settings after run: %v", readErr)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("tracked .gemini/settings.json changed; output=%s", out)
+	}
+}
+
+func TestInstallGeminiExtensionHooksFlagStillSkipsWhenHooksPresent(t *testing.T) {
+	repoRoot := repoRootFromScripts(t)
+	settings := filepath.Join(repoRoot, ".gemini", "settings.json")
+	before, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatalf("tracked settings: %v", err)
+	}
+	if !strings.Contains(string(before), "traceary-session-start") {
+		t.Skip("tracked .gemini/settings.json has no traceary-session-start marker")
+	}
+
+	home := t.TempDir()
+	extHome := filepath.Join(home, ".gemini", "extensions")
+	bin := t.TempDir()
+	tracearyLog := filepath.Join(t.TempDir(), "traceary.log")
+	geminiLog := filepath.Join(t.TempDir(), "gemini.log")
+	writeLoggingTracearyStub(t, bin)
+	writeStub(t, filepath.Join(bin, "gemini"), `#!/bin/sh
+echo "$*" >> "$STUB_LOG"
+exit 0
+`)
+	cmd := exec.Command("bash", filepath.Join(repoRoot, "scripts", "install-gemini-extension.sh"), "--hooks")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"GEMINI_EXTENSION_HOME="+extHome,
+		"REPO_ROOT="+repoRoot,
+		"STUB_LOG="+geminiLog,
+		"STUB_TRACEARY_LOG="+tracearyLog,
+		"TRACEARY_GEMINI_TIMEOUT=5",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install --hooks failed: %v\n%s", err, out)
+	}
+	assertNoHooksInstall(t, tracearyLog, out)
+	after, readErr := os.ReadFile(settings)
+	if readErr != nil {
+		t.Fatalf("tracked settings after run: %v", readErr)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("tracked .gemini/settings.json changed with --hooks; output=%s", out)
+	}
+}
+
+func TestInstallGeminiExtensionFromSubdirCreatesNoNestedGeminiDir(t *testing.T) {
+	repoRoot := repoRootFromScripts(t)
+	subdir := filepath.Join(repoRoot, "presentation", "cli")
+	if info, err := os.Stat(subdir); err != nil || !info.IsDir() {
+		t.Skip("presentation/cli not present")
+	}
+	nested := filepath.Join(subdir, ".gemini")
+	if _, err := os.Stat(nested); err == nil {
+		t.Skip("presentation/cli/.gemini already exists locally")
+	}
+
+	home := t.TempDir()
+	extHome := filepath.Join(home, ".gemini", "extensions")
+	bin := t.TempDir()
+	tracearyLog := filepath.Join(t.TempDir(), "traceary.log")
+	geminiLog := filepath.Join(t.TempDir(), "gemini.log")
+	writeLoggingTracearyStub(t, bin)
+	writeStub(t, filepath.Join(bin, "gemini"), `#!/bin/sh
+echo "$*" >> "$STUB_LOG"
+exit 0
+`)
+	cmd := exec.Command("bash", filepath.Join(repoRoot, "scripts", "install-gemini-extension.sh"))
+	cmd.Dir = subdir
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"GEMINI_EXTENSION_HOME="+extHome,
+		"REPO_ROOT="+repoRoot,
+		"STUB_LOG="+geminiLog,
+		"STUB_TRACEARY_LOG="+tracearyLog,
+		"TRACEARY_GEMINI_TIMEOUT=5",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install from subdir failed: %v\n%s", err, out)
+	}
+	if _, statErr := os.Stat(nested); !os.IsNotExist(statErr) {
+		t.Fatalf("nested %s exists after subdir run (err=%v); output=%s", nested, statErr, out)
+	}
+	assertNoHooksInstall(t, tracearyLog, out)
+	logBytes, logErr := os.ReadFile(geminiLog)
+	if logErr != nil {
+		t.Fatalf("gemini stub log: %v", logErr)
+	}
+	if !strings.Contains(string(logBytes), "extensions install --consent") {
+		t.Fatalf("gemini log = %q, want extensions install --consent", logBytes)
+	}
+}
+
+func TestInstallGeminiExtensionHooksFlagPinsProjectDirToRepoRoot(t *testing.T) {
+	repoRoot := repoRootFromScripts(t)
+	tmpRoot := t.TempDir()
+	scriptsDir := filepath.Join(tmpRoot, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	scriptBytes, err := os.ReadFile(filepath.Join(repoRoot, "scripts", "install-gemini-extension.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "install-gemini-extension.sh"), scriptBytes, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpRoot, "VERSION"), []byte("0.0.0-test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpRoot, "integrations", "gemini-extension"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// No .gemini/settings.json in the temp tree: the marker is absent.
+
+	home := t.TempDir()
+	extHome := filepath.Join(home, ".gemini", "extensions")
+	bin := t.TempDir()
+	tracearyLog := filepath.Join(t.TempDir(), "traceary.log")
+	writeStub(t, filepath.Join(bin, "traceary"), `#!/bin/sh
+echo "$*" >> "$STUB_TRACEARY_LOG"
+exit 0
+`)
+	writeStub(t, filepath.Join(bin, "gemini"), `#!/bin/sh
+exit 0
+`)
+	subdir := filepath.Join(tmpRoot, "integrations", "gemini-extension")
+	cmd := exec.Command("bash", filepath.Join(scriptsDir, "install-gemini-extension.sh"), "--ref", "v0.0.0-test", "--hooks")
+	cmd.Dir = subdir
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"GEMINI_EXTENSION_HOME="+extHome,
+		"STUB_TRACEARY_LOG="+tracearyLog,
+		"TRACEARY_GEMINI_TIMEOUT=5",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install --hooks failed: %v\n%s", err, out)
+	}
+	logBytes, logErr := os.ReadFile(tracearyLog)
+	if logErr != nil {
+		t.Fatalf("traceary stub log: %v\n%s", logErr, out)
+	}
+	want := "hooks install --client gemini --project-dir " + tmpRoot
+	if !strings.Contains(string(logBytes), want) {
+		t.Fatalf("traceary argv = %q, want substring %q", logBytes, want)
+	}
+	if strings.Contains(string(logBytes), "--project-dir .") {
+		t.Fatalf("traceary argv = %q, must not use --project-dir .", logBytes)
+	}
+	if strings.Contains(string(logBytes), "--force") || strings.Contains(string(logBytes), "--upgrade") {
+		t.Fatalf("traceary argv = %q, must not pass --force/--upgrade", logBytes)
+	}
+	if _, statErr := os.Stat(filepath.Join(subdir, ".gemini")); !os.IsNotExist(statErr) {
+		t.Fatalf("nested .gemini created under cwd (err=%v)", statErr)
+	}
+}
+
+func writeLoggingTracearyStub(t *testing.T, bin string) {
+	t.Helper()
+	writeStub(t, filepath.Join(bin, "traceary"), `#!/bin/sh
+echo "$*" >> "$STUB_TRACEARY_LOG"
+if [ "$1" = "-v" ]; then echo "traceary $(cat "$REPO_ROOT/VERSION")"; exit 0; fi
+exit 0
+`)
+}
+
+func assertNoHooksInstall(t *testing.T, tracearyLog string, out []byte) {
+	t.Helper()
+	logBytes, err := os.ReadFile(tracearyLog)
+	if err != nil {
+		t.Fatalf("traceary stub log: %v\n%s", err, out)
+	}
+	if strings.Contains(string(logBytes), "hooks install") {
+		t.Fatalf("traceary argv = %q, want no hooks install; output=%s", logBytes, out)
+	}
+}
+
 func repoRootFromScripts(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()


### PR DESCRIPTION
## Summary

`scripts/install-gemini-extension.sh` no longer unconditionally runs `traceary hooks install --client gemini --project-dir .`.

- Skip when repo `.gemini/settings.json` already contains Traceary Gemini hooks (avoids key-order-only churn).
- `--project-dir` is the script's repository root (never cwd), so a subdirectory run cannot create `presentation/cli/.gemini/`.
- `--hooks` opts into writing hooks at repo root, still skipped when already present.

Design: grok 4.6 medium (`.ai/spec/2215.md`). Implementation: kimi k3.

Closes #2215