### PR TITLE
Add FixCommand for leftover Claude local plugin installs

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,9 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ## [Unreleased]
 
+### Fixed
+- **Claude `--scope local` の leftover install に operator 向け FixCommand を追加 (#2236)** — `claude-plugin-local-leftovers` WARN が `traceary doctor --fix --dry-run --client claude` を表示する。dry-run は leftover path をすべて一覧し、apply は print だけの no-op。Claude の inventory は引き続き書き換えず、user-scope / marketplace install には触れない。親 #2230 は open のまま。
+
 ## [v0.46.0] - 2026-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ## [Unreleased]
 
+### Fixed
+- **Leftover Claude `--scope local` installs get an operator-guided FixCommand (#2236)** — the `claude-plugin-local-leftovers` WARN now prints `traceary doctor --fix --dry-run --client claude`; the dry-run lists every leftover path and apply is a print-only no-op. Claude's inventory is still never rewritten, and user-scope / marketplace installs are untouched. Leaves parent #2230 open.
+
 ## [v0.46.0] - 2026-08-21
 
 ### Fixed

--- a/docs/release/post-upgrade-plugins.ja.md
+++ b/docs/release/post-upgrade-plugins.ja.md
@@ -44,7 +44,7 @@ release 済みバイナリを更新するたびに、次を実行してくださ
 
 doctor が正確な非対話コマンドを `FixCommand` に出す場合は、そちらを優先してください。ホスト CLI のフラグを推測で追加してはいけません。
 
-`--scope local` install に関する補足: Claude の `~/.claude/plugins/installed_plugins.json` にある local install の行は、指していた project ディレクトリが削除されても残ります。doctor はこれらの行を additive な `claude-plugin-local-leftovers` WARN（件数と欠落 path の上限付きサンプル）として報告します。user cache の `claude-plugin-cache` / `claude-plugin-version` は `pass` のままです。Traceary は Claude の inventory を書き換えません。`installed_plugins.json` を確認し、leftover の local 行は Claude 側で自分で削除してください。
+`--scope local` install に関する補足: Claude の `~/.claude/plugins/installed_plugins.json` にある local install の行は、指していた project ディレクトリが削除されても残ります。doctor はこれらの行を additive な `claude-plugin-local-leftovers` WARN（件数と欠落 path の上限付きサンプル）として報告します。user cache の `claude-plugin-cache` / `claude-plugin-version` は `pass` のままです。WARN には FixCommand が付き、`traceary doctor --fix --dry-run --client claude` が leftover path をすべて一覧し、`traceary doctor --fix` は同じ一覧を print するだけの no-op です。Traceary は Claude の inventory を書き換えません。project ディレクトリが消えた local-scope 行を uninstall できる host CLI はないため、`installed_plugins.json` を確認し、leftover の local 行は Claude 側で自分で削除してください。
 
 ## 古いプロセス
 

--- a/docs/release/post-upgrade-plugins.md
+++ b/docs/release/post-upgrade-plugins.md
@@ -44,7 +44,7 @@ After every released binary upgrade:
 
 Prefer the `FixCommand` printed by doctor when it provides an exact non-interactive command. Do not invent host CLI flags.
 
-Note on `--scope local` installs: a local install row in Claude's `~/.claude/plugins/installed_plugins.json` survives the deletion of the project directory it points at. Doctor reports those rows as the additive `claude-plugin-local-leftovers` WARN (count plus a bounded sample of the missing paths); the user-cache `claude-plugin-cache` / `claude-plugin-version` checks stay `pass`. Traceary never rewrites Claude's inventory — inspect `installed_plugins.json` and remove the leftover local rows in Claude yourself.
+Note on `--scope local` installs: a local install row in Claude's `~/.claude/plugins/installed_plugins.json` survives the deletion of the project directory it points at. Doctor reports those rows as the additive `claude-plugin-local-leftovers` WARN (count plus a bounded sample of the missing paths); the user-cache `claude-plugin-cache` / `claude-plugin-version` checks stay `pass`. The WARN carries a FixCommand — `traceary doctor --fix --dry-run --client claude` lists every leftover path, and `traceary doctor --fix` prints the same list as a no-op. Traceary never rewrites Claude's inventory — no host CLI can uninstall a local-scope row whose project directory is gone, so inspect `installed_plugins.json` and remove the leftover local rows in Claude yourself.
 
 ## Stale processes
 

--- a/presentation/cli/doctor_claude_local_leftovers_test.go
+++ b/presentation/cli/doctor_claude_local_leftovers_test.go
@@ -59,14 +59,38 @@ func TestInspectClaudePluginLocalLeftoversWarnsWithCountAndSample(t *testing.T) 
 	if !strings.Contains(check.Hint, "installed_plugins.json") {
 		t.Fatalf("hint = %q, want it to name installed_plugins.json", check.Hint)
 	}
-	if check.AutoFixAvailable {
-		t.Fatal("AutoFixAvailable = true, want false")
+	if check.FixCommand == "" {
+		t.Fatal("FixCommand = empty, want a guided cleanup command")
 	}
-	if check.FixCommand != "" {
-		t.Fatalf("FixCommand = %q, want empty", check.FixCommand)
+	if !strings.Contains(check.FixCommand, "traceary doctor --fix --dry-run") {
+		t.Fatalf("FixCommand = %q, want the print-only dry-run wrapper", check.FixCommand)
 	}
-	if check.FixFunc != nil || check.StructuredFixFunc != nil {
-		t.Fatal("leftover check must not carry a fixer (doctor --fix must not write Claude config)")
+	if !check.AutoFixAvailable {
+		t.Fatal("AutoFixAvailable = false, want true (print-only fixer)")
+	}
+	if check.FixFunc == nil {
+		t.Fatal("FixFunc = nil, want a print-only fixer")
+	}
+	dryRun, err := check.FixFunc(context.Background(), true)
+	if err != nil {
+		t.Fatalf("FixFunc(dry-run) error = %v", err)
+	}
+	for _, path := range missing {
+		if !strings.Contains(dryRun, path) {
+			t.Fatalf("dry-run action = %q, want leftover path %q", dryRun, path)
+		}
+	}
+	applied, err := check.FixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("FixFunc(apply) error = %v", err)
+	}
+	if !strings.Contains(applied, "print-only") || !strings.Contains(applied, "no changes") {
+		t.Fatalf("apply action = %q, want a print-only no-op note", applied)
+	}
+	for _, path := range missing {
+		if !strings.Contains(applied, path) {
+			t.Fatalf("apply action = %q, want leftover path %q", applied, path)
+		}
 	}
 }
 
@@ -238,6 +262,19 @@ func TestInspectClaudePluginLocalLeftoversRealInventory(t *testing.T) {
 	if strings.Contains(leftovers.Message, existingProject) {
 		t.Fatalf("message = %q, must not flag the existing project %q", leftovers.Message, existingProject)
 	}
+	if leftovers.FixCommand == "" || !leftovers.AutoFixAvailable || leftovers.FixFunc == nil {
+		t.Fatalf("leftovers check = %+v, want a guided FixCommand with a print-only fixer", leftovers)
+	}
+	dryRun, err := leftovers.FixFunc(context.Background(), true)
+	if err != nil {
+		t.Fatalf("FixFunc(dry-run) error = %v", err)
+	}
+	if !strings.Contains(dryRun, missingProject) {
+		t.Fatalf("dry-run action = %q, want missing path %q", dryRun, missingProject)
+	}
+	if strings.Contains(dryRun, existingProject) {
+		t.Fatalf("dry-run action = %q, must not list the existing project %q", dryRun, existingProject)
+	}
 
 	cache := cli.inspectClaudePluginCacheStatus()
 	if cache == nil || cache.Status != doctorStatusPass {
@@ -257,7 +294,7 @@ func TestInspectClaudePluginLocalLeftoversRealInventory(t *testing.T) {
 
 // TestFilesystemHostDoctorIncludesLocalLeftovers proves the bounded
 // (large-store) doctor path also reports leftover local installs and that
-// the emitted check carries no fixer, so `doctor --fix` cannot rewrite
+// the emitted fixer is print-only, so `doctor --fix` cannot rewrite
 // Claude's inventory.
 func TestFilesystemHostDoctorIncludesLocalLeftovers(t *testing.T) {
 	home := t.TempDir()
@@ -302,8 +339,15 @@ func TestFilesystemHostDoctorIncludesLocalLeftovers(t *testing.T) {
 	if leftover.Status != doctorStatusWarn {
 		t.Fatalf("status = %q, want warn", leftover.Status)
 	}
-	if leftover.FixFunc != nil || leftover.StructuredFixFunc != nil || leftover.FixCommand != "" || leftover.AutoFixAvailable {
-		t.Fatalf("leftover check must not be fixable: %+v", leftover)
+	if leftover.FixCommand == "" || !leftover.AutoFixAvailable || leftover.FixFunc == nil {
+		t.Fatalf("leftover check = %+v, want a guided FixCommand with a print-only fixer", leftover)
+	}
+	action, err := leftover.FixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("FixFunc(apply) error = %v", err)
+	}
+	if !strings.Contains(action, "print-only") || !strings.Contains(action, missingProject) {
+		t.Fatalf("apply action = %q, want a print-only no-op listing %q", action, missingProject)
 	}
 
 	after, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))

--- a/presentation/cli/doctor_claude_local_leftovers_test.go
+++ b/presentation/cli/doctor_claude_local_leftovers_test.go
@@ -94,6 +94,37 @@ func TestInspectClaudePluginLocalLeftoversWarnsWithCountAndSample(t *testing.T) 
 	}
 }
 
+func TestInspectClaudePluginLocalLeftoversDryRunJapaneseLocale(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "ja")
+	missing := []string{filepath.Join(t.TempDir(), "gone-a"), filepath.Join(t.TempDir(), "gone-b")}
+	cli := &RootCLI{pluginDetector: stubClaudePluginDetector{
+		scan: application.ClaudeLocalLeftoverScan{
+			InventoryPath: "/home/test/.claude/plugins/installed_plugins.json",
+			LeftoverPaths: missing,
+		},
+	}}
+
+	check := cli.inspectClaudePluginLocalLeftovers()
+	if check == nil || check.FixFunc == nil {
+		t.Fatalf("check = %+v, want WARN check with a print-only fixer", check)
+	}
+	dryRun, err := check.FixFunc(context.Background(), true)
+	if err != nil {
+		t.Fatalf("FixFunc(dry-run) error = %v", err)
+	}
+	if !strings.Contains(dryRun, "2 件") {
+		t.Fatalf("dry-run action = %q, want leftover count 2", dryRun)
+	}
+	if strings.Contains(dryRun, "%!") {
+		t.Fatalf("dry-run action = %q, want no format-verb mismatch garbling", dryRun)
+	}
+	for _, path := range missing {
+		if !strings.Contains(dryRun, path) {
+			t.Fatalf("dry-run action = %q, want leftover path %q", dryRun, path)
+		}
+	}
+}
+
 func TestInspectClaudePluginLocalLeftoversPassesWhenNoneLeftover(t *testing.T) {
 	cli := &RootCLI{pluginDetector: stubClaudePluginDetector{
 		scan: application.ClaudeLocalLeftoverScan{

--- a/presentation/cli/doctor_config_inspect.go
+++ b/presentation/cli/doctor_config_inspect.go
@@ -89,9 +89,13 @@ const claudeLocalLeftoverSampleLimit = 5
 // inspectClaudePluginLocalLeftovers surfaces enabled local-scope Traceary
 // installs in Claude's installed_plugins.json whose project directory no
 // longer exists (deleted worktrees). The check is additive: it never
-// changes the claude-plugin-cache / claude-plugin-version results, has no
-// auto-fix, and never writes Claude's inventory — removing the leftover
-// rows is the operator's call inside Claude.
+// changes the claude-plugin-cache / claude-plugin-version results and
+// never writes Claude's inventory — removing the leftover rows is the
+// operator's call inside Claude. The WARN carries a guided FixCommand and
+// a print-only fixer: `doctor --fix --dry-run` lists the leftover paths
+// and `doctor --fix` prints the same list without mutating anything,
+// because no host CLI can uninstall a local-scope row whose project
+// directory is already gone.
 func (c *RootCLI) inspectClaudePluginLocalLeftovers() *doctorCheck {
 	if c == nil || c.pluginDetector == nil {
 		return nil
@@ -142,14 +146,23 @@ func (c *RootCLI) inspectClaudePluginLocalLeftovers() *doctorCheck {
 	if remainder > 0 {
 		sampleText = localizef("%s, and %d more", "%s ほか %d 件", sampleText, remainder)
 	}
+	fixCommand := "traceary doctor --fix --dry-run --client claude"
+	leftoverPaths := append([]string(nil), scan.LeftoverPaths...)
+	inventoryPath := scan.InventoryPath
 	return &doctorCheck{
-		Name:   "claude-plugin-local-leftovers",
-		Status: doctorStatusWarn,
+		Name:       "claude-plugin-local-leftovers",
+		Status:     doctorStatusWarn,
+		FixCommand: fixCommand,
 		Hint: localizef(
-			"inspect %s and remove the leftover local Traceary rows from Claude's inventory yourself (`claude plugin disable --scope local` only works inside a live project directory); Traceary never rewrites Claude's inventory",
-			"%s を確認し、leftover の local Traceary 行を Claude の inventory から自分で削除してください (`claude plugin disable --scope local` は生存している project 内でのみ動作します)。Traceary が Claude の inventory を書き換えることはありません",
-			scan.InventoryPath,
+			"preview the leftover rows with `%s` (print-only); then remove the leftover local Traceary rows from Claude's inventory yourself — `claude plugin disable --scope local` only works inside a live project directory, and no host CLI can uninstall a row whose project directory is gone. Traceary never rewrites Claude's inventory: %s",
+			"`%s` で leftover 行をプレビューしてください (print-only)。その後、leftover の local Traceary 行を Claude の inventory から自分で削除してください。`claude plugin disable --scope local` は生存している project 内でのみ動作し、project ディレクトリが消えた行を uninstall できる host CLI はありません。Traceary が Claude の inventory を書き換えることはありません: %s",
+			fixCommand,
+			inventoryPath,
 		),
+		AutoFixAvailable: true,
+		FixFunc: func(_ context.Context, dryRun bool) (string, error) {
+			return claudeLocalLeftoverPrintOnlyFix(inventoryPath, leftoverPaths, dryRun), nil
+		},
 		Message: localizef(
 			"claude plugin inventory lists %d enabled local Traceary install(s) whose project directory no longer exists: %s",
 			"claude plugin inventory に project ディレクトリが消えた enabled な local Traceary install が %d 件あります: %s",
@@ -157,6 +170,36 @@ func (c *RootCLI) inspectClaudePluginLocalLeftovers() *doctorCheck {
 			sampleText,
 		),
 	}
+}
+
+// claudeLocalLeftoverPrintOnlyFix renders the operator-guided cleanup list
+// for the claude-plugin-local-leftovers WARN. Both the dry-run preview and
+// the apply path only print the leftover projectPath values — the apply
+// path is a deliberate no-op that never rewrites Claude's inventory and
+// never deletes files, because removing the rows is the operator's call
+// inside Claude.
+func claudeLocalLeftoverPrintOnlyFix(inventoryPath string, leftoverPaths []string, dryRun bool) string {
+	lines := make([]string, 0, len(leftoverPaths))
+	for _, path := range leftoverPaths {
+		lines = append(lines, "  - "+path)
+	}
+	list := strings.Join(lines, "\n")
+	if dryRun {
+		return localizef(
+			"would list %d leftover local Traceary install row(s) for manual removal from %s (no host CLI can uninstall a local-scope row whose project directory is gone):\n%s",
+			"%s から手動削除すべき leftover local Traceary install 行 %d 件を一覧します (project ディレクトリが消えた local-scope 行を uninstall できる host CLI はありません):\n%s",
+			len(leftoverPaths),
+			inventoryPath,
+			list,
+		)
+	}
+	return localizef(
+		"print-only: no changes were made to %s; remove these %d leftover local Traceary install row(s) from Claude's inventory yourself:\n%s",
+		"print-only: %s への変更は行っていません。以下の %d 件の leftover local Traceary install 行を Claude の inventory から自分で削除してください:\n%s",
+		inventoryPath,
+		len(leftoverPaths),
+		list,
+	)
 }
 
 // inspectHostCapabilityGaps surfaces informational notes about host

--- a/presentation/cli/doctor_config_inspect.go
+++ b/presentation/cli/doctor_config_inspect.go
@@ -187,7 +187,7 @@ func claudeLocalLeftoverPrintOnlyFix(inventoryPath string, leftoverPaths []strin
 	if dryRun {
 		return localizef(
 			"would list %d leftover local Traceary install row(s) for manual removal from %s (no host CLI can uninstall a local-scope row whose project directory is gone):\n%s",
-			"%s から手動削除すべき leftover local Traceary install 行 %d 件を一覧します (project ディレクトリが消えた local-scope 行を uninstall できる host CLI はありません):\n%s",
+			"leftover local Traceary install 行 %d 件を %s から手動削除する対象として一覧します (project ディレクトリが消えた local-scope 行を uninstall できる host CLI はありません):\n%s",
 			len(leftoverPaths),
 			inventoryPath,
 			list,


### PR DESCRIPTION
## Summary

claude-plugin-local-leftovers WARN now has a copy-paste FixCommand and a print-only --fix that lists leftover project paths. It does not rewrite Claude inventory or delete files.

Implementation: kimi k3.

Closes #2236

## Merge verification

Original: 22 leftovers, auto_fix_available=false, no FixCommand.

Go tests: missing vs present projectPath; WARN has FixCommand; dry-run lists; apply print-only; Japanese dry-run verbs match args.

Live doctor --json --warnings-ok should show FixCommand when leftovers remain. Do not mass-delete plugins.

## Test plan

- [x] go test ./presentation/cli/ -run ClaudeLocalLeftover
