### PR TITLE
Resolve Claude SessionEnd cancellation when session already ended

### DIFF
--- a/application/ended_session_inspector.go
+++ b/application/ended_session_inspector.go
@@ -1,0 +1,16 @@
+package application
+
+import (
+	"context"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// EndedSessionInspector answers which of the given session IDs have a
+// session_ended boundary in the store at dbPath. It is the bounded
+// large-store counterpart of the session repository lookup: implementations
+// must open the store read-only, key the query by session ID against the
+// sessions primary key, and never walk event bodies or dbstat.
+type EndedSessionInspector interface {
+	FindEndedSessionIDs(ctx context.Context, dbPath string, sessionIDs []types.SessionID) (map[types.SessionID]struct{}, error)
+}

--- a/infrastructure/sqlite/ended_session_inspector.go
+++ b/infrastructure/sqlite/ended_session_inspector.go
@@ -1,0 +1,85 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// EndedSessionInspector opens a store mode=ro with no busy wait — the same
+// bounded probe as the page-metadata inspector — and answers which of the
+// given session IDs have ended. The query is session-id keyed against the
+// sessions primary key in bounded batches, so large-store doctor can resolve
+// hook cancellation markers without walking event bodies or dbstat (#2235).
+type EndedSessionInspector struct{}
+
+// NewEndedSessionInspector creates a path-based bounded ended-session reader.
+func NewEndedSessionInspector() *EndedSessionInspector {
+	return &EndedSessionInspector{}
+}
+
+var _ application.EndedSessionInspector = (*EndedSessionInspector)(nil)
+
+// FindEndedSessionIDs returns the subset of sessionIDs whose sessions row has
+// ended_at set. An unreadable or locked store returns an error so the caller
+// can fail-soft instead of guessing session state.
+func (EndedSessionInspector) FindEndedSessionIDs(ctx context.Context, dbPath string, sessionIDs []types.SessionID) (_ map[types.SessionID]struct{}, err error) {
+	result := make(map[types.SessionID]struct{})
+	if len(sessionIDs) == 0 {
+		return result, nil
+	}
+	db, err := sql.Open("sqlite", sqliteO1ReadOnlyDSN(dbPath))
+	if err != nil {
+		return nil, xerrors.Errorf("open store for ended session lookup: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = xerrors.Errorf("close ended session lookup: %w", closeErr)
+		}
+	}()
+	if err := db.PingContext(ctx); err != nil {
+		return nil, xerrors.Errorf("ping store for ended session lookup: %w", err)
+	}
+
+	const batchSize = 900
+	for start := 0; start < len(sessionIDs); start += batchSize {
+		end := min(start+batchSize, len(sessionIDs))
+		batch := sessionIDs[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		args := make([]any, 0, len(batch))
+		for _, sessionID := range batch {
+			args = append(args, sessionID.String())
+		}
+		if err := func() (resultErr error) {
+			rows, err := db.QueryContext(ctx, "SELECT session_id FROM sessions WHERE ended_at IS NOT NULL AND session_id IN ("+placeholders+")", args...)
+			if err != nil {
+				return xerrors.Errorf("failed to query ended sessions: %w", err)
+			}
+			defer func() {
+				if err := rows.Close(); err != nil && resultErr == nil {
+					resultErr = xerrors.Errorf("failed to close ended session rows: %w", err)
+				}
+			}()
+			for rows.Next() {
+				var sessionID string
+				if err := rows.Scan(&sessionID); err != nil {
+					return xerrors.Errorf("failed to scan ended session ID: %w", err)
+				}
+				result[types.SessionID(sessionID)] = struct{}{}
+			}
+			if err := rows.Err(); err != nil {
+				return xerrors.Errorf("failed to iterate ended session IDs: %w", err)
+			}
+			return nil
+		}(); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}

--- a/infrastructure/sqlite/ended_session_inspector_test.go
+++ b/infrastructure/sqlite/ended_session_inspector_test.go
@@ -1,0 +1,82 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestEndedSessionInspector_FindEndedSessionIDs(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := infra.NewDatabase(dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := infra.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	ds := infra.NewSessionDatasource(db)
+	agent, err := types.AgentFrom("claude")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	startedAt := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	activeID := types.SessionID("active-session")
+	endedID := types.SessionID("ended-session")
+	for _, sessionID := range []types.SessionID{activeID, endedID} {
+		session := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
+		event := model.EventOf(types.EventID("start-"+sessionID.String()), types.EventKindSessionStarted, types.Client("cli"), agent, sessionID, types.Workspace("workspace"), "started", startedAt)
+		if err := ds.SaveBoundary(ctx, session, event); err != nil {
+			t.Fatalf("SaveBoundary(start %s) error = %v", sessionID, err)
+		}
+	}
+	ended, err := ds.FindByID(ctx, endedID)
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	endedSession, ok := ended.Value()
+	if !ok {
+		t.Fatal("ended session is missing")
+	}
+	endedAt := startedAt.Add(time.Minute)
+	if err := endedSession.End(endedAt, "done"); err != nil {
+		t.Fatalf("End() error = %v", err)
+	}
+	endEvent := model.EventOf(types.EventID("end-ended-session"), types.EventKindSessionEnded, types.Client("cli"), agent, endedID, types.Workspace("workspace"), "ended", endedAt)
+	if err := ds.SaveBoundary(ctx, endedSession, endEvent); err != nil {
+		t.Fatalf("SaveBoundary(end) error = %v", err)
+	}
+
+	inspector := infra.NewEndedSessionInspector()
+	got, err := inspector.FindEndedSessionIDs(ctx, dbPath, []types.SessionID{activeID, endedID, "missing-session"})
+	if err != nil {
+		t.Fatalf("FindEndedSessionIDs() error = %v", err)
+	}
+	if diff := cmp.Diff(map[types.SessionID]struct{}{endedID: {}}, got); diff != "" {
+		t.Fatalf("ended IDs mismatch (-want +got):\n%s", diff)
+	}
+
+	empty, err := inspector.FindEndedSessionIDs(ctx, dbPath, nil)
+	if err != nil {
+		t.Fatalf("FindEndedSessionIDs(nil) error = %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("FindEndedSessionIDs(nil) = %v, want empty", empty)
+	}
+}
+
+func TestEndedSessionInspector_MissingStoreFails(t *testing.T) {
+	t.Parallel()
+
+	inspector := infra.NewEndedSessionInspector()
+	if _, err := inspector.FindEndedSessionIDs(context.Background(), filepath.Join(t.TempDir(), "absent.db"), []types.SessionID{"s"}); err == nil {
+		t.Fatal("FindEndedSessionIDs() on a missing store must fail instead of guessing session state")
+	}
+}

--- a/infrastructure/sqlite/sqlite_open_inventory_test.go
+++ b/infrastructure/sqlite/sqlite_open_inventory_test.go
@@ -19,6 +19,7 @@ func TestRuntimeSQLiteOpenInventoryIsExplicit(t *testing.T) {
 		"infrastructure/sqlite/compaction_sqlite.go":                  2, // EX-held source/candidate only.
 		"infrastructure/sqlite/compaction_copy_filter.go":             2, // EX-held work copy plus EX-held in-place incremental vacuum.
 		"infrastructure/sqlite/database.go":                           1, // in-memory driver probe only.
+		"infrastructure/sqlite/ended_session_inspector.go":            1, // mode=ro bounded ended-session probe; no coordinated lease, no dbstat.
 		"infrastructure/sqlite/page_metadata_inspector.go":            1, // mode=ro O(1) doctor probe; no coordinated lease, no dbstat.
 		"infrastructure/sqlite/payload_rehearsal.go":                  7, // copied rehearsal targets only.
 		"infrastructure/sqlite/payload_rehearsal_migration.go":        1, // copied migration target.

--- a/main.go
+++ b/main.go
@@ -242,6 +242,7 @@ func run() error {
 		cli.WithStoreManagement(storeManagementUsecase),
 		cli.WithCapacityInspector(sqlite.NewCapacityInspector(db)),
 		cli.WithPageMetadataInspector(sqlite.NewPageMetadataInspector()),
+		cli.WithEndedSessionInspector(sqlite.NewEndedSessionInspector()),
 		cli.WithOperatorCostInspector(sqlite.NewOperatorCostInspector(db)),
 		cli.WithPayloadCodecInspector(sqlite.NewPayloadCodecInspector(db)),
 		cli.WithAttestationAnchorInspector(sqlite.NewAttestationAnchorInspector(db)),

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -387,7 +387,9 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			report.Checks = append(report.Checks, c.inspectAttestationAnchor(ctx, resolvedDBPath, false))
 		}
 		// This is an intentional, successful bounded outcome. The only SQLite
-		// open is the O(1) mode=ro pragma + projection-state read. Do not
+		// opens are the O(1) mode=ro pragma + projection-state read and the
+		// session-id keyed ended-session probe behind the hook-cancellation
+		// check (#2235). Do not
 		// initialize, list events, open spool payloads, inspect payload codec,
 		// walk dbstat, or inspect client state here: those operations can
 		// block behind a live writer and some inspect event bodies/payloads.

--- a/presentation/cli/doctor_filesystem_host.go
+++ b/presentation/cli/doctor_filesystem_host.go
@@ -7,9 +7,12 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-// appendFilesystemHostDoctorChecks emits host-file hook and config checks
-// that never open the Traceary SQLite store. Large-store doctor uses this
-// so operators still see gemini-config / hook queues / cancellations.
+// appendFilesystemHostDoctorChecks emits host-file hook and config checks.
+// Large-store doctor uses this so operators still see gemini-config / hook
+// queues / cancellations. These checks never initialize or migrate the
+// Traceary SQLite store; the only store read is the bounded mode=ro
+// session-id keyed ended-session probe behind
+// inspectClaudeHookCancellationDiagnosticsFilesystem (#2235).
 func (c *RootCLI) appendFilesystemHostDoctorChecks(
 	ctx context.Context,
 	report *doctorReport,

--- a/presentation/cli/hook_diagnostics.go
+++ b/presentation/cli/hook_diagnostics.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -87,7 +88,34 @@ func (c *RootCLI) inspectClaudeHookCancellationDiagnostics(ctx context.Context, 
 }
 
 func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsFilesystem(ctx context.Context, dbPath, projectDir string) doctorCheck {
-	return c.inspectClaudeHookCancellationDiagnosticsWithLookup(ctx, dbPath, projectDir, nil)
+	// Large-store doctor resolves markers through the bounded path-based
+	// ended-session probe (session-id keyed, mode=ro, no event bodies/dbstat)
+	// so a SessionEnd that recorded session_ended before the host killed the
+	// hook classifies Resolved instead of staying Actionable forever (#2235).
+	// Without an inspector (or a resolved store path) the nil lookup keeps
+	// the previous same-store Actionable fallback.
+	var sessions hookDiagnosticSessionLookup
+	if c != nil && c.endedSessionInspector != nil && strings.TrimSpace(dbPath) != "" {
+		sessions = hookDiagnosticFilesystemSessionLookup{inspector: c.endedSessionInspector, dbPath: dbPath}
+	}
+	return c.inspectClaudeHookCancellationDiagnosticsWithLookup(ctx, dbPath, projectDir, sessions)
+}
+
+// hookDiagnosticFilesystemSessionLookup binds the path-based ended-session
+// inspector to the store the filesystem doctor inspects.
+type hookDiagnosticFilesystemSessionLookup struct {
+	inspector application.EndedSessionInspector
+	dbPath    string
+}
+
+func (l hookDiagnosticFilesystemSessionLookup) FindEndedSessionIDs(ctx context.Context, sessionIDs []types.SessionID) (map[types.SessionID]struct{}, error) {
+	lookupCtx, cancel := context.WithTimeout(ctx, largeStoreO1InspectTimeout)
+	defer cancel()
+	ended, err := l.inspector.FindEndedSessionIDs(lookupCtx, l.dbPath, sessionIDs)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to look up ended sessions for filesystem doctor: %w", err)
+	}
+	return ended, nil
 }
 
 func (c *RootCLI) inspectClaudeHookCancellationDiagnosticsWithLookup(ctx context.Context, dbPath, projectDir string, sessions hookDiagnosticSessionLookup) doctorCheck {

--- a/presentation/cli/hook_diagnostics_test.go
+++ b/presentation/cli/hook_diagnostics_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
 )
 
 type hookDiagnosticSessionLookupStub struct {
@@ -479,5 +481,165 @@ func TestScanHookCancellationDiagnosticsSkipsEmptyMarkers(t *testing.T) {
 	}
 	if !strings.Contains(check.Message, "unreadable nonempty") || !strings.Contains(check.Message, garbage) {
 		t.Fatalf("nonempty unreadable must remain reported: %q", check.Message)
+	}
+}
+
+type endedSessionInspectorStub struct {
+	ended   map[types.SessionID]struct{}
+	err     error
+	dbPaths []string
+}
+
+func (s *endedSessionInspectorStub) FindEndedSessionIDs(_ context.Context, dbPath string, _ []types.SessionID) (map[types.SessionID]struct{}, error) {
+	s.dbPaths = append(s.dbPaths, dbPath)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.ended, nil
+}
+
+// The filesystem (large-store) inspect must resolve markers whose sessions
+// already ended instead of reporting every same-store marker actionable the
+// way the previous nil lookup did (#2235).
+func TestInspectClaudeHookCancellationDiagnosticsFilesystem_ResolvesEndedSession(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	diagDir := filepath.Join(stateDir, hookDiagnosticsDirName)
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const dbPath = "/store/current.db"
+	writeHookCancellationDiagnosticForTest(t, filepath.Join(diagDir, "ended.json"), hookCancellationDiagnostic{
+		SchemaVersion: hookCancellationDiagnosticSchemaVersion,
+		Client:        "claude",
+		HostEvent:     "SessionEnd",
+		SessionID:     "ended-session",
+		DBPath:        dbPath,
+		Status:        hookCancellationDiagnosticStatusStarted,
+		StartedAt:     time.Now().UTC().Add(-time.Hour),
+	})
+
+	inspector := &endedSessionInspectorStub{ended: map[types.SessionID]struct{}{"ended-session": {}}}
+	root := &RootCLI{endedSessionInspector: inspector}
+	check := root.inspectClaudeHookCancellationDiagnosticsFilesystem(context.Background(), dbPath, "")
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q message=%q", check.Status, check.Message)
+	}
+	if strings.Contains(check.Message, "unresolved") {
+		t.Fatalf("ended session marker must not stay unresolved: %q", check.Message)
+	}
+	if !strings.Contains(check.Message, "resolved=1") {
+		t.Fatalf("message %q, want resolved=1 cleanup path", check.Message)
+	}
+	if !check.AutoFixAvailable || check.FixFunc == nil {
+		t.Fatalf("resolved marker must stay auto-fixable: %+v", check)
+	}
+	if len(inspector.dbPaths) != 1 || inspector.dbPaths[0] != dbPath {
+		t.Fatalf("inspector dbPaths = %v, want [%s]", inspector.dbPaths, dbPath)
+	}
+}
+
+// A marker without an ended (or any) session row stays actionable; only the
+// marker backed by a real session_ended resolves. Drives the shipped
+// filesystem inspect against a real store so the nil-lookup blind spot
+// cannot regress (#2235).
+func TestInspectClaudeHookCancellationDiagnosticsFilesystem_EndToEndStore(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	diagDir := filepath.Join(stateDir, hookDiagnosticsDirName)
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := sqliteinfra.NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	sessionDS := sqliteinfra.NewSessionDatasource(database)
+	agent, err := types.AgentFrom("claude")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	startedAt := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	endedID := types.SessionID("ended-session")
+	openID := types.SessionID("open-session")
+	for _, sessionID := range []types.SessionID{endedID, openID} {
+		session := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
+		event := model.EventOf(types.EventID("start-"+sessionID.String()), types.EventKindSessionStarted, types.Client("cli"), agent, sessionID, types.Workspace("workspace"), "started", startedAt)
+		if err := sessionDS.SaveBoundary(ctx, session, event); err != nil {
+			t.Fatalf("SaveBoundary(start %s) error = %v", sessionID, err)
+		}
+	}
+	ended, err := sessionDS.FindByID(ctx, endedID)
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	endedSession, ok := ended.Value()
+	if !ok {
+		t.Fatal("ended session is missing")
+	}
+	endedAt := startedAt.Add(time.Minute)
+	if err := endedSession.End(endedAt, "done"); err != nil {
+		t.Fatalf("End() error = %v", err)
+	}
+	endEvent := model.EventOf(types.EventID("end-ended-session"), types.EventKindSessionEnded, types.Client("cli"), agent, endedID, types.Workspace("workspace"), "ended", endedAt)
+	if err := sessionDS.SaveBoundary(ctx, endedSession, endEvent); err != nil {
+		t.Fatalf("SaveBoundary(end) error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	write := func(name, sessionID string) string {
+		path := filepath.Join(diagDir, name)
+		writeHookCancellationDiagnosticForTest(t, path, hookCancellationDiagnostic{
+			SchemaVersion: hookCancellationDiagnosticSchemaVersion,
+			Client:        "claude",
+			HostEvent:     "SessionEnd",
+			SessionID:     sessionID,
+			DBPath:        dbPath,
+			Status:        hookCancellationDiagnosticStatusStarted,
+			StartedAt:     now.Add(-time.Hour),
+		})
+		return path
+	}
+	endedPath := write("ended.json", endedID.String())
+	openPath := write("open.json", openID.String())
+	ghostPath := write("ghost.json", "ghost-session")
+
+	root := &RootCLI{endedSessionInspector: sqliteinfra.NewEndedSessionInspector()}
+	check := root.inspectClaudeHookCancellationDiagnosticsFilesystem(ctx, dbPath, "")
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("status=%q message=%q", check.Status, check.Message)
+	}
+	if !strings.Contains(check.Message, "found 2 unresolved") {
+		t.Fatalf("message %q, want open and ghost sessions still unresolved", check.Message)
+	}
+	if !strings.Contains(check.Message, "1 resolved") {
+		t.Fatalf("message %q, want 1 resolved", check.Message)
+	}
+	if !check.AutoFixAvailable || check.FixFunc == nil {
+		t.Fatalf("resolved marker must be auto-fixable: %+v", check)
+	}
+
+	action, err := check.FixFunc(ctx, true)
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if !strings.Contains(action, "would remove 1") {
+		t.Fatalf("dry-run action=%q, want 1 removal", action)
+	}
+	if _, err := check.FixFunc(ctx, false); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(endedPath); !os.IsNotExist(err) {
+		t.Fatalf("ended marker survived --fix: err=%v", err)
+	}
+	for _, path := range []string{openPath, ghostPath} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("unresolved marker %s must remain: %v", path, err)
+		}
 	}
 }

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -41,6 +41,7 @@ type RootCLI struct {
 	storeManagement            usecase.StoreManagementUsecase
 	capacityInspector          application.CapacityInspector
 	pageMetadataInspector      application.PageMetadataInspector
+	endedSessionInspector      application.EndedSessionInspector
 	operatorCostInspector      application.OperatorCostInspector
 	payloadCodecInspector      application.PayloadCodecInspector
 	attestationAnchorInspector application.AttestationAnchorInspector
@@ -221,6 +222,12 @@ func WithCapacityInspector(inspector application.CapacityInspector) RootCLIOptio
 // WithPageMetadataInspector injects the O(1) large-store pragma reader.
 func WithPageMetadataInspector(inspector application.PageMetadataInspector) RootCLIOption {
 	return func(c *RootCLI) { c.pageMetadataInspector = inspector }
+}
+
+// WithEndedSessionInspector injects the bounded path-based ended-session
+// reader large-store doctor uses to resolve hook cancellation markers.
+func WithEndedSessionInspector(inspector application.EndedSessionInspector) RootCLIOption {
+	return func(c *RootCLI) { c.endedSessionInspector = inspector }
 }
 
 // WithOperatorCostInspector injects this-store measured cost for doctor.


### PR DESCRIPTION
## Summary

Large-store doctor treated every same-store Claude SessionEnd cancellation marker as Actionable because filesystem inspect passed a nil session lookup. A SessionEnd that already wrote session_ended then got Hook cancelled stayed an unresolved WARN.

This PR wires a bounded mode=ro session-id keyed EndedSessionInspector so those markers classify Resolved and keep the existing --fix cleanup. Markers without an ended session row stay actionable. No extra session_ended events.

Implementation: kimi k3.

Closes #2235

## Merge verification

Original: isolated Claude -p wrote session_ended and stderr Hook cancelled; live doctor unresolved=3 resolved=0.

Go tests drive shipped filesystem inspect with a real store: ended session marker is Resolved; open/ghost sessions stay actionable.

Isolated Claude -p (if re-run) is recorded in review comments. Live home store not used as --db-path for a repo-built binary.

## Test plan

- [x] go test ./presentation/cli/ ./infrastructure/sqlite/ -run HookCancellation|ClaudeHookCancellation|EndedSession
