### PR TITLE
Stop claiming Kimi SessionEnd as verified 10-event coverage

### DIFF
--- a/presentation/cli/doctor_kimi.go
+++ b/presentation/cli/doctor_kimi.go
@@ -213,12 +213,19 @@ func buildKimiDoctorChecks(state kimiDoctorState, tracearyVersion string) []doct
 	}
 	checks = append(checks, doctorCheck{Name: "kimi-plugin", Status: pluginStatus, Message: pluginMessage, Hint: pluginHint})
 
-	hookStatus := doctorStatusPass
-	hookMessage := Localize("native Kimi plugin hooks cover all ten verified events", "native Kimi plugin hook は検証済み 10 event をすべてカバーしています")
+	// The manifest declares all ten events, but SessionEnd is declared-only:
+	// Kimi Code 0.38.0 in -p mode never dispatches it (dogfood sessions record
+	// session_started/prompt/transcript, never session_ended). Report this
+	// honestly as WARN instead of claiming verified 10-event coverage; the
+	// support matrix keeps SessionEnd available, not verified.
+	hookStatus := doctorStatusWarn
+	hookMessage := Localize("native Kimi plugin hooks declare all ten events including SessionEnd, but SessionEnd is unobserved on Kimi Code 0.38.0 -p; the support matrix keeps it available, not verified", "native Kimi plugin hook は SessionEnd を含む 10 event を宣言していますが、SessionEnd は Kimi Code 0.38.0 の -p では観測されていません。matrix では available（未検証）です")
+	hookHint := ""
 	if !state.NativeHooks {
-		hookStatus, hookMessage = doctorStatusWarn, Localize("native Kimi plugin hook coverage is missing or incomplete", "native Kimi plugin hook coverage が不足しています")
+		hookMessage = Localize("native Kimi plugin hook coverage is missing or incomplete", "native Kimi plugin hook coverage が不足しています")
+		hookHint = Localize("reinstall the native Traceary Kimi plugin", "native Traceary Kimi plugin を再インストールしてください")
 	}
-	checks = append(checks, doctorCheck{Name: "kimi-hooks", Status: hookStatus, Message: hookMessage, Hint: Localize("reinstall the native Traceary Kimi plugin", "native Traceary Kimi plugin を再インストールしてください")})
+	checks = append(checks, doctorCheck{Name: "kimi-hooks", Status: hookStatus, Message: hookMessage, Hint: hookHint})
 
 	skillStatus := doctorStatusPass
 	skillMessage := Localize("native Kimi plugin exposes all four Traceary skills", "native Kimi plugin は Traceary skill を4件すべて公開しています")

--- a/presentation/cli/doctor_kimi_internal_test.go
+++ b/presentation/cli/doctor_kimi_internal_test.go
@@ -23,6 +23,7 @@ func TestBuildKimiDoctorChecks(t *testing.T) {
 		{name: "disabled plugin", mutate: func(s *kimiDoctorState) { s.PluginEnabled = false }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "not enabled"},
 		{name: "version mismatch", mutate: func(s *kimiDoctorState) { s.PluginVersion = "0.27.0" }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "does not match"},
 		{name: "incomplete hooks", mutate: func(s *kimiDoctorState) { s.NativeHooks = false }, check: "kimi-hooks", status: doctorStatusWarn, messageSub: "incomplete"},
+		{name: "declared SessionEnd unobserved", mutate: func(*kimiDoctorState) {}, check: "kimi-hooks", status: doctorStatusWarn, messageSub: "SessionEnd"},
 		{name: "missing skills", mutate: func(s *kimiDoctorState) { s.Skills = 2 }, check: "kimi-skills", status: doctorStatusWarn, messageSub: "2"},
 		{name: "healthy", mutate: func(*kimiDoctorState) {}, check: "kimi-plugin", status: doctorStatusPass, messageSub: "enabled"},
 	}
@@ -56,8 +57,41 @@ func TestBuildKimiDoctorChecks(t *testing.T) {
 func TestBuildKimiDoctorChecksHealthyStatePassesEveryCheck(t *testing.T) {
 	state := kimiDoctorState{CLIAvailable: true, HostVersion: "0.27.0", PluginInstalled: true, PluginEnabled: true, PluginRecordKnown: true, PluginVersion: "0.28.0", NativeHooks: true, Skills: 4}
 	for _, check := range buildKimiDoctorChecks(state, "0.28.0") {
+		if check.Name == "kimi-hooks" {
+			// SessionEnd is declared in the plugin but unobserved on Kimi Code
+			// 0.38.0 -p, so even a fully healthy install must not PASS here.
+			if check.Status != doctorStatusWarn {
+				t.Fatalf("kimi-hooks status = %s, want WARN: %s", check.Status, check.Message)
+			}
+			continue
+		}
 		if check.Status != doctorStatusPass {
 			t.Fatalf("healthy state produced %s %s: %s", check.Name, check.Status, check.Message)
+		}
+	}
+}
+
+func TestBuildKimiDoctorChecksReportsUnobservedSessionEnd(t *testing.T) {
+	state := kimiDoctorState{CLIAvailable: true, HostVersion: "0.38.0", PluginInstalled: true, PluginEnabled: true, PluginRecordKnown: true, PluginVersion: "0.28.0", NativeHooks: true, Skills: 4}
+	checks := buildKimiDoctorChecks(state, "0.28.0")
+	var hookCheck *doctorCheck
+	for i := range checks {
+		if checks[i].Name == "kimi-hooks" {
+			hookCheck = &checks[i]
+		}
+	}
+	if hookCheck == nil {
+		t.Fatal("kimi-hooks check missing")
+	}
+	if hookCheck.Status == doctorStatusPass {
+		t.Fatalf("kimi-hooks must not PASS while SessionEnd is unobserved: %s", hookCheck.Message)
+	}
+	if strings.Contains(hookCheck.Message, "all ten verified events") {
+		t.Fatalf("kimi-hooks still claims verified 10-event coverage: %s", hookCheck.Message)
+	}
+	for _, sub := range []string{"SessionEnd", "unobserved", "0.38.0"} {
+		if !strings.Contains(hookCheck.Message, sub) {
+			t.Fatalf("kimi-hooks message %q missing %q", hookCheck.Message, sub)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

kimi-hooks no longer PASSes as all ten verified events when the plugin merely declares SessionEnd. Kimi Code 0.38.0 -p still does not dispatch it. Status is WARN with an honest declared-but-unobserved message. Matrix session_ended stays available.

Implementation: kimi k3. No session_ended synthesis.

Closes #2234

## Merge verification

Original: isolated kimi -p kinds session_started / prompt / transcript, session_ended=0; doctor kimi-hooks=pass (10 events).

This PR: throwaway TRACEARY_DB_PATH kimi -p recorded session_ended=0; worktree doctor --json --warnings-ok --client kimi --db-path throwaway shows kimi-hooks warn that SessionEnd is unobserved on 0.38.0 -p. Live home store not used as --db-path.

Go tests drive shipped buildKimiDoctorChecks.

## Test plan

- [x] go test ./presentation/cli/ -count=1 -timeout 120s -run KimiDoctor
