### PR TITLE
Warn when Grok inspect lists plugin hooks but does not dispatch them

### DIFF
--- a/.ai/spec/2233.md
+++ b/.ai/spec/2233.md
@@ -19,7 +19,7 @@ Risk: **Medium** — operator-visible doctor vs actual Grok capture. Prefer **B 
 | Concept | Meaning | PASS grok-hooks? |
 |---|---|---|
 | Plugin listed | inspect `plugins[]` enabled, hook file has 7 events | no, listing only |
-| Dispatched plugin route | inspect `hooks[]` has `source.type=plugin` + `plugin_name=traceary-grok` | necessary, not sufficient for capture |
+| Dispatched plugin route | inspect `hooks[]` has `source.type=plugin` + `plugin_name=traceary-grok` **and** the entry is a dispatched hook (`hookType` not `file`, `event` not `(plugin)`); the plugin manifest file listing is not dispatch | necessary, not sufficient for capture |
 | Dispatched user-only | inspect `hooks[]` only `source.type=user` (cmux) | no — WARN |
 | Capture | throwaway DB has ≥1 grok event | A; matrix may become wired |
 

--- a/.ai/spec/2233.md
+++ b/.ai/spec/2233.md
@@ -1,0 +1,53 @@
+# Issue 2233: Grok 1.0.5 doctor must not PASS grok-hooks as wired capture
+
+Engine: grok 4.6 medium  
+Date: 2026-08-21  
+Parent: #2230  
+PR: `Closes #2233` only
+
+## Structure-Behavior Design Note
+
+Risk: **Medium** — operator-visible doctor vs actual Grok capture. Prefer **B (honest doctor)** unless Merge verification records ≥1 event on a throwaway store (then A + matrix `wired`).
+
+### Requirement summary
+- 目的: Grok Build 1.0.5 が plugin hook を dispatch しないのに `grok-hooks=pass`「検証済み7 eventをすべてカバー」と出ないようにする。
+- 現状: `probeGrokDoctorState` は `inspect --json` の `hooks[]` で `plugin_name=traceary-grok` かつ native path かつ hook **ファイル**が 7 event 契約なら `NativeHooks=true`。ファイル契約 ≠ host が plugin 経路を実行したこと。dogfood: plugin enabled / inspect `hooks: true` だが実行は user-level `~/.grok/hooks` (cmux)。isolated `-p` は DB 未作成。matrix.json の Grok セルは既に `available`（2026-08-21）。doctor だけが嘘の PASS。
+- 禁止: `session_ended` を process exit / TUI quit / `-p` exit から合成しない。user-level に Traceary hook を二重インストールしない。
+- 非対象: #2232 queue Action、#2234 Kimi SessionEnd、live store compact。
+
+### Conceptual model
+| Concept | Meaning | PASS grok-hooks? |
+|---|---|---|
+| Plugin listed | inspect `plugins[]` enabled, hook file has 7 events | no, listing only |
+| Dispatched plugin route | inspect `hooks[]` has `source.type=plugin` + `plugin_name=traceary-grok` | necessary, not sufficient for capture |
+| Dispatched user-only | inspect `hooks[]` only `source.type=user` (cmux) | no — WARN |
+| Capture | throwaway DB has ≥1 grok event | A; matrix may become wired |
+
+### Responsibility assignment
+| Responsibility | Owner | Change | Not owner |
+|---|---|---|---|
+| Dispatch vs file | `probeGrokDoctorState` | `NativeHooks` true only when inspect **dispatches** a plugin-source hook whose target still has verified coverage | treating plugin-provides or file-on-disk as dispatch |
+| Honest message | `buildGrokDoctorChecks` grok-hooks | if plugin installed/enabled but inspect dispatches only user-level: WARN, not “7 events covered” | dual-fire user hook installer |
+| Matrix | `application/hostcoverage/matrix.json` + generated host-coverage docs | keep `available` unless Merge verification captures events | inventing wired cells |
+
+### Boundaries
+| IF | Consumer | Hidden | Error |
+|---|---|---|---|
+| inspect `hooks[].source.type` | probe | plugin vs user vs project | malformed inspect → existing fail |
+| grok-hooks check | operators | WARN when plugin listed but not in dispatched list | no payloads |
+| matrix cells | docs / landing (#2239) | stay `available` on B | no session_ended synthesis |
+
+### Tests (inspect fixtures, no live grok required)
+| Fixture | Then |
+|---|---|
+| plugin installed+enabled, hook file 7 events, inspect.hooks only `source.type=user` | `NativeHooks=false`; grok-hooks is WARN (not PASS-as-wired) |
+| inspect.hooks includes `source.type=plugin` + native coverage file | grok-hooks PASS (same as today’s happy path) |
+| no grok CLI | existing skip/empty path unchanged |
+
+Reuse `grokDoctorOutput` fakes in `doctor_grok_internal_test.go`. Do not add a second user-level Traceary hook.
+
+### Merge verification
+Isolated throwaway `TRACEARY_DB_PATH` + `HOME`. `grok --permission-mode plan --no-subagents --max-turns 1 --prompt-file …` (private leader-socket if required). `traceary list --json --limit 20` from that cwd (`traceary list --kind`, not `list events`).
+- events ≥ 1 → kinds only in Evidence; matrix cells that fired may become `wired` with probe date; grok-hooks PASS allowed.
+- events = 0 → Evidence: inspect hook source types/paths (no bodies) + doctor JSON `grok-hooks` WARN or FAIL. matrix remains `available`.
+Never repo-built binary vs live home store.

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -65,7 +65,9 @@ type grokDoctorState struct {
 	// still merges that route even when coverage is incomplete/stale, so
 	// duplicate-route detection must use presence rather than verified
 	// coverage. A plugin that is merely installed/listed does not count: Grok
-	// can list plugin hooks while dispatching only user-level routes.
+	// can list plugin hooks while dispatching only user-level routes, and the
+	// inspect hooks[] entry for the plugin manifest itself (hookType=file,
+	// event "(plugin)") is a listing, not a dispatched hook.
 	NativeHooksPresent bool
 	// NativeHooks is true only when the dispatched plugin-source route also
 	// passes the exact seven-event verified coverage contract. Used by
@@ -88,16 +90,20 @@ type grokPluginListEntry struct {
 	Source  string `json:"source"`
 }
 
+type grokInspectHook struct {
+	Target   string `json:"target"`
+	HookType string `json:"hookType"`
+	Event    string `json:"event"`
+	Source   struct {
+		Type       string `json:"type"`
+		PluginName string `json:"plugin_name"`
+	} `json:"source"`
+}
+
 type grokInspectDocument struct {
-	ProjectTrusted bool `json:"projectTrusted"`
-	Hooks          []struct {
-		Target string `json:"target"`
-		Source struct {
-			Type       string `json:"type"`
-			PluginName string `json:"plugin_name"`
-		} `json:"source"`
-	} `json:"hooks"`
-	Plugins []struct {
+	ProjectTrusted bool              `json:"projectTrusted"`
+	Hooks          []grokInspectHook `json:"hooks"`
+	Plugins        []struct {
 		Name     string `json:"name"`
 		Enabled  bool   `json:"enabled"`
 		Path     string `json:"path"`
@@ -194,7 +200,7 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		if hook.Source.PluginName == legacyTracearyPluginName {
 			state.LegacyPluginDetected = true
 		}
-		if hook.Source.Type == "plugin" && hook.Source.PluginName == grokTracearyPluginName && pathClass == grokPluginPathClassNative {
+		if hook.Source.Type == "plugin" && hook.Source.PluginName == grokTracearyPluginName && pathClass == grokPluginPathClassNative && grokInspectHookIsDispatch(hook) {
 			state.NativeHooksPresent = true
 			if grokHookFileHasVerifiedCoverage(hook.Target) {
 				state.NativeHooks = true
@@ -216,6 +222,21 @@ func probeGrokUserHooksFile(state *grokDoctorState, userPath string) {
 	if readErr != nil || !json.Valid(data) {
 		state.UserHooksInvalid = true
 	}
+}
+
+// grokInspectHookIsDispatch reports whether an inspect hooks[] entry is a
+// dispatched lifecycle hook rather than the plugin's file listing. Grok 1.0.5
+// lists the plugin manifest target (hooks/hooks.json) as hookType=file with
+// event "(plugin)": that entry proves the plugin is installed, not that Grok
+// dispatches any plugin hook for it. Dispatched hooks carry a concrete
+// hookType such as "command" and a lifecycle event name. Entries from Grok
+// versions that predate the hookType/event fields are treated as dispatched,
+// matching the pre-listing inspect contract.
+func grokInspectHookIsDispatch(hook grokInspectHook) bool {
+	if strings.EqualFold(strings.TrimSpace(hook.HookType), "file") {
+		return false
+	}
+	return strings.TrimSpace(hook.Event) != "(plugin)"
 }
 
 // grokIsTracearyUserHookTarget reports whether an inspect hook target looks like

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -60,16 +60,24 @@ type grokDoctorState struct {
 	// UserHooksInvalid is true when the user-level file exists but is unreadable
 	// or not valid JSON. Diagnosis only; doctor does not rewrite the file.
 	UserHooksInvalid bool
-	// NativeHooksPresent is true when inspect reports a traceary-grok hook with
-	// a native path class. Grok still merges that route even when coverage is
-	// incomplete/stale, so duplicate-route detection must use presence rather
-	// than verified coverage.
+	// NativeHooksPresent is true when inspect dispatches a plugin-source
+	// (source.type=plugin) traceary-grok hook with a native path class. Grok
+	// still merges that route even when coverage is incomplete/stale, so
+	// duplicate-route detection must use presence rather than verified
+	// coverage. A plugin that is merely installed/listed does not count: Grok
+	// can list plugin hooks while dispatching only user-level routes.
 	NativeHooksPresent bool
-	// NativeHooks is true only when the native route also passes the exact
-	// seven-event verified coverage contract. Used by grok-hooks only.
+	// NativeHooks is true only when the dispatched plugin-source route also
+	// passes the exact seven-event verified coverage contract. Used by
+	// grok-hooks only.
 	NativeHooks bool
-	MCPServers  int
-	Skills      int
+	// PluginHookFileVerified is true when the installed plugin's own hook file
+	// (PluginPath/hooks/hooks.json) passes the seven-event verified coverage
+	// contract, regardless of whether Grok actually dispatches it. Listing or
+	// file coverage alone never proves the host executes the plugin route.
+	PluginHookFileVerified bool
+	MCPServers             int
+	Skills                 int
 }
 
 type grokPluginListEntry struct {
@@ -161,6 +169,12 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		state.MCPServers = plugin.Provides.MCPServers
 		state.Skills = plugin.Provides.Skills
 	}
+	// The installed plugin's own hook file is verified independently of the
+	// inspect dispatch list: a listed/enabled plugin whose hooks Grok never
+	// dispatches must not read as wired capture.
+	if state.PluginInstalled && strings.TrimSpace(state.PluginPath) != "" {
+		state.PluginHookFileVerified = grokHookFileHasVerifiedCoverage(filepath.Join(state.PluginPath, "hooks", "hooks.json"))
+	}
 	for _, hook := range document.Hooks {
 		switch hook.Source.Type {
 		case "project":
@@ -180,7 +194,7 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		if hook.Source.PluginName == legacyTracearyPluginName {
 			state.LegacyPluginDetected = true
 		}
-		if hook.Source.PluginName == grokTracearyPluginName && pathClass == grokPluginPathClassNative {
+		if hook.Source.Type == "plugin" && hook.Source.PluginName == grokTracearyPluginName && pathClass == grokPluginPathClassNative {
 			state.NativeHooksPresent = true
 			if grokHookFileHasVerifiedCoverage(hook.Target) {
 				state.NativeHooks = true
@@ -377,10 +391,22 @@ func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doct
 	checks = append(checks, doctorCheck{Name: "grok-hook-trust", Status: trustStatus, Message: trustMessage, Hint: Localize("use Grok /hooks-trust for this project when project hooks are intended", "project hook を使用する場合は Grok の /hooks-trust で信頼してください")})
 	hookStatus := doctorStatusPass
 	hookMessage := Localize("native Grok hooks cover all seven verified events", "native Grok hook は検証済み7 eventをすべてカバーしています")
-	if !state.NativeHooks {
+	hookHint := Localize("update or reinstall the native Traceary Grok plugin", "native Traceary Grok plugin を更新または再インストールしてください")
+	switch {
+	case state.NativeHooks:
+		// PASS: a dispatched plugin-source route with verified coverage.
+	case !state.NativeHooksPresent && (state.PluginHookFileVerified || (state.PluginInstalled && state.PluginEnabled)):
+		// The plugin is installed/listed (and its own hook file may satisfy the
+		// seven-event contract), but inspect dispatches no plugin-source
+		// traceary-grok hook — only user-level or other sources. Listing or
+		// file coverage is not capture.
+		hookStatus = doctorStatusWarn
+		hookMessage = Localize("native Traceary Grok plugin hooks are installed but Grok does not dispatch them: inspect lists only user-level hook sources, so no plugin hook route is active", "native Traceary Grok plugin の hook はインストールされていますが Grok が dispatch していません。inspect では user-level の hook source のみが列挙され、plugin の hook 経路は有効ではありません")
+		hookHint = Localize("run grok inspect --json to confirm which hook sources Grok dispatches; a listed plugin is not necessarily an active hook route", "grok inspect --json で Grok が dispatch している hook source を確認してください。一覧にある plugin が有効な hook 経路とは限りません")
+	case !state.NativeHooks:
 		hookStatus, hookMessage = doctorStatusWarn, Localize("native Grok hook coverage is missing or incomplete", "native Grok hook coverage が不足しています")
 	}
-	checks = append(checks, doctorCheck{Name: "grok-hooks", Status: hookStatus, Message: hookMessage, Hint: Localize("update or reinstall the native Traceary Grok plugin", "native Traceary Grok plugin を更新または再インストールしてください")})
+	checks = append(checks, doctorCheck{Name: "grok-hooks", Status: hookStatus, Message: hookMessage, Hint: hookHint})
 	checks = append(checks, buildGrokUserHooksCheck(state), buildGrokHookRoutesSummary(state))
 	skillStatus := doctorStatusPass
 	skillMessage := Localize("native Grok plugin exposes all four Traceary skills", "native Grok plugin は Traceary skill を4件すべて公開しています")

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -189,9 +189,11 @@ func TestProbeGrokDoctorStateDoesNotTrustProvidesHooksBoolean(t *testing.T) {
 
 // TestProbeGrokDoctorStateWarnsWhenPluginHooksNotDispatched reproduces the
 // Grok 1.0.5 dogfood: the traceary-grok plugin is installed and enabled and
-// its on-disk hook file satisfies the seven-event contract, yet inspect
-// dispatches only user-level hook sources. A listed plugin is not capture, so
-// grok-hooks must WARN instead of claiming the native route covers all events.
+// its on-disk hook file satisfies the seven-event contract, yet inspect lists
+// the plugin only as a file-type manifest listing (hookType=file,
+// event "(plugin)") while every dispatched lifecycle hook is a user-level
+// command hook. A listed plugin is not capture, so grok-hooks must WARN
+// instead of claiming the native route covers all events.
 func TestProbeGrokDoctorStateWarnsWhenPluginHooksNotDispatched(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
 	originalLookPath, originalOutput, originalHome := grokDoctorLookPath, grokDoctorOutput, currentUserHomeDirFunc()
@@ -217,7 +219,11 @@ func TestProbeGrokDoctorStateWarnsWhenPluginHooksNotDispatched(t *testing.T) {
 		case "plugin list --json":
 			return []byte(`[{"name":"traceary-grok","version":"0.46.0","path":` + strconv.Quote(filepath.Dir(filepath.Dir(pluginHook))) + `}]`), nil
 		case "--cwd " + projectDir + " inspect --json":
-			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":4,"hooks":true,"mcpServers":0}}],"hooks":[{"target":` + strconv.Quote(userHookPath) + `,"source":{"type":"user"}}]}`), nil
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":4,"hooks":true,"mcpServers":0}}],"hooks":[` +
+				`{"target":` + strconv.Quote(pluginHook) + `,"hookType":"file","event":"(plugin)","source":{"type":"plugin","plugin_name":"traceary-grok"}},` +
+				`{"target":` + strconv.Quote(userHookPath) + `,"hookType":"command","event":"session_start","source":{"type":"user"}},` +
+				`{"target":` + strconv.Quote(userHookPath) + `,"hookType":"command","event":"user_prompt_submit","source":{"type":"user"}}` +
+				`]}`), nil
 		default:
 			t.Fatalf("unexpected Grok arguments: %v", args)
 			return nil, nil
@@ -260,8 +266,9 @@ func TestProbeGrokDoctorStateWarnsWhenPluginHooksNotDispatched(t *testing.T) {
 }
 
 // TestProbeGrokDoctorStatePassesWhenPluginSourceDispatched keeps the happy
-// path honest: inspect reporting a plugin-source traceary-grok hook whose
-// target file still has verified seven-event coverage passes grok-hooks.
+// path honest: inspect dispatching a plugin-source traceary-grok hook
+// (hookType=command, a concrete lifecycle event) whose target file still has
+// verified seven-event coverage passes grok-hooks.
 func TestProbeGrokDoctorStatePassesWhenPluginSourceDispatched(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
 	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
@@ -278,7 +285,7 @@ func TestProbeGrokDoctorStatePassesWhenPluginSourceDispatched(t *testing.T) {
 		case "plugin list --json":
 			return []byte(`[{"name":"traceary-grok","version":"0.46.0","path":"/cache/grok-plugin-traceary-grok"}]`), nil
 		case "--cwd " + projectDir + " inspect --json":
-			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":4,"mcpServers":0}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary-grok"}}]}`), nil
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":4,"mcpServers":0}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"hookType":"command","event":"SessionStart","source":{"type":"plugin","plugin_name":"traceary-grok"}}]}`), nil
 		default:
 			t.Fatalf("unexpected Grok arguments: %v", args)
 			return nil, nil
@@ -297,6 +304,34 @@ func TestProbeGrokDoctorStatePassesWhenPluginSourceDispatched(t *testing.T) {
 		if check.Name == "grok-hooks" && (check.Status != doctorStatusPass || !strings.Contains(check.Message, "cover all seven")) {
 			t.Fatalf("grok-hooks = %+v, want PASS for dispatched plugin-source route", check)
 		}
+	}
+}
+
+func TestGrokInspectHookIsDispatch(t *testing.T) {
+	hook := func(hookType, event string) grokInspectHook {
+		var h grokInspectHook
+		h.HookType, h.Event = hookType, event
+		return h
+	}
+	tests := []struct {
+		name string
+		hook grokInspectHook
+		want bool
+	}{
+		{name: "command lifecycle hook is dispatched", hook: hook("command", "session_start"), want: true},
+		{name: "command hook with PascalCase event is dispatched", hook: hook("command", "SessionStart"), want: true},
+		{name: "non-file hookType without event is dispatched", hook: hook("command", ""), want: true},
+		{name: "file listing is not dispatch", hook: hook("file", "(plugin)")},
+		{name: "file hookType alone is not dispatch", hook: hook("file", "session_start")},
+		{name: "plugin event marker alone is not dispatch", hook: hook("", "(plugin)")},
+		{name: "legacy entry without hookType or event is dispatched", hook: hook("", ""), want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := grokInspectHookIsDispatch(tc.hook); got != tc.want {
+				t.Fatalf("grokInspectHookIsDispatch(%+v) = %v, want %v", tc.hook, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -24,7 +24,7 @@ func TestBuildGrokDoctorChecks(t *testing.T) {
 		{name: "version mismatch", mutate: func(s *grokDoctorState) { s.PluginVersion = "0.22.0" }, check: "grok-plugin", status: doctorStatusWarn, messageSub: "does not match"},
 		{name: "untrusted project hooks", mutate: func(s *grokDoctorState) { s.ProjectHooks, s.ProjectTrusted = true, false }, check: "grok-hook-trust", status: doctorStatusWarn, messageSub: "not trusted"},
 		{name: "missing skills", mutate: func(s *grokDoctorState) { s.Skills = 2 }, check: "grok-skills", status: doctorStatusWarn, messageSub: "2"},
-		{name: "missing hooks", mutate: func(s *grokDoctorState) { s.NativeHooks = false }, check: "grok-hooks", status: doctorStatusWarn, messageSub: "incomplete"},
+		{name: "missing hooks", mutate: func(s *grokDoctorState) { s.NativeHooks, s.NativeHooksPresent = false, true }, check: "grok-hooks", status: doctorStatusWarn, messageSub: "incomplete"},
 		{name: "missing local plugin source", mutate: func(s *grokDoctorState) { s.PluginSource, s.PluginSourceMissing = "/does/not/exist/traceary", true }, check: "grok-plugin", status: doctorStatusFail, messageSub: "does not exist"},
 		{name: "healthy", mutate: func(*grokDoctorState) {}, check: "grok-plugin", status: doctorStatusPass, messageSub: "enabled"},
 	}
@@ -184,6 +184,119 @@ func TestProbeGrokDoctorStateDoesNotTrustProvidesHooksBoolean(t *testing.T) {
 	}
 	if state.NativeHooks || !state.ProjectHooks || state.ProjectTrusted {
 		t.Fatalf("state = %+v, invalid hook contract must not pass and untrusted project hooks must be detected", state)
+	}
+}
+
+// TestProbeGrokDoctorStateWarnsWhenPluginHooksNotDispatched reproduces the
+// Grok 1.0.5 dogfood: the traceary-grok plugin is installed and enabled and
+// its on-disk hook file satisfies the seven-event contract, yet inspect
+// dispatches only user-level hook sources. A listed plugin is not capture, so
+// grok-hooks must WARN instead of claiming the native route covers all events.
+func TestProbeGrokDoctorStateWarnsWhenPluginHooksNotDispatched(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	originalLookPath, originalOutput, originalHome := grokDoctorLookPath, grokDoctorOutput, currentUserHomeDirFunc()
+	t.Cleanup(func() {
+		grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput
+		storeUserHomeDirFunc(originalHome)
+	})
+
+	home := t.TempDir()
+	storeUserHomeDirFunc(func() (string, error) { return home, nil })
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+
+	projectDir := t.TempDir()
+	userHookPath := filepath.Join(home, ".grok", "hooks", "traceary.json")
+	writeGrokDoctorHookFixture(t, userHookPath, true)
+	pluginHook := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-traceary-grok", "hooks", "hooks.json")
+	writeGrokDoctorHookFixture(t, pluginHook, true)
+
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 1.0.5\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary-grok","version":"0.46.0","path":` + strconv.Quote(filepath.Dir(filepath.Dir(pluginHook))) + `}]`), nil
+		case "--cwd " + projectDir + " inspect --json":
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":4,"hooks":true,"mcpServers":0}}],"hooks":[{"target":` + strconv.Quote(userHookPath) + `,"source":{"type":"user"}}]}`), nil
+		default:
+			t.Fatalf("unexpected Grok arguments: %v", args)
+			return nil, nil
+		}
+	}
+
+	state, err := probeGrokDoctorState(context.Background(), projectDir)
+	if err != nil {
+		t.Fatalf("probeGrokDoctorState() error = %v", err)
+	}
+	if !state.PluginInstalled || !state.PluginEnabled || !state.PluginHookFileVerified {
+		t.Fatalf("state = %+v, want installed/enabled plugin with verified hook file", state)
+	}
+	if state.NativeHooks || state.NativeHooksPresent {
+		t.Fatalf("state = %+v, user-only dispatch must not count as a native plugin route", state)
+	}
+
+	checks := buildGrokDoctorChecks(state, "0.46.0")
+	byName := map[string]doctorCheck{}
+	for _, check := range checks {
+		byName[check.Name] = check
+		if strings.Contains(check.Message+check.Hint, "/private/") {
+			t.Fatalf("check exposed private path: %+v", check)
+		}
+	}
+	hooksCheck, ok := byName["grok-hooks"]
+	if !ok || hooksCheck.Status != doctorStatusWarn {
+		t.Fatalf("grok-hooks = %+v, want WARN for undispatched plugin hooks", hooksCheck)
+	}
+	if strings.Contains(hooksCheck.Message, "cover all seven") {
+		t.Fatalf("grok-hooks = %+v, must not claim wired native coverage", hooksCheck)
+	}
+	if !strings.Contains(hooksCheck.Message, "does not dispatch") || !strings.Contains(hooksCheck.Message, "user-level") {
+		t.Fatalf("grok-hooks = %+v, want message naming plugin hooks absent from the dispatched inspect list", hooksCheck)
+	}
+	routesCheck, ok := byName["grok-hooks-routes"]
+	if !ok || routesCheck.Status != doctorStatusPass || !strings.Contains(routesCheck.Message, "user-level") {
+		t.Fatalf("grok-hooks-routes = %+v, want single user-level route", routesCheck)
+	}
+}
+
+// TestProbeGrokDoctorStatePassesWhenPluginSourceDispatched keeps the happy
+// path honest: inspect reporting a plugin-source traceary-grok hook whose
+// target file still has verified seven-event coverage passes grok-hooks.
+func TestProbeGrokDoctorStatePassesWhenPluginSourceDispatched(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
+	t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+
+	projectDir := t.TempDir()
+	pluginHook := filepath.Join(projectDir, "integrations", "grok-plugin", "hooks", "hooks.json")
+	writeGrokDoctorHookFixture(t, pluginHook, true)
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 1.0.5\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary-grok","version":"0.46.0","path":"/cache/grok-plugin-traceary-grok"}]`), nil
+		case "--cwd " + projectDir + " inspect --json":
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":4,"mcpServers":0}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary-grok"}}]}`), nil
+		default:
+			t.Fatalf("unexpected Grok arguments: %v", args)
+			return nil, nil
+		}
+	}
+
+	state, err := probeGrokDoctorState(context.Background(), projectDir)
+	if err != nil {
+		t.Fatalf("probeGrokDoctorState() error = %v", err)
+	}
+	if !state.NativeHooks || !state.NativeHooksPresent {
+		t.Fatalf("state = %+v, want dispatched plugin route with verified coverage", state)
+	}
+	checks := buildGrokDoctorChecks(state, "0.46.0")
+	for _, check := range checks {
+		if check.Name == "grok-hooks" && (check.Status != doctorStatusPass || !strings.Contains(check.Message, "cover all seven")) {
+			t.Fatalf("grok-hooks = %+v, want PASS for dispatched plugin-source route", check)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`grok-hooks` no longer PASSes as “seven verified events covered” when Grok inspect only lists the plugin hook **file** (`hookType=file`, `event=(plugin)`) and dispatches lifecycle hooks from user-level (cmux) commands.

Design: grok 4.6 medium (outcome B: honest doctor). Implementation: kimi k3. Matrix Grok cells stay `available`.

Closes #2233

## Merge verification

Original: isolated Grok 1.0.5 `-p` recorded 0 events; doctor `grok-hooks=pass` “7 events covered”; live grok last events 2026-07-23.

Live `grok inspect --json` (2026-08-21, names/types only):

- plugin `traceary-grok` enabled, `provides.hooks=true`
- 1 plugin-source entry: `hookType=file`, `event=(plugin)` (listing)
- dispatched lifecycle hooks: `hookType=command`, `source.type=user` (cmux)

Go tests:

- live-shaped fixture → `grok-hooks` WARN, not PASS-as-wired
- plugin-source `hookType=command` + coverage file → PASS
- `TestGrokInspectHookIsDispatch` for file / `(plugin)` / command / missing fields

Isolated throwaway DB `grok -p` (if captured in PR comments) + worktree `doctor --json --warnings-ok` against throwaway `--db-path` using live inspect. No repo-built binary against the live home store. No `session_ended` synthesis.

## Test plan

- [x] `go test ./presentation/cli/ -count=1 -timeout 120s -run 'GrokDoctor|ProbeGrok|GrokInspectHookIsDispatch'`
