### PR TITLE
Document Codex exec trusted git directory requirement

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 
 ### Fixed
 - **Claude `--scope local` の leftover install に operator 向け FixCommand を追加 (#2236)** — `claude-plugin-local-leftovers` WARN が `traceary doctor --fix --dry-run --client claude` を表示する。dry-run は leftover path をすべて一覧し、apply は print だけの no-op。Claude の inventory は引き続き書き換えず、user-scope / marketplace install には触れない。親 #2230 は open のまま。
+- **Codex `codex exec` probe に trusted git directory 要件があることを文書化 (#2238)** — ドキュメントがホスト側エラーの正確な文言（"Not inside a trusted directory and --skip-git-repo-check was not specified."）と、動作する probe の形（`-C <git-root>` と使い捨て `TRACEARY_DB_PATH`。`--skip-git-repo-check` や `-a never` は使わない）を示す。smoke の runtime probe は git root への `-C` を維持し、hook 書き込みを使い捨て store に隔離するようにした。Codex 向けの `session_ended` 合成は引き続き行わない。親 #2230 は open のまま。
 
 ## [v0.46.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 
 ### Fixed
 - **Leftover Claude `--scope local` installs get an operator-guided FixCommand (#2236)** — the `claude-plugin-local-leftovers` WARN now prints `traceary doctor --fix --dry-run --client claude`; the dry-run lists every leftover path and apply is a print-only no-op. Claude's inventory is still never rewritten, and user-scope / marketplace installs are untouched. Leaves parent #2230 open.
+- **Codex `codex exec` probes documented as requiring a trusted git directory (#2238)** — docs now name the exact host error ("Not inside a trusted directory and --skip-git-repo-check was not specified.") and the working probe shape: `-C <git-root>` with a throwaway `TRACEARY_DB_PATH`, no `--skip-git-repo-check` or `-a never`. The smoke runtime probe keeps its git-root `-C` and now isolates hook writes in a throwaway store; `session_ended` is still never synthesized for Codex. Leaves parent #2230 open.
 
 ## [v0.46.0] - 2026-08-21
 

--- a/docs/integrations/codex-plugin.ja.md
+++ b/docs/integrations/codex-plugin.ja.md
@@ -92,6 +92,35 @@ Traceary が assistant text に使うのは inline の `last_assistant_message` 
 coverage を partial として扱います。manifest を発行証拠にはせず、欠落を
 埋めるために別 rollout や無関係な private history を走査しません。
 
+## Headless `codex exec` probe は trusted な git directory が必要
+
+`codex exec` は trusted directory の外では起動を拒否します。git で管理
+されていない一時 directory から実行すると、即座に失敗します
+（Codex CLI 0.148.0、2026-08-21 に確認）。
+
+```
+Not inside a trusted directory and --skip-git-repo-check was not specified.
+```
+
+これは Codex ホスト側のポリシーであり、Traceary は変更しません。
+`--skip-git-repo-check` や `-a never` のような blanket 承認フラグで回避
+してもいけません。probe は git root から（`-C <git-root>`、または git
+管理下の任意の cwd で）実行し、`TRACEARY_DB_PATH` に使い捨て store を
+指させて、probe の hook 書き込みが実 store に混入しないようにします。
+
+```sh
+tmp_db_dir="$(mktemp -d)"
+TRACEARY_DB_PATH="${tmp_db_dir}/traceary.db" \
+  codex exec -C /path/to/git-root -s read-only 'Reply with exactly: ok'
+rm -rf "${tmp_db_dir}"
+```
+
+trusted な git root から実行すると、Traceary plugin hook は
+`session_started` / `prompt` / `transcript` event を記録します。
+transcript の供給元である `Stop` は turn 境界であり session 終了では
+ありません（上の表を参照）。Traceary は Codex 向けに `session_ended`
+を合成しません。
+
 ## Capture gap の診断
 
 `traceary doctor --client codex --project-dir <workspace> --json` は

--- a/docs/integrations/codex-plugin.md
+++ b/docs/integrations/codex-plugin.md
@@ -92,6 +92,34 @@ If a future or interrupted headless run records activity but no runtime
 as partial. It does not use the manifest as proof of emission and does not scan
 another rollout or unrelated private history to fill the gap.
 
+## Headless `codex exec` probes require a trusted git directory
+
+`codex exec` refuses to start outside a trusted directory. Running it from a
+non-git throwaway directory fails immediately (observed on Codex CLI 0.148.0,
+2026-08-21):
+
+```
+Not inside a trusted directory and --skip-git-repo-check was not specified.
+```
+
+That is Codex host policy; Traceary does not change it, and probes must not
+bypass it with `--skip-git-repo-check` or a blanket-approval flag such as
+`-a never`. Run the probe from a git root (`-C <git-root>` or any cwd inside
+one) and point `TRACEARY_DB_PATH` at a throwaway store so the probe's hook
+writes never touch the real one:
+
+```sh
+tmp_db_dir="$(mktemp -d)"
+TRACEARY_DB_PATH="${tmp_db_dir}/traceary.db" \
+  codex exec -C /path/to/git-root -s read-only 'Reply with exactly: ok'
+rm -rf "${tmp_db_dir}"
+```
+
+From a trusted git root, the Traceary plugin hooks record `session_started`,
+`prompt`, and `transcript` events. `Stop` supplies the transcript and remains
+a turn boundary, not a session end (see the matrix above); Traceary never
+synthesizes `session_ended` for Codex.
+
 ## Capture-gap diagnostics
 
 `traceary doctor --client codex --project-dir <workspace> --json` includes a

--- a/docs/release/post-upgrade-plugins.ja.md
+++ b/docs/release/post-upgrade-plugins.ja.md
@@ -46,6 +46,32 @@ doctor が正確な非対話コマンドを `FixCommand` に出す場合は、�
 
 `--scope local` install に関する補足: Claude の `~/.claude/plugins/installed_plugins.json` にある local install の行は、指していた project ディレクトリが削除されても残ります。doctor はこれらの行を additive な `claude-plugin-local-leftovers` WARN（件数と欠落 path の上限付きサンプル）として報告します。user cache の `claude-plugin-cache` / `claude-plugin-version` は `pass` のままです。WARN には FixCommand が付き、`traceary doctor --fix --dry-run --client claude` が leftover path をすべて一覧し、`traceary doctor --fix` は同じ一覧を print するだけの no-op です。Traceary は Claude の inventory を書き換えません。project ディレクトリが消えた local-scope 行を uninstall できる host CLI はないため、`installed_plugins.json` を確認し、leftover の local 行は Claude 側で自分で削除してください。
 
+## Codex の headless probe は trusted な git directory が必要
+
+`scripts/smoke_test_integrations.sh` が
+`TRACEARY_ENABLE_CODEX_RUNTIME_SMOKE=1` で使う形の headless
+`codex exec` probe は、git で管理されていない directory からだと即座に
+失敗します。
+
+```
+Not inside a trusted directory and --skip-git-repo-check was not specified.
+```
+
+この Codex ホスト側ポリシーを `--skip-git-repo-check` や `-a never` で
+回避してはいけません。git root から、使い捨て store を指して実行します。
+
+```sh
+tmp_db_dir="$(mktemp -d)"
+TRACEARY_DB_PATH="${tmp_db_dir}/traceary.db" \
+  codex exec -C <traceary-git-root> -s read-only '<probe prompt>'
+rm -rf "${tmp_db_dir}"
+```
+
+hook は `session_started` / `prompt` / `transcript` を使い捨て store に
+記録します。`session_ended` は合成しません。probe 手順の全体は
+[Codex plugin](../integrations/codex-plugin.ja.md#headless-codex-exec-probe-は-trusted-な-git-directory-が必要)
+を参照してください。
+
 ## 古いプロセス
 
 Homebrew / `go install` の更新は PATH 上のバイナリを置き換えますが、**すでに動いているプロセスは古い実行ファイルのまま**です。2026-08-18 の dogfood では、置き換わった Cellar バイナリ（0.32–0.34）上の `traceary mcp-server` が長時間残っていました。MCP は v0.35.0 で引退しており、これらのプロセスは store-lease プロトコルより前のものです。stale なホスト session が compact 中にそれらへリクエストすると、排他制御なしで書き込めます。

--- a/docs/release/post-upgrade-plugins.md
+++ b/docs/release/post-upgrade-plugins.md
@@ -46,6 +46,31 @@ Prefer the `FixCommand` printed by doctor when it provides an exact non-interact
 
 Note on `--scope local` installs: a local install row in Claude's `~/.claude/plugins/installed_plugins.json` survives the deletion of the project directory it points at. Doctor reports those rows as the additive `claude-plugin-local-leftovers` WARN (count plus a bounded sample of the missing paths); the user-cache `claude-plugin-cache` / `claude-plugin-version` checks stay `pass`. The WARN carries a FixCommand — `traceary doctor --fix --dry-run --client claude` lists every leftover path, and `traceary doctor --fix` prints the same list as a no-op. Traceary never rewrites Claude's inventory — no host CLI can uninstall a local-scope row whose project directory is gone, so inspect `installed_plugins.json` and remove the leftover local rows in Claude yourself.
 
+## Codex headless probes require a trusted git directory
+
+A headless `codex exec` probe (the shape `scripts/smoke_test_integrations.sh`
+uses with `TRACEARY_ENABLE_CODEX_RUNTIME_SMOKE=1`) fails immediately from a
+non-git directory:
+
+```
+Not inside a trusted directory and --skip-git-repo-check was not specified.
+```
+
+Do not bypass this Codex host policy with `--skip-git-repo-check` or
+`-a never`. Run the probe from a git root with a throwaway store instead:
+
+```sh
+tmp_db_dir="$(mktemp -d)"
+TRACEARY_DB_PATH="${tmp_db_dir}/traceary.db" \
+  codex exec -C <traceary-git-root> -s read-only '<probe prompt>'
+rm -rf "${tmp_db_dir}"
+```
+
+The hooks then record `session_started` / `prompt` / `transcript` into the
+throwaway store; no `session_ended` is synthesized. See
+[Codex plugin](../integrations/codex-plugin.md#headless-codex-exec-probes-require-a-trusted-git-directory)
+for the full probe recipe.
+
 ## Stale processes
 
 Homebrew / `go install` upgrades replace the on-PATH binary, but **already-running processes keep the old executable**. The 2026-08-18 dogfood found long-lived `traceary mcp-server` processes on superseded Cellar binaries (0.32–0.34). MCP was retired in v0.35.0; those processes predate the store-lease protocol, so a stale host session that talks to them mid-compact can write without exclusive access.

--- a/scripts/smoke_test_integrations.sh
+++ b/scripts/smoke_test_integrations.sh
@@ -77,7 +77,17 @@ run_codex() {
     return 0
   }
 
-  codex exec -C "${ROOT_DIR}" -s read-only 'In one sentence, name the Traceary slash command or skill exposed by the current repository plugin bundle.'
+  # The probe must run from a trusted git directory: `codex exec` from a
+  # non-git cwd fails immediately with "Not inside a trusted directory and
+  # --skip-git-repo-check was not specified." (#2238). `-C "${ROOT_DIR}"`
+  # is a git root. Point TRACEARY_DB_PATH at a throwaway store so the
+  # probe's hook writes (session_started/prompt/transcript) never touch
+  # the real one.
+  local tmp_db_dir
+  tmp_db_dir="$(mktemp -d)"
+  TRACEARY_DB_PATH="${tmp_db_dir}/traceary.db" \
+    codex exec -C "${ROOT_DIR}" -s read-only 'In one sentence, name the Traceary slash command or skill exposed by the current repository plugin bundle.' </dev/null
+  rm -rf "${tmp_db_dir}"
   echo 'ok: codex runtime probe completed'
 }
 


### PR DESCRIPTION
## Summary

Document that Codex exec from a non-git directory fails with the trusted-directory error, and that probes must use -C a git root with throwaway TRACEARY_DB_PATH. Smoke still uses git root, no -a never, no session_ended synthesis.

Implementation: kimi k3.

Closes #2238

## Merge verification

Repro: non-git cwd expected host error. Working probe from git root with throwaway TRACEARY_DB_PATH. smoke_test_integrations.sh Codex runtime still -C ROOT_DIR.

## Test plan

- [x] rg error string in docs
- [x] smoke uses -C git root, not -a never
