### PR TITLE
Report remaining grok-transcript jobs after doctor --fix

### DIFF
--- a/.ai/spec/2232.md
+++ b/.ai/spec/2232.md
@@ -1,0 +1,52 @@
+# Issue 2232: grok-transcript `--fix` must not claim a drain when jobs remain
+
+Engine: grok 4.6 medium  
+Date: 2026-08-21  
+Parent: #2230  
+PR: `Closes #2232` only
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — operator-visible doctor Action vs remaining queue. Check name `hook-grok-transcript` stays frozen. No event-body reads.
+
+### Requirement summary
+- 目的: `doctor --fix` の `hook-grok-transcript` Action が `launched=N removed=N` だけで「drain 完了」に見えないようにする。再 launch しても残る job / GC 対象外の terminal は `remaining=` / `failed=` で明示する。
+- 現状: `inspectHookGrokTranscriptDiagnostics` の `FixFunc`（`hook_grok_transcript_queue.go`）は `drainHookGrokTranscriptQueue` の launch/remove 件数だけを返す。drain は backoff 外の job を detached launch するだけで、成功時も pending ファイルを消さない。dogfood: Action `launched=2 removed=2` なのに同じ report が `pending=2 previously_failed=2` の WARN。
+- 期待: apply 後に queue を再スキャンし、Action に `remaining=` と `failed=` を入れる。outstanding が残れば check は WARN のまま。空なら PASS。失敗 job を自動削除しない。
+- 非対象: grok host dispatch（#2233）、live 13 GiB compact、`session_ended` 合成、SQLite、payload 本文。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint |
+|---|---|---|---|
+| Drain launch | job due, not in backoff | detached worker relaunch | file stays until worker succeeds or expire/GC |
+| Remaining | post-drain scan | pending files still in `grok-transcript/` | Action `remaining=N` |
+| Failed | job.Attempts > 0 after scan | still outstanding | Action `failed=N`; do not delete |
+| Terminal GC | past retention | `removed` counts GC | not outstanding |
+
+### Responsibility assignment
+| Responsibility | Owner | Change | Not owner |
+|---|---|---|---|
+| Post-drain recount | `FixFunc` after `drainHookGrokTranscriptQueue` | scan jobs; build Action | new drain implementation |
+| Launch/GC | existing `drainHookGrokTranscriptQueue` | keep | delete-on-launch |
+| Check status | existing `inspectHookGrokTranscriptDiagnostics` + `annotateDoctorFixesAfter` | PASS iff scan empty of outstanding work | synthesizing PASS from launched>0 |
+
+### Boundaries
+| IF | Consumer | Hidden | Error |
+|---|---|---|---|
+| FixFunc Action | operators, Merge verification | `launched=%d removed=%d remaining=%d failed=%d` | scan error returned; no bodies |
+| Metrics (optional StructuredFixFunc) | doctor JSON | keep string Action stable if not converting | do not rename check |
+
+Prefer keeping `FixFunc` string + optional metrics via `StructuredFixFunc` only if existing doctor tests already accept structured. Do not drop `FixFunc` if tests require it.
+
+### Behavior tests
+| Behavior | Given | When | Then |
+|---|---|---|---|
+| Re-fail | 2 jobs; launcher succeeds but files remain (increment Attempts) | FixFunc apply | Action contains remaining>0 and failed≥0; re-inspect WARN |
+| Empty after drain | 1 job; launcher + test double removes file (or GC-eligible terminal only) | apply + inspect | remaining=0; check PASS |
+| Dry-run | pending jobs | dry-run | no launches |
+| Do not delete failed | re-fail fixture | apply | job files still present |
+
+Drive shipped `inspectHookGrokTranscriptDiagnostics` / `drainHookGrokTranscriptQueue`, not a reimplementation.
+
+### Merge verification
+Throwaway `TRACEARY_HOOK_STATE_DIR` + worktree or Homebrew CLI. Never repo-built binary vs live home store. Fixture: 2 jobs that survive launch. `doctor --fix --json --warnings-ok` then `doctor --json --warnings-ok`. If jobs remain: WARN + Action does not claim a clean drain (`remaining=` > 0). If they actually drain: PASS on second doctor.

