### PR TITLE
Bound large-store doctor --fix to the 45s wall including SQLite replay

### DIFF
--- a/.ai/spec/2231.md
+++ b/.ai/spec/2231.md
@@ -1,0 +1,79 @@
+# Issue 2231: bound large-store `doctor --fix` wall including SQLite replay
+
+Engine: grok 4.6 medium  
+Date: 2026-08-21  
+Parent: #2230  
+PR: `Closes #2231` only (never parent or dogfood indexes)
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — operator-visible `doctor --fix` duration and leftover pending on ≥2 GiB stores. Check **name** `hook-spool` and existing metric keys stay frozen.
+
+### Requirement summary
+- 目的: `doctor --fix` が文書化した 45s wall を **SQLite replay を含む一連の適用** で守り、wall 到達時は `remaining=N` を Action に出し、再 inspect で `store-size` を「O(1) page metadata unavailable」にしない。
+- 現状: `hookSpoolDeadRequeueDoctorWall` (45s) は (1) requeue ループと (2) `drainHookSpoolRecordsUntil` の **ラウンド間** に別々にリセットされる。1 round は最大 200 replay。`drainHookSpoolRecordsDetailed` は record ごとには wall を見ない。13.4 GiB では 1 replay が数秒かかり、dogfood は ~451s / pending=97 / Action 空。`applyDoctorFixes` は全 auto-fix を順に実行し、その後 `buildDoctorReport` が再 inspect する。
+- 期待する振る舞い:
+  - `--fix` 適用フェーズは **1 つの 45s deadline**（requeue + drain + 後続 auto-fix）。dry-run は壁不要・SQLite 非オープン。
+  - drain は **record ごと** に deadline を見る。到達したらその record は claim せず、`remaining` を数えて戻る。
+  - Action は常に `requeued=… remaining=N` を含む（wall hit でも空文字にしない）。
+  - wall 後の auto-fix は `skip: doctor --fix wall exhausted`。
+  - 再 inspect は書き込み lease を持たない。wall で SQLite を手放したあと O(1) page metadata が読める。
+- 非対象: dbstat / capacity walk、non-transient 自動削除、13 GiB compact、`session_ended` 合成、spool JSON フィールド名変更、grok-transcript の中身（#2232）。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Doctor `--fix` wall | apply phase started | one deadline = start+45s | shared by requeue, drain, later auto-fixes |
+| Drain round | pending > 0, before deadline | up to 200 claims | must abort **before** next claim if now ≥ deadline |
+| Wall hit | deadline reached, pending remain | stop replay, count remaining | Action includes `remaining=N`; no silent pile |
+| Dry-run | `--fix --dry-run` | planned counts only | no SQLite, no file moves |
+| Reinspect | after apply | metadata-only O(1) reads | must not see a writer still holding the store from `--fix` |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Wall clock | existing `hookSpoolDeadRequeueClock` / `hookSpoolDeadRequeueNow` | tests already replace it | new clock type を増やさない |
+| Per-record abort | `drainHookSpoolRecordsDetailed` (accept deadline or use clock) | round 200 の内側が overrun の原因 | 新しい drain 実装を作らない |
+| Shared requeue+drain wall | `fixHookSpoolRequeueThenDrain` | 今日は requeue 45s のあと drain が 45s を取り直す | requeue と drain で別 deadline |
+| Skip later fixes | `applyDoctorFixes` | 451s の一因は spool 後も transcript 等が続く | 各 FixFunc が独自 45s を足し算しない |
+| Action string | `fixHookSpoolRequeueThenDrain` return | empty Action は operator に remaining を隠す | check name 変更なし |
+| Replay | `replayHookSpoolRecord` | 変更しない | 新しい replay |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `drainHookSpoolRecordsUntil` | fixer | pass start time or deadline; check before each claim | remaining set on wall; Err only for I/O/cancel |
+| `applyDoctorFixes` | `runDoctor` | ctx deadline or shared now+45s | later checks skip, not error |
+| doctor JSON `fixes[].action` | operators, Merge verification | must contain `remaining=` when pending left | no payload bodies |
+| Metric keys | `fixes[].metrics` | keep `requeued`, `skipped_nontransient`, `replayed`, `failed`, `unreadable`, `remaining` | do not rename |
+
+Do not wrap `ctx` in a 45s timeout that cancels an in-flight replay mid-SQLite write if that can leave a claimed `*.json.claim-*` file. Check the wall **before claim**; let the current replay finish (one record slack). Document that slack.
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Wall mid-drain | N>round pending; clock jumps past 45s after 1 replay | `fixHookSpoolRequeueThenDrain` apply | `remaining>0`, Action contains `remaining=`, replayed << N, elapsed (fake clock) ≥ wall | unit |
+| Drain to empty inside wall | 2 pending, clock static | apply | remaining=0, replayed=2 | unit |
+| Dry-run | pending+dead transients | dry-run | no SQLite (event stub logCalls=0), no file moves | unit |
+| Requeue+drain share wall | requeue consumes wall | drain | drain does not take a fresh 45s; remaining explained | unit |
+| Non-transient skip | poison dead letter | apply | skipped_nontransient=1, file stays in dead/ | existing |
+| applyDoctorFixes skip tail | first fix exhausts wall | second AutoFixAvailable check | second Action is skip wall exhausted | unit |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| Per-record wall | TestDrainHookSpoolRecordsUntil_StopsWhenWallElapsed with fake clock | check now≥deadline before claim | keep round limit |
+| Shared wall | TestFixHookSpoolRequeueThenDrain_DoesNotResetWallForDrain | one deadline from fixer start | |
+| Action remaining | assert Action contains remaining= when wall hit | Action builder | |
+| Skip later fixes | TestApplyDoctorFixes_SkipsAfterWall | applyDoctorFixes | |
+
+### Risks / rollback
+- 手続き化リスク: fixer に if の山を足さず、deadline を drain に渡す。
+- one-record slack: 1 replay が極端に遅いと wall+slack。受け入れ（claim 前チェック）。13 GiB で 200 連続は禁止。
+- Claimed leftover: wall abort は unclaimed のみ。in-flight claim は既存 retry/dead 経路。
+- rollback: revert PR。spool ファイル契約は変えない。
+- #2232 grok-transcript: この PR は wall skip だけ。drain の sticky は触らない。
+
+### Merge verification (kimi must capture)
+Fixture: metadata-only path + pending spool (temp state dir + optional ≥2GiB sparse copy if available). Never repo-built binary vs live home store.
+`time traceary doctor --fix --json --warnings-ok --db-path <fixture>` wall-clock ≤ 45s + small slack; Action or second doctor shows remaining; store-size not “page metadata unavailable” from this run holding the writer.

--- a/docs/operations/large-store-doctor.ja.md
+++ b/docs/operations/large-store-doctor.ja.md
@@ -43,6 +43,16 @@ dead-letter と orphan `*.tmp` を prune します。spool replay は event 書�
 ためだけに SQLite を開くことがあります。dbstat、event body、store 容量は
 読みません。`--fix --dry-run` は何も開きません。
 
+`--fix` の apply フェーズ全体（dead-letter の再キュー、SQLite replay を含む
+未処理 record の drain、後続の自動 fix）は、1 つの共有された 45 秒の wall
+clock の下で実行されます。drain は各 record を claim する前に wall を確認します。
+実行中の replay は最後まで完了するため wall には 1 record 分の slack がありますが、
+wall 到達後に新しい SQLite replay は開始されません。未処理 record が残ったまま
+wall に達した場合、fix の action は残りを `remaining=N` として報告し、後続の
+自動 fix 可能な check は `skip: doctor --fix wall exhausted` でスキップされます。
+wall 到達時点で apply フェーズは store を手放すため、後続の検査は O(1) page
+metadata を「unavailable」ではなく正常に読めます。
+
 ## 2 つの doctor mode と check のスコープ
 
 | Mode | いつ | Store アクセス | `hook-spool` の単位 |

--- a/docs/operations/large-store-doctor.md
+++ b/docs/operations/large-store-doctor.md
@@ -46,6 +46,17 @@ orphan `*.tmp` leftovers older than 14 days. Spool replay may open SQLite for
 event writes only — it never walks dbstat, event bodies, or store capacity —
 and `--fix --dry-run` opens nothing.
 