--- a/presentation/cli/hook_grok_transcript_queue.go
+++ b/presentation/cli/hook_grok_transcript_queue.go
@@ -162,7 +162,22 @@ func (c *RootCLI) inspectHookGrokTranscriptDiagnostics(now time.Time) doctorChec
 				return localizef("would drain/GC up to %d pending Grok transcript job(s)/terminal marker(s)", "未処理 Grok transcript job/terminal marker 最大 %d 件を drain/GC します", min(len(pending)+len(terminals), hookGrokTranscriptDoctorFixLimit)), nil
 			}
 			launched, removed := c.drainHookGrokTranscriptQueue(time.Now().UTC(), hookGrokTranscriptDoctorFixLimit)
-			return localizef("drained Grok transcript queue: launched=%d removed=%d", "Grok transcript queue を drain しました: launched=%d removed=%d", launched, removed), nil
+			// A successful launch does not remove the job file; only the
+			// detached worker finalizes it. Re-scan so the Action reflects
+			// what is still outstanding instead of claiming a clean drain
+			// (#2232). Failed jobs stay on disk for operator attention.
+			remainingJobs, unreadable, scanErr := scanHookGrokTranscriptJobs()
+			if scanErr != nil {
+				return "", scanErr
+			}
+			failed := 0
+			for _, job := range remainingJobs {
+				if job.Attempts > 0 {
+					failed++
+				}
+			}
+			remaining := len(remainingJobs) + len(unreadable)
+			return localizef("drained Grok transcript queue: launched=%d removed=%d remaining=%d failed=%d", "Grok transcript queue を drain しました: launched=%d removed=%d remaining=%d failed=%d", launched, removed, remaining, failed), nil
 		},
 	}
 }

--- a/presentation/cli/hook_grok_transcript_queue_internal_test.go
+++ b/presentation/cli/hook_grok_transcript_queue_internal_test.go
@@ -335,11 +335,114 @@ func TestInspectHookGrokTranscriptDiagnosticsFixFuncDrainsAndGCs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FixFunc(apply) error = %v", err)
 	}