+The whole `--fix` apply phase — dead-letter requeue, the pending-record drain
+including SQLite replay, and any later automatic fixes — runs under one shared
+45-second wall clock. The drain checks the wall before claiming each record;
+an in-flight replay is allowed to finish, so the wall carries a one-record
+slack, but no new SQLite replay starts after it. When the wall is reached with
+records still pending, the fix action reports the leftover as `remaining=N`,
+and later auto-fixable checks are skipped with
+`skip: doctor --fix wall exhausted`. Because the apply phase stops holding the
+store once the wall hits, the follow-up inspection can still read the O(1)
+page metadata instead of reporting it unavailable.
+
 ## Two doctor modes and check scoping
 
 | Mode | When | Store access | `hook-spool` unit |

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -266,6 +266,12 @@ func (c *RootCLI) applyDoctorFixes(ctx context.Context, report *doctorReport, dr
 	if report == nil {
 		return nil
 	}
+	// One shared wall for the whole apply phase: hook-spool requeue+drain
+	// take their deadline from the same clock, and once the wall (or the
+	// caller context) is exhausted, later auto-fixes are skipped instead of
+	// each adding its own unbounded work. Dry-run previews never consume the
+	// wall — they open no SQLite and move no files.
+	applyDeadline := hookSpoolDeadRequeueNow().Add(hookSpoolDeadRequeueDoctorWall)
 	fixes := []doctorFixLog{}
 	for _, check := range report.Checks {
 		if check.Severity != doctorSeverityWarn && check.Severity != doctorSeverityFail {
@@ -274,6 +280,11 @@ func (c *RootCLI) applyDoctorFixes(ctx context.Context, report *doctorReport, dr
 		log := doctorFixLog{Name: check.Name, Before: check.Status}
 		if !check.AutoFixAvailable || (check.FixFunc == nil && check.StructuredFixFunc == nil) {
 			log.Action = guidedDoctorFixAction(check)
+			fixes = append(fixes, log)
+			continue
+		}
+		if !dryRun && (ctx.Err() != nil || !hookSpoolDeadRequeueNow().Before(applyDeadline)) {
+			log.Action = Localize("skip: doctor --fix wall exhausted", "skip: doctor --fix の wall 制限時間を使い切りました")
 			fixes = append(fixes, log)
 			continue
 		}

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -61,9 +61,13 @@ const (
 	hookSpoolDeadRetention    = 14 * 24 * time.Hour
 	hookSpoolDeadPruneLimit   = 200
 	hookSpoolDeadRequeueLimit = 200
-	// hookSpoolDeadRequeueDoctorWall bounds one doctor --fix requeue drain.
-	// The per-batch cap stays hookSpoolDeadRequeueLimit; the loop continues
-	// while headroom remains, matching hook-state residue / extract queue.
+	// hookSpoolDeadRequeueDoctorWall bounds one whole doctor --fix apply
+	// phase: dead-letter requeue, pending drain, and any later auto-fixes
+	// share a single deadline. The per-batch cap stays
+	// hookSpoolDeadRequeueLimit; loops continue while headroom remains,
+	// matching hook-state residue / extract queue. The drain checks the wall
+	// before each claim, so one in-flight replay may finish past the wall
+	// (one-record slack) but a new SQLite replay never starts after it.
 	hookSpoolDeadRequeueDoctorWall = 45 * time.Second
 	// Claimed paths are pending/*.json.claim-<rand> so listHookSpoolRecordPaths
 	// (suffix .json only) cannot pick them up while another process owns them.
@@ -260,23 +264,27 @@ type hookSpoolDrainResult struct {
 // after hookSpoolRetryLimit attempts, retained under spool/dead/. Returns
 // counts of successful replays and retained failures.
 func (c *RootCLI) drainHookSpoolRecords(ctx context.Context, limit int) (replayed, failed int) {
-	result := c.drainHookSpoolRecordsDetailed(ctx, limit)
+	result := c.drainHookSpoolRecordsDetailed(ctx, limit, time.Time{})
 	// Preserve the legacy aggregate used by opportunistic debug logging while
 	// the structured result keeps replay failures and unreadable records
 	// disjoint.
 	return result.Replayed, result.Failed + result.Unreadable
 }
 
-func (c *RootCLI) drainHookSpoolRecordsUntil(ctx context.Context, pending int) hookSpoolDrainResult {
+// drainHookSpoolRecordsUntil drains pending records in rounds bounded by
+// hookSpoolDoctorDrainRoundLimit until the queue is empty or the shared
+// doctor --fix deadline is reached. The deadline is taken by the caller
+// (fixHookSpoolRequeueThenDrain) so requeue and drain share one wall; a zero
+// deadline disables the wall check.
+func (c *RootCLI) drainHookSpoolRecordsUntil(ctx context.Context, pending int, deadline time.Time) hookSpoolDrainResult {
 	aggregated := hookSpoolDrainResult{}
-	deadline := hookSpoolDeadRequeueNow().Add(hookSpoolDeadRequeueDoctorWall)
 	remaining := pending
 	for remaining > 0 {
 		if err := ctx.Err(); err != nil {
 			aggregated.Err = xerrors.Errorf("hook spool drain cancelled: %w", err)
 			return aggregated
 		}
-		if !hookSpoolDeadRequeueNow().Before(deadline) {
+		if !deadline.IsZero() && !hookSpoolDeadRequeueNow().Before(deadline) {
 			aggregated.Remaining = remaining
 			return aggregated
 		}
@@ -284,7 +292,7 @@ func (c *RootCLI) drainHookSpoolRecordsUntil(ctx context.Context, pending int) h
 		if round > hookSpoolDoctorDrainRoundLimit {
 			round = hookSpoolDoctorDrainRoundLimit
 		}
-		result := c.drainHookSpoolRecordsDetailed(ctx, round)
+		result := c.drainHookSpoolRecordsDetailed(ctx, round, deadline)
 		if result.Err != nil {
 			aggregated.Err = result.Err
 			aggregated.Remaining = result.Remaining
@@ -305,7 +313,7 @@ func (c *RootCLI) drainHookSpoolRecordsUntil(ctx context.Context, pending int) h
 	return aggregated
 }
 
-func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) hookSpoolDrainResult {
+func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int, deadline time.Time) hookSpoolDrainResult {
 	now := time.Now().UTC()
 	if err := recoverStaleCurrentHookSpoolRecords(now); err != nil {
 		return hookSpoolDrainResult{Err: err}
@@ -328,6 +336,13 @@ func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) 
 			break
 		}
 		if err := ctx.Err(); err != nil {
+			break
+		}
+		// Doctor --fix wall: stop before claiming the next record once the
+		// shared deadline is reached. An in-flight replay is never cancelled
+		// mid-SQLite write (one-record slack); unclaimed records stay pending
+		// and are counted in Remaining below.
+		if !deadline.IsZero() && !hookSpoolDeadRequeueNow().Before(deadline) {
 			break
 		}
 		// Exclusive claim via same-directory rename (CAS). Concurrent drainers
@@ -1062,19 +1077,21 @@ func requeueHookSpoolDeadLetters(ctx context.Context, now time.Time, dryRun bool
 }
 
 // requeueHookSpoolDeadLettersUntil loops bounded requeue batches until the
-// dead-letter directory has no remaining transients or the doctor wall clock
-// is exhausted. Dry-run counts every requeueable record in one pass (no cap)
-// so the preview is the full planned drain, not the first batch.
-func requeueHookSpoolDeadLettersUntil(ctx context.Context, now time.Time, dryRun bool) (requeued, skipped, remaining int, err error) {
+// dead-letter directory has no remaining transients or the shared doctor --fix
+// deadline is reached. The deadline is taken by the caller
+// (fixHookSpoolRequeueThenDrain) so requeue and drain share one wall; a zero
+// deadline disables the wall check. Dry-run counts every requeueable record
+// in one pass (no cap) so the preview is the full planned drain, not the
+// first batch.
+func requeueHookSpoolDeadLettersUntil(ctx context.Context, now time.Time, dryRun bool, deadline time.Time) (requeued, skipped, remaining int, err error) {
 	if dryRun {
 		return requeueHookSpoolDeadLettersLimited(ctx, now, true, 0)
 	}
-	deadline := hookSpoolDeadRequeueNow().Add(hookSpoolDeadRequeueDoctorWall)
 	for {
 		if err := ctx.Err(); err != nil {
 			return requeued, skipped, remaining, xerrors.Errorf("hook spool dead-letter requeue cancelled: %w", err)
 		}
-		if !hookSpoolDeadRequeueNow().Before(deadline) {
+		if !deadline.IsZero() && !hookSpoolDeadRequeueNow().Before(deadline) {
 			// Dry-run unlimited counts leftover transients as requeued, not
 			// remaining. Fold them back so remaining is files still in dead/.
 			wouldRequeue, leftoverSkipped, leftoverRemaining, inspectErr := requeueHookSpoolDeadLettersLimited(ctx, now, true, 0)
@@ -1314,13 +1331,21 @@ func (c *RootCLI) inspectHookSpoolFilesystemMetadata() doctorCheck {
 // replay, then prune aged dead-letter and orphan tmp files. Dry-run performs
 // no file moves and does not open SQLite. Apply may open SQLite only for
 // spool replay via drainHookSpoolRecordsUntil / replayHookSpoolRecord — never
-// dbstat or store capacity.
+// dbstat or store capacity. Apply takes one 45s deadline up front and shares
+// it between requeue and drain, so the documented wall covers the whole
+// apply including SQLite replay; the drain checks the wall before each claim
+// and lets one in-flight replay finish (one-record slack). The Action always
+// reports remaining= so a wall hit never hides leftover pending records.
 func (c *RootCLI) fixHookSpoolRequeueThenDrain(ctx context.Context, now time.Time, dryRun bool) (doctorFixResult, error) {
 	pending, err := countHookSpoolPendingPaths(now)
 	if err != nil {
 		return doctorFixResult{}, err
 	}
-	requeued, skippedNontransient, _, err := requeueHookSpoolDeadLettersUntil(ctx, now, dryRun)
+	deadline := time.Time{}
+	if !dryRun {
+		deadline = hookSpoolDeadRequeueNow().Add(hookSpoolDeadRequeueDoctorWall)
+	}
+	requeued, skippedNontransient, _, err := requeueHookSpoolDeadLettersUntil(ctx, now, dryRun, deadline)
 	if err != nil {
 		return doctorFixResult{}, err
 	}
@@ -1343,11 +1368,8 @@ func (c *RootCLI) fixHookSpoolRequeueThenDrain(ctx context.Context, now time.Tim
 			prunedTmp,
 		)}, nil
 	}
-	result := c.drainHookSpoolRecordsUntil(ctx, pending+requeued)
-	if result.Err != nil {
-		return doctorFixResult{}, result.Err
-	}
-	return doctorFixResult{
+	result := c.drainHookSpoolRecordsUntil(ctx, pending+requeued, deadline)
+	fixed := doctorFixResult{
 		Action: localizef(
 			"drained hook spool: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
 			"hook spool を drain しました: requeued=%d skipped_nontransient=%d replayed=%d failed=%d unreadable=%d remaining=%d; pruned_dead=%d dead_remaining=%d pruned_tmp=%d",
@@ -1372,7 +1394,10 @@ func (c *RootCLI) fixHookSpoolRequeueThenDrain(ctx context.Context, now time.Tim
 			"dead_remaining":       deadRemaining,
 			"pruned_tmp":           prunedTmp,
 		},
-	}, nil
+	}
+	// Even on a drain error the populated result is returned so the operator
+	// sees the counts (including remaining=) alongside the error.
+	return fixed, result.Err
 }
 
 func scanHookSpoolRecords(clients []string) ([]hookSpoolRecord, []string, error) {

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1024,7 +1024,7 @@ func TestDrainHookSpoolRecordsUntil_LoopsPastRoundLimit(t *testing.T) {
 			t.Fatalf("persist %d: %v", i, err)
 		}
 	}
-	result := root.drainHookSpoolRecordsUntil(context.Background(), total)
+	result := root.drainHookSpoolRecordsUntil(context.Background(), total, hookSpoolDeadRequeueNow().Add(hookSpoolDeadRequeueDoctorWall))
 	if result.Err != nil {
 		t.Fatalf("until: %v", result.Err)
 	}
@@ -1821,7 +1821,7 @@ func TestRequeueHookSpoolDeadLettersUntil_DrainsBeyondBatchLimitWithinBudget(t *
 		t.Fatal(err)
 	}
 
-	dryRequeued, drySkipped, _, err := requeueHookSpoolDeadLettersUntil(context.Background(), time.Now().UTC(), true)
+	dryRequeued, drySkipped, _, err := requeueHookSpoolDeadLettersUntil(context.Background(), time.Now().UTC(), true, time.Time{})
 	if err != nil {
 		t.Fatalf("dry-run: %v", err)
 	}
@@ -1832,7 +1832,7 @@ func TestRequeueHookSpoolDeadLettersUntil_DrainsBeyondBatchLimitWithinBudget(t *
 		t.Fatalf("dry-run must leave dead files, n=%d err=%v", len(entries), err)
 	}
 
-	requeued, skipped, remaining, err := requeueHookSpoolDeadLettersUntil(context.Background(), time.Now().UTC(), false)
+	requeued, skipped, remaining, err := requeueHookSpoolDeadLettersUntil(context.Background(), time.Now().UTC(), false, hookSpoolDeadRequeueNow().Add(hookSpoolDeadRequeueDoctorWall))
 	if err != nil {
 		t.Fatalf("requeue: %v", err)
 	}
@@ -1857,16 +1857,16 @@ func TestRequeueHookSpoolDeadLettersUntil_StopsWhenWallClockExpires(t *testing.T
 	calls := 0
 	hookSpoolDeadRequeueClock = func() time.Time {
 		calls++
-		// deadline is taken from the first call; the third call is the
-		// start of the second batch and must be past the 45s wall.
-		if calls >= 3 {
+		// The deadline is passed in by the caller; the second loop check
+		// must be past the 45s wall so only the first batch is requeued.
+		if calls >= 2 {
 			return origin.Add(hookSpoolDeadRequeueDoctorWall + time.Second)
 		}
 		return origin
 	}
 	t.Cleanup(func() { hookSpoolDeadRequeueClock = nil })
 
-	requeued, _, remaining, err := requeueHookSpoolDeadLettersUntil(context.Background(), origin, false)
+	requeued, _, remaining, err := requeueHookSpoolDeadLettersUntil(context.Background(), origin, false, origin.Add(hookSpoolDeadRequeueDoctorWall))
 	if err != nil {
 		t.Fatalf("requeue: %v", err)
 	}
@@ -1902,6 +1902,243 @@ func TestFixHookSpoolRequeueThenDrain_DryRunPreviewsFullDrain(t *testing.T) {
 	if entries, err := os.ReadDir(deadDir); err != nil || len(entries) != total {
 		t.Fatalf("dry-run must leave files, n=%d err=%v", len(entries), err)
 	}
+}
+
+func TestFixHookSpoolRequeueThenDrain_SharedWallBoundsDrain(t *testing.T) {
+	origin := time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)
+	persistPending := func(t *testing.T, n int) {
+		t.Helper()
+		base := time.Now().UTC().Add(-time.Minute)
+		for i := 0; i < n; i++ {
+			if _, err := persistHookSpoolRecord(hookSpoolRecord{
+				SchemaVersion: hookSpoolSchemaVersion,
+				Command:       "prompt",
+				Client:        "claude",
+				Payload:       fmt.Sprintf(`{"prompt":"wall-%d","session_id":"s-wall-%d","cwd":"/tmp"}`, i, i),
+				CreatedAt:     base.Add(time.Duration(i) * time.Millisecond),
+			}); err != nil {
+				t.Fatalf("persist %d: %v", i, err)
+			}
+		}
+	}
+
+	t.Run("wall hit after one replay leaves remaining", func(t *testing.T) {
+		stateDir := t.TempDir()
+		t.Setenv(hookStateDirEnvKey, stateDir)
+		eventStub := &spoolEventUsecaseStub{}
+		root := NewRootCLI(
+			WithStoreManagement(&spoolStoreManagementStub{}),
+			WithEvent(eventStub),
+		)
+		const total = 5
+		persistPending(t, total)
+		// The clock jumps past the 45s wall as soon as the first replay
+		// commits, so the drain must stop before claiming the next record
+		// instead of overrunning inside a 200-record round.
+		hookSpoolDeadRequeueClock = func() time.Time {
+			if eventStub.logCalls > 0 {
+				return origin.Add(hookSpoolDeadRequeueDoctorWall + time.Second)
+			}
+			return origin
+		}
+		t.Cleanup(func() { hookSpoolDeadRequeueClock = nil })
+
+		result, err := root.fixHookSpoolRequeueThenDrain(context.Background(), time.Now().UTC(), false)
+		if err != nil {
+			t.Fatalf("fix: %v", err)
+		}
+		if result.Metrics["replayed"] == 0 || result.Metrics["replayed"] >= total {
+			t.Fatalf("replayed=%d, want at least one replay but << %d", result.Metrics["replayed"], total)
+		}
+		if result.Metrics["remaining"] == 0 {
+			t.Fatalf("remaining=0, want leftover pending records: metrics=%v", result.Metrics)
+		}
+		if !strings.Contains(result.Action, fmt.Sprintf("remaining=%d", result.Metrics["remaining"])) {
+			t.Fatalf("action=%q, want remaining=%d", result.Action, result.Metrics["remaining"])
+		}
+		if eventStub.logCalls != result.Metrics["replayed"] {
+			t.Fatalf("logCalls=%d, want replayed=%d", eventStub.logCalls, result.Metrics["replayed"])
+		}
+	})
+
+	t.Run("two pending drain to empty inside the wall", func(t *testing.T) {
+		stateDir := t.TempDir()
+		t.Setenv(hookStateDirEnvKey, stateDir)
+		eventStub := &spoolEventUsecaseStub{}
+		root := NewRootCLI(
+			WithStoreManagement(&spoolStoreManagementStub{}),
+			WithEvent(eventStub),
+		)
+		persistPending(t, 2)
+		hookSpoolDeadRequeueClock = func() time.Time { return origin }
+		t.Cleanup(func() { hookSpoolDeadRequeueClock = nil })
+
+		result, err := root.fixHookSpoolRequeueThenDrain(context.Background(), time.Now().UTC(), false)
+		if err != nil {
+			t.Fatalf("fix: %v", err)
+		}
+		if result.Metrics["replayed"] != 2 || result.Metrics["remaining"] != 0 {
+			t.Fatalf("replayed=%d remaining=%d, want 2 and 0", result.Metrics["replayed"], result.Metrics["remaining"])
+		}
+		if !strings.Contains(result.Action, "remaining=0") {
+			t.Fatalf("action=%q, want remaining=0", result.Action)
+		}
+		if eventStub.logCalls != 2 {
+			t.Fatalf("logCalls=%d, want 2", eventStub.logCalls)
+		}
+	})
+
+	t.Run("dry run replays nothing and moves no files", func(t *testing.T) {
+		stateDir := t.TempDir()
+		t.Setenv(hookStateDirEnvKey, stateDir)
+		eventStub := &spoolEventUsecaseStub{}
+		root := NewRootCLI(
+			WithStoreManagement(&spoolStoreManagementStub{}),
+			WithEvent(eventStub),
+		)
+		persistPending(t, 2)
+		// The clock is stuck past the wall to prove dry-run never consults it.
+		hookSpoolDeadRequeueClock = func() time.Time {
+			return origin.Add(hookSpoolDeadRequeueDoctorWall + time.Second)
+		}
+		t.Cleanup(func() { hookSpoolDeadRequeueClock = nil })
+
+		result, err := root.fixHookSpoolRequeueThenDrain(context.Background(), time.Now().UTC(), true)
+		if err != nil {
+			t.Fatalf("dry-run fix: %v", err)
+		}
+		if !strings.Contains(result.Action, "drain up to 2 pending hook spool record(s)") {
+			t.Fatalf("dry-run action=%q, want drain plan for 2 records", result.Action)
+		}
+		if eventStub.logCalls != 0 {
+			t.Fatalf("logCalls=%d, want 0 for dry-run", eventStub.logCalls)
+		}
+		if remaining, err := countHookSpoolRecordPaths(); err != nil || remaining != 2 {
+			t.Fatalf("pending files=%d err=%v, want 2 untouched", remaining, err)
+		}
+	})
+}
+
+func TestFixHookSpoolRequeueThenDrain_DoesNotResetWallForDrain(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	deadDir := filepath.Join(stateDir, "spool", hookSpoolDeadDirName)
+	if err := os.MkdirAll(deadDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const extra = 10
+	for i := 0; i < hookSpoolDeadRequeueLimit+extra; i++ {
+		writeTransientDeadLetter(t, deadDir, fmt.Sprintf("t-%04d.json", i))
+	}
+	eventStub := &spoolEventUsecaseStub{}
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+	origin := time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)
+	calls := 0
+	hookSpoolDeadRequeueClock = func() time.Time {
+		calls++
+		// Call 1 takes the shared fixer deadline, call 2 starts the first
+		// requeue batch, and call 3 (the second batch) is past the 45s wall.
+		// The drain must see the same exhausted wall, not a fresh 45s.
+		if calls >= 3 {
+			return origin.Add(hookSpoolDeadRequeueDoctorWall + time.Second)
+		}
+		return origin
+	}
+	t.Cleanup(func() { hookSpoolDeadRequeueClock = nil })
+
+	result, err := root.fixHookSpoolRequeueThenDrain(context.Background(), origin, false)
+	if err != nil {
+		t.Fatalf("fix: %v", err)
+	}
+	if result.Metrics["requeued"] != hookSpoolDeadRequeueLimit {
+		t.Fatalf("requeued=%d, want first batch only (%d)", result.Metrics["requeued"], hookSpoolDeadRequeueLimit)
+	}
+	if result.Metrics["replayed"] != 0 || eventStub.logCalls != 0 {
+		t.Fatalf("replayed=%d logCalls=%d, want no drain replay after requeue consumed the wall", result.Metrics["replayed"], eventStub.logCalls)
+	}
+	if result.Metrics["remaining"] != hookSpoolDeadRequeueLimit {
+		t.Fatalf("remaining=%d, want %d requeued records left pending", result.Metrics["remaining"], hookSpoolDeadRequeueLimit)
+	}
+	if !strings.Contains(result.Action, fmt.Sprintf("remaining=%d", hookSpoolDeadRequeueLimit)) {
+		t.Fatalf("action=%q, want remaining=%d", result.Action, hookSpoolDeadRequeueLimit)
+	}
+}
+
+func TestApplyDoctorFixes_SkipsAfterWall(t *testing.T) {
+	origin := time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)
+	warnCheck := func(name string, fix doctorStructuredFixFunc) doctorCheck {
+		return doctorCheck{
+			Name:              name,
+			Status:            doctorStatusWarn,
+			Severity:          doctorSeverityWarn,
+			AutoFixAvailable:  true,
+			StructuredFixFunc: fix,
+		}
+	}
+
+	t.Run("apply skips later auto-fixes once the wall is exhausted", func(t *testing.T) {
+		firstDone := false
+		secondRan := false
+		hookSpoolDeadRequeueClock = func() time.Time {
+			if firstDone {
+				return origin.Add(hookSpoolDeadRequeueDoctorWall + time.Second)
+			}
+			return origin
+		}
+		t.Cleanup(func() { hookSpoolDeadRequeueClock = nil })
+		root := NewRootCLI(WithStoreManagement(&spoolStoreManagementStub{}))
+		report := &doctorReport{Checks: []doctorCheck{
+			warnCheck("hook-spool", func(context.Context, bool) (doctorFixResult, error) {
+				firstDone = true
+				return doctorFixResult{Action: "drained hook spool: remaining=3"}, nil
+			}),
+			warnCheck("transcript", func(context.Context, bool) (doctorFixResult, error) {
+				secondRan = true
+				return doctorFixResult{Action: "second fix ran"}, nil
+			}),
+		}}
+
+		fixes := root.applyDoctorFixes(context.Background(), report, false)
+		if len(fixes) != 2 {
+			t.Fatalf("fixes=%v, want two", fixes)
+		}
+		if fixes[0].Action != "drained hook spool: remaining=3" {
+			t.Fatalf("first action=%q", fixes[0].Action)
+		}
+		if secondRan {
+			t.Fatal("second fix ran after the wall was exhausted")
+		}
+		if fixes[1].Action != "skip: doctor --fix wall exhausted" {
+			t.Fatalf("second action=%q, want wall-exhausted skip", fixes[1].Action)
+		}
+	})
+
+	t.Run("dry run never skips on the wall", func(t *testing.T) {
+		secondRan := false
+		// The clock is stuck past the wall; dry-run previews must still run.
+		hookSpoolDeadRequeueClock = func() time.Time {
+			return origin.Add(hookSpoolDeadRequeueDoctorWall + time.Second)
+		}
+		t.Cleanup(func() { hookSpoolDeadRequeueClock = nil })
+		root := NewRootCLI(WithStoreManagement(&spoolStoreManagementStub{}))
+		report := &doctorReport{Checks: []doctorCheck{
+			warnCheck("hook-spool", func(context.Context, bool) (doctorFixResult, error) {
+				return doctorFixResult{Action: "would drain"}, nil
+			}),
+			warnCheck("transcript", func(context.Context, bool) (doctorFixResult, error) {
+				secondRan = true
+				return doctorFixResult{Action: "would prune"}, nil
+			}),
+		}}
+
+		fixes := root.applyDoctorFixes(context.Background(), report, true)
+		if len(fixes) != 2 || !secondRan {
+			t.Fatalf("fixes=%v secondRan=%v, want both dry-run previews", fixes, secondRan)
+		}
+	})
 }
 
 func TestInspectHookSpoolFilesystemMetadata_FixRequeuesAndDrains(t *testing.T) {


### PR DESCRIPTION
## Summary

Bound `doctor --fix` so the documented 45s wall covers the whole apply phase, including SQLite spool replay.

`hookSpoolDeadRequeueDoctorWall` used to be checked only between 200-record drain rounds, and requeue then drain each took a fresh 45s. On a large live store that made `--fix` run for hundreds of seconds and hide leftover pending behind an empty action.

This change:

- takes **one shared deadline** in `fixHookSpoolRequeueThenDrain` and passes it to requeue and drain
- checks the wall **before each record claim** (in-flight replay may finish: one-record slack)
- always reports `remaining=N` in the hook-spool Action
- skips later auto-fixes with `skip: doctor --fix wall exhausted` once the apply wall is spent

Design: grok 4.6 medium (`.ai/spec/2231.md`, also posted on the issue). Implementation: kimi k3.

Closes #2231

## Merge verification

Original 2026-08-21 observation: `doctor --fix` on a 13.4 GiB live store ran ~451s, pending leftover, empty Action, then reinspect `store-size` O(1) page metadata unavailable.

**Not re-run against the live home store.** Worktree-built binary + throwaway `HOME` / `TRACEARY_HOOK_STATE_DIR` / sparse ≥2 GiB `--db-path` only.

| Check | Result |
|---|---|
| Fake-clock unit tests drive shipped `fixHookSpoolRequeueThenDrain` / `applyDoctorFixes` | PASS (`TestFixHookSpoolRequeueThenDrain_SharedWallBoundsDrain`, `TestFixHookSpoolRequeueThenDrain_DoesNotResetWallForDrain`, `TestApplyDoctorFixes_SkipsAfterWall`) |
| Fixture `time doctor --fix --json --warnings-ok --db-path <sparse-2GiB>` with 30 pending spool files | `real 1.91s` (≤ 45s + slack); Action `replayed=30 remaining=0`; `mode=metadata_only_large_store` |
| Live home store | not opened; fixture replay wrote under throwaway `HOME/.config/traceary/` |
| `store-size` on this fixture | still `O(1) page metadata unavailable` because the sparse file is not valid SQLite (not writer-hold from `--fix`) |

Wall-hit `remaining=N` is proven by the fake-clock tests (clock jumps after 1 replay → leftover pending + Action contains `remaining=`). Requeue consuming the wall does not give drain a fresh 45s.

Action format when the wall hits:

```
drained hook spool: requeued=<n> skipped_nontransient=<n> replayed=<n> failed=<n> unreadable=<n> remaining=<N>; pruned_dead=<n> dead_remaining=<n> pruned_tmp=<n>
```

## Test plan

- [x] `go test ./presentation/cli/ -count=1 -timeout 180s -run 'TestFixHookSpoolRequeueThenDrain_SharedWallBoundsDrain|TestFixHookSpoolRequeueThenDrain_DoesNotResetWallForDrain|TestApplyDoctorFixes_SkipsAfterWall'`
- [x] `go tool golangci-lint run` (0 issues)
- [x] Fixture `doctor --fix` wall-clock (throwaway paths only)

## Docs

- `docs/operations/large-store-doctor.md` and `.ja.md`: shared 45s wall includes SQLite replay; one-record slack; `remaining=N`; later auto-fixes skip.