-	if !strings.Contains(fixMessage, "launched=1") {
-		t.Fatalf("fixMessage = %q, want launched=1", fixMessage)
+	// The launcher succeeded but did not finalize the job, so the Action must
+	// not claim a clean drain: the job is still outstanding (#2232).
+	for _, want := range []string{"launched=1", "removed=0", "remaining=1", "failed=0"} {
+		if !strings.Contains(fixMessage, want) {
+			t.Fatalf("fixMessage = %q, want %q", fixMessage, want)
+		}
 	}
 	if len(launched) != 1 {
 		t.Fatalf("launched = %v, want exactly one relaunch", launched)
+	}
+	jobs, _, err := scanHookGrokTranscriptJobs()
+	if err != nil {
+		t.Fatalf("scanHookGrokTranscriptJobs() error = %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %d, want the launched job to remain on disk", len(jobs))
+	}
+	reinspect := c.inspectHookGrokTranscriptDiagnostics(time.Now().UTC())
+	if reinspect.Status != doctorStatusWarn {
+		t.Fatalf("re-inspect check = %+v, want warning while jobs remain", reinspect)
+	}
+}
+
+func TestInspectHookGrokTranscriptDiagnosticsFixFuncReportsFailedRemainingJobs(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	now := time.Now().UTC()
+
+	var paths []string
+	for _, sessionID := range []string{"refail-session-a", "refail-session-b"} {
+		payload := []byte(`{"session_id":"` + sessionID + `","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
+		path, _, err := enqueueHookGrokTranscript(payload, "", now.Add(-time.Minute))
+		if err != nil {
+			t.Fatalf("enqueueHookGrokTranscript(%s) error = %v", sessionID, err)
+		}
+		paths = append(paths, path)
+	}
+
+	c := &RootCLI{}
+	// Launcher "succeeds" (returns nil) but the worker never finalizes: the
+	// job stays on disk with a bumped attempt count.
+	c.hookGrokTranscriptLauncher = func(path string) error {
+		job, err := readHookGrokTranscriptJob(path)
+		if err != nil {
+			return err
+		}
+		job.Attempts++
+		job.LastAttemptAt = now
+		job.LastError = "transcript remained delayed"
+		return writeHookGrokTranscriptJob(path, job)
+	}
+
+	check := c.inspectHookGrokTranscriptDiagnostics(now)
+	if check.Status != doctorStatusWarn || check.FixFunc == nil {
+		t.Fatalf("check = %+v, want an auto-fixable warning", check)
+	}
+	fixMessage, err := check.FixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("FixFunc(apply) error = %v", err)
+	}
+	for _, want := range []string{"launched=2", "remaining=2", "failed=2"} {
+		if !strings.Contains(fixMessage, want) {
+			t.Fatalf("fixMessage = %q, want %q", fixMessage, want)
+		}
+	}
+	// Failed jobs must not be deleted; they still need operator attention.
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("job %q must remain on disk: %v", path, err)
+		}
+	}
+	reinspect := c.inspectHookGrokTranscriptDiagnostics(time.Now().UTC())
+	if reinspect.Status != doctorStatusWarn {
+		t.Fatalf("re-inspect check = %+v, want warning while failed jobs remain", reinspect)
+	}
+}
+
+func TestInspectHookGrokTranscriptDiagnosticsFixFuncPassesWhenDrainEmptiesQueue(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	now := time.Now().UTC()
+
+	payload := []byte(`{"session_id":"drain-session","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
+	if _, _, err := enqueueHookGrokTranscript(payload, "", now.Add(-time.Minute)); err != nil {
+		t.Fatalf("enqueueHookGrokTranscript() error = %v", err)
+	}
+
+	c := &RootCLI{}
+	// Test double for a worker that finalizes immediately: the job file is
+	// gone by the time the post-drain scan runs.
+	c.hookGrokTranscriptLauncher = func(path string) error {
+		return os.Remove(path)
+	}
+
+	check := c.inspectHookGrokTranscriptDiagnostics(now)
+	if check.FixFunc == nil {
+		t.Fatalf("check = %+v, want an auto-fixable check", check)
+	}
+	fixMessage, err := check.FixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("FixFunc(apply) error = %v", err)
+	}
+	for _, want := range []string{"launched=1", "remaining=0", "failed=0"} {
+		if !strings.Contains(fixMessage, want) {
+			t.Fatalf("fixMessage = %q, want %q", fixMessage, want)
+		}
+	}
+	reinspect := c.inspectHookGrokTranscriptDiagnostics(time.Now().UTC())
+	if reinspect.Status != doctorStatusPass {
+		t.Fatalf("re-inspect check = %+v, want pass once the queue is empty", reinspect)
 	}
 }
 


### PR DESCRIPTION
## Summary

`doctor --fix` for `hook-grok-transcript` now re-scans the queue after drain and reports `remaining=` / `failed=` instead of looking like a clean drain when relaunched jobs stay on disk.

Design: grok 4.6 medium. Implementation: kimi k3.

Closes #2232

## Merge verification

Original: Action `launched=2 removed=2` while the same report WARNed `pending=2 previously_failed=2`.

Go tests drive shipped `inspectHookGrokTranscriptDiagnostics` / `drainHookGrokTranscriptQueue` (not a reimplementation):

- Re-fail fixture: launcher succeeds, job files remain → Action `remaining=2 failed=2`; re-inspect WARN; files not deleted
- Empty-after-drain: launcher removes files → `remaining=0`; re-inspect PASS
- Dry-run: no launches

Did not point a repo-built binary at the live home store.

## Test plan

- [x] `go test ./presentation/cli/ -count=1 -timeout 120s -run 'GrokTranscript'`
